### PR TITLE
Fixed typos in README.md

### DIFF
--- a/crates/enclave-server/src/coco_aa/README.md
+++ b/crates/enclave-server/src/coco_aa/README.md
@@ -1,6 +1,6 @@
-# Attestion Agent
+# Attestation Agent
 
-The Attestation Agent package provides handlers for interacting with the [CoCo Attestation Agent](https://github.com/confidential-containers/guest-components/tree/main/attestation-agent). The attestation agent privides APIs to interact with the secure hardware features of the enclave. 
+The Attestation Agent package provides handlers for interacting with the [CoCo Attestation Agent](https://github.com/confidential-containers/guest-components/tree/main/attestation-agent). The attestation agent provides APIs to interact with the secure hardware features of the enclave. 
 
 Below is a quick explainer of the features offered by the attestation agent, and how they are relevant to Seismic.
 
@@ -22,9 +22,9 @@ This feature returns the type of enclave hardware being used.
 It's not relevant to Seismic at the moment because we want to abstract this information away from other services we currently use (namely reth).
 
 ### Extend Runtime Measurement
-Extending runtime measurements sets the values of RTMR registers. By convention for TDX, RTMR registers 0-2 are used to measure the kernal and OS, and register 3 is used to measure the guest workload.
+Extending runtime measurements sets the values of RTMR registers. By convention for TDX, RTMR registers 0-2 are used to measure the kernel and OS, and register 3 is used to measure the guest workload.
 
-Because Seismic is building our application into a yocto image, our measurements will included in [INSERT CORRECT FACT HERE WHEN WE HAVE SUCCESS WITH YOCTO]. We currently have no plans to expose this feature to other services, like RETH.
+Because Seismic is building our application into a yocto image, our measurements will be included in [INSERT CORRECT FACT HERE WHEN WE HAVE SUCCESS WITH YOCTO]. We currently have no plans to expose this feature to other services, like RETH.
 
 ### Check Init Data
 For Intel TDX, the init_data are the 48 bytes in MRCONFIGID. MRCONFIGID is a fingerprint of software that is setup by the host (i.e. the person or platform providing the hardware), such as the OS that the guest application runs on.
@@ -34,4 +34,4 @@ The init_data feature is not supported for AzTdxVtpm because their secure boot w
 ### Get token
 The CoCo library is built as a series of services that communicate with each other. Get token has the AA generate an attestation, and then send it to the AS to have the attestation verified. The AS then returns a token, which can be used to request resources. 
 
-This feature is not relevant to Seimic because we do not have this architecture. 
+This feature is not relevant to Seismic because we do not have this architecture. 


### PR DESCRIPTION
Hello,

Here are typos that I noticed in this section:

1- "Attestion Agent" → "Attestation Agent" (Title) 
2- "privides" → "provides" (First paragraph)
3- "kernal" → "kernel" (Extend Runtime Measurement section) 
4- "will included" → "will be included" (Extend Runtime Measurement section) 
5- "Seimic" → "Seismic" (Get Token section)

Thanks.