### PR TITLE
feat(enclave-server): support env-var bootstrap config

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ aes-gcm = "0.10"
 anyhow = "1.0"
 az-tdx-vtpm = "0.7.4"
 bincode = "1.3.3"
-clap = { version = "4.5.51", features = ["derive"] }
+clap = { version = "4.5.51", features = ["derive", "env"] }
 dcap-rs = "0.1.0"
 #auto_impl = "1"
 #base64 = "0.22"

--- a/crates/enclave-server/src/lib.rs
+++ b/crates/enclave-server/src/lib.rs
@@ -29,11 +29,12 @@ pub struct Args {
     pub port: u16,
 
     /// Flag if this is the genesis node that needs to generate the keys
-    #[arg(long, default_value_t = false)]
+    #[arg(long, env = "SEISMIC_ENCLAVE_GENESIS_NODE", default_value_t = false)]
     pub genesis_node: bool,
 
-    /// List of peer ips to fetch root key from. Must be {ip}:{port}
-    #[arg(long)]
+    /// Comma-separated list of peer URLs to fetch root key from (e.g. `http://10.0.0.1:7878`).
+    /// Required when `genesis_node` is false.
+    #[arg(long, env = "SEISMIC_ENCLAVE_PEERS", value_delimiter = ',')]
     pub peers: Vec<String>,
 
     /// path to unix socket used to communicate with Summit

--- a/crates/enclave-server/src/server.rs
+++ b/crates/enclave-server/src/server.rs
@@ -208,8 +208,24 @@ pub async fn start_server(addr: SocketAddr, args: Args) -> anyhow::Result<()> {
     let attestation_agent = AttestationAgent::new().unwrap();
 
     let key_manager = if args.genesis_node {
+        info!("Starting as genesis node; generating fresh network root key");
         KeyManager::new_as_genesis()?
     } else {
+        if args.peers.is_empty() {
+            anyhow::bail!(
+                "Non-genesis enclave started with no peers. Either:\n  \
+                 - set SEISMIC_ENCLAVE_PEERS to a comma-separated list of \
+                 peer enclave URLs (e.g. http://10.0.0.1:7878) to fetch \
+                 the root_key from an existing peer, OR\n  \
+                 - set SEISMIC_ENCLAVE_GENESIS_NODE=true to bootstrap a new \
+                 chain (set this on exactly one node in the deployment; \
+                 setting it on multiple nodes causes a silent network split)."
+            );
+        }
+        info!(
+            "Starting as peer node; fetching root key from {} peer(s)",
+            args.peers.len()
+        );
         fetch_root_key_from_peers(args.peers, &attestation_agent).await
     };
 
@@ -233,12 +249,6 @@ pub async fn fetch_root_key_from_peers(
     peers: Vec<String>,
     attestation_agent: &AttestationAgent,
 ) -> KeyManager {
-    // let peers: Vec<SocketAddr> = peers.iter().filter_map(|p| p.parse().ok()).collect();
-
-    if peers.is_empty() {
-        panic!("Started in non-genesis with no valid peers");
-    }
-
     info!("Starting root key fetching from peers");
     loop {
         let evidence = attestation_agent


### PR DESCRIPTION
`--genesis-node` and `--peers` gain `env=` attrs so they can be supplied via systemd EnvironmentFile (`SEISMIC_ENCLAVE_GENESIS_NODE`, `SEISMIC_ENCLAVE_PEERS`). tdx-init writes those vars at deploy time; ExecStart stays static. 

Also Replaced the cryptic non-genesis-no-peers panic with a startup-time error naming both env vars and warning about the silent network split if multiple VMs are flagged genesis.