### PR TITLE
chore: gate az-tdx-vtpm on Linux for macOS dev builds

### DIFF
--- a/crates/enclave-server/Cargo.toml
+++ b/crates/enclave-server/Cargo.toml
@@ -22,7 +22,6 @@ seismic-enclave.workspace = true
 enclave-contract.workspace = true
 
 alloy.workspace = true
-az-tdx-vtpm.workspace = true
 openssl.workspace = true
 coco-provider.workspace = true
 chrono = "0.4.40"
@@ -50,6 +49,14 @@ rand.workspace = true
 zeroize.workspace = true
 sha2.workspace = true
 
+# az-tdx-vtpm pulls in tss-esapi-sys, which links against the Linux tpm2-tss
+# user-space stack and only ships prebuilt bindings for Linux tuples (plus
+# x86_64-darwin in theory, but pkg-config can't find tss2-* on macOS anyway).
+# Production runs on x86_64 Linux Azure TDX VMs, so gate the dep on Linux to
+# let the rest of the crate build on macOS for development.
+[target.'cfg(target_os = "linux")'.dependencies]
+az-tdx-vtpm.workspace = true
+
 [dev-dependencies]
 serial_test = "3.2.0"
 tempfile = "3.17.1"
@@ -57,4 +64,3 @@ tempfile = "3.17.1"
 [features]
 default = []
 systemctl = []
-

--- a/crates/enclave-server/src/attestation/mod.rs
+++ b/crates/enclave-server/src/attestation/mod.rs
@@ -3,6 +3,7 @@ pub mod upgrade_contract;
 pub mod utils;
 
 use anyhow::{Result, anyhow};
+#[cfg(target_os = "linux")]
 use az_tdx_vtpm::{hcl::HclReport, imds, tdx, vtpm};
 use coco_provider::{coco::CocoDeviceType, get_coco_provider};
 use dcap_rs::{types::quotes::version_4::QuoteV4, utils::quotes::version_4::verify_quote_dcapv4};
@@ -43,6 +44,12 @@ impl AttestationAgent {
         }
     }
 
+    // Only this function (and its `az_tdx_vtpm` import above) is gated on Linux
+    // — not the whole `attestation` module or `enclave-server` crate — so the
+    // rest of the codebase remains buildable / IDE-navigable on macOS. CI runs
+    // on Linux and exercises the gated body. See the matching `[target.'cfg(...)'.dependencies]`
+    // comment in Cargo.toml for why the dep itself is Linux-only.
+    #[cfg(target_os = "linux")]
     fn get_attestation_evidence_tpm(&self) -> Result<AttestationGetEvidenceResponse> {
         // todo this will be included in the quote, placeholding this for now we probably want our public key or a nonce here instead
         let report_data = [1u8; 32];
@@ -62,6 +69,13 @@ impl AttestationAgent {
             hcl_report: hcl_report_bytes,
             quote: signed_td_report_bytes,
         })
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    fn get_attestation_evidence_tpm(&self) -> Result<AttestationGetEvidenceResponse> {
+        Err(anyhow!(
+            "TPM attestation requires az-tdx-vtpm, which is only available on Linux"
+        ))
     }
 
     pub async fn verify_attestation_report(&self, quote: QuoteV4) -> Result<()> {


### PR DESCRIPTION
tss-esapi-sys (pulled in via az-tdx-vtpm) panics in its build script on aarch64-darwin because Apple Silicon isn't in its prebuilt-bindings tuple list, blocking `cargo check` and rust-analyzer on Mac:
```
2026-04-27T13:02:25.132979-04:00 ERROR FetchBuildDataError: error: failed to run custom build command for `tss-esapi-sys v0.5.0`
note: To improve backtraces for build dependencies, set the CARGO_PROFILE_DEV_BUILD_OVERRIDE_DEBUG=true environment variable to enable debug information generation.

Caused by:
  process didn't exit successfully: `/Users/samlaf/devel/seismic-workspace/enclave/target/debug/build/tss-esapi-sys-730a1f635a6eddc8/build-script-build` (exit status: 101)
  --- stderr

  thread 'main' (43137174) panicked at /Users/samlaf/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tss-esapi-sys-0.5.0/build.rs:35:17:
  Compilation target (architecture, OS) tuple (aarch64, darwin) is not part of the supported tuples. Please compile with the "generate-bindings" feature or add support for your platform :)
  stack backtrace:
     0: __rustc::rust_begin_unwind
               at /rustc/4a4ef493e3a1488c6e321570238084b38948f6db/library/std/src/panicking.rs:689:5
     1: core::panicking::panic_fmt
               at /rustc/4a4ef493e3a1488c6e321570238084b38948f6db/library/core/src/panicking.rs:80:14
     2: build_script_build::main
     3: core::ops::function::FnOnce::call_once
  note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```

## Fix

Move az-tdx-vtpm to a `[target.'cfg(target_os = "linux")'.dependencies]` entry and split `get_attestation_evidence_tpm` into a Linux impl (unchanged) and a non-Linux stub returning an error. The rest of the enclave-server crate now builds on macOS so dev/IDE works; the Linux build path and prod behavior are byte-identical to before. CI already runs on Linux, so the gated block is still type-checked there.

We could also just disable the entire attestation crate, but at least this way mac developers can still have IDE support if they want to make changes to the rest of this crate.