### PR TITLE
chore: replace println with tracing::info

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1884,6 +1884,7 @@ dependencies = [
  "anyhow",
  "reqwest 0.11.27",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -4450,6 +4451,7 @@ dependencies = [
  "secp256k1",
  "serde",
  "sha2",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/enclave-contract/Cargo.toml
+++ b/crates/enclave-contract/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 alloy.workspace = true
 anyhow.workspace = true
 reqwest.workspace = true
+tracing.workspace = true
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full", "test-util"] }

--- a/crates/enclave-contract/src/contract_interface.rs
+++ b/crates/enclave-contract/src/contract_interface.rs
@@ -7,6 +7,7 @@ use alloy::{
     signers::local::PrivateKeySigner,
     sol,
 };
+use tracing::info;
 
 use crate::{Measurements, MultisigUpgradeOperator::ProposalCreated};
 
@@ -147,7 +148,7 @@ pub async fn vote_on_multisig_proposal(
         .await
         .map_err(|e| anyhow::anyhow!("Failed to get vote receipt: {:?}", e))?;
 
-    println!("Voted on proposal:{:?}", proposal_id);
+    info!("Voted on proposal:{:?}", proposal_id);
 
     Ok(())
 }
@@ -194,7 +195,7 @@ pub async fn execute_multisig_proposal(
         .await
         .map_err(|e| anyhow::anyhow!("Failed to get execution receipt: {:?}", e))?;
 
-    println!("Proposal executed successfully");
+    info!("Proposal executed successfully");
 
     Ok(())
 }

--- a/crates/enclave-server/src/lib.rs
+++ b/crates/enclave-server/src/lib.rs
@@ -14,6 +14,7 @@ use anyhow::Result;
 use clap::Parser;
 use seismic_enclave::mock::start_mock_server;
 use std::net::SocketAddr;
+use tracing::info;
 
 /// Command line arguments for the enclave server
 #[derive(Parser, Debug)]
@@ -50,7 +51,7 @@ impl Args {
     pub async fn start(self) -> Result<()> {
         let addr: SocketAddr = format!("{}:{}", self.ip, self.port).parse()?;
 
-        println!("Starting TDX Quote JSON-RPC Server on {addr}...");
+        info!("Starting TDX Quote JSON-RPC Server on {addr}...");
 
         if self.mock {
             start_mock_server(addr).await

--- a/crates/enclave-server/src/server.rs
+++ b/crates/enclave-server/src/server.rs
@@ -219,7 +219,7 @@ pub async fn start_server(addr: SocketAddr, args: Args) -> anyhow::Result<()> {
 
     let handle = server.start(TdxQuoteServer::new(attestation_agent, key_manager).into_rpc());
 
-    println!("TDX Quote JSON-RPC Server started at {}", addr);
+    info!("TDX Quote JSON-RPC Server started at {}", addr);
 
     handle.stopped().await;
 

--- a/crates/enclave/Cargo.toml
+++ b/crates/enclave/Cargo.toml
@@ -18,3 +18,4 @@ secp256k1.workspace = true
 sha2.workspace = true
 rand.workspace = true
 serde.workspace = true
+tracing.workspace = true

--- a/crates/enclave/src/mock.rs
+++ b/crates/enclave/src/mock.rs
@@ -4,6 +4,7 @@ use std::net::SocketAddr;
 
 use jsonrpsee::core::{RpcResult, async_trait};
 use jsonrpsee::server::ServerBuilder;
+use tracing::info;
 
 use crate::api::{
     AttestationGetEvidenceResponse, GetPurposeKeysResponse, ShareRootKeyResponse, TdxQuoteRpcServer,
@@ -20,7 +21,7 @@ pub async fn start_mock_server(addr: SocketAddr) -> anyhow::Result<()> {
 
     let handle = server.start(MockServer {}.into_rpc());
 
-    println!("TDX Quote JSON-RPC Server started at {}", addr);
+    info!("TDX Quote JSON-RPC Server started at {}", addr);
 
     handle.stopped().await;
     Ok(())


### PR DESCRIPTION
Noticed in a few places that we were using println instead of info. When starting reth with --quiet, the printlns are still present:
```
Running `target/debug/seismic-reth node --dev --dev.block-time 2s --http --http.port 8545 --ws --ws.port 8545 --enclave.mock-server --quiet`
TDX Quote JSON-RPC Server started at 0.0.0.0:7878
```

Switching to info allows binaries that import the enclave lib to turn off the logs when they dont want them.