### PR TITLE
chore(enclave-server): drop coco_provider dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1323,25 +1323,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cbindgen"
-version = "0.29.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "befbfd072a8e81c02f8c507aefce431fe5e7d051f83d48a23ffc9b9fe5a11799"
-dependencies = [
- "clap",
- "heck",
- "indexmap 2.10.0",
- "log",
- "proc-macro2",
- "quote",
- "serde",
- "serde_json",
- "syn 2.0.104",
- "tempfile",
- "toml",
-]
-
-[[package]]
 name = "cc"
 version = "1.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1426,23 +1407,6 @@ name = "clap_lex"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
-
-[[package]]
-name = "coco-provider"
-version = "0.3.0"
-source = "git+https://github.com/automata-network/coco-provider-sdk#3a832b8cf5e88ef71649ab56e4efd67067b26b7c"
-dependencies = [
- "bitfield 0.19.1",
- "cbindgen",
- "iocuddle",
- "libc",
- "log",
- "rand 0.8.5",
- "serde",
- "serde-big-array",
- "sysinfo",
- "uuid",
-]
 
 [[package]]
 name = "codicon"
@@ -3244,15 +3208,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ntapi"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8a3895c6391c39d7fe7ebc444a87eb2991b2a0bc718fdabd071eec617fc68e4"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "nu-ansi-term"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3351,25 +3306,6 @@ dependencies = [
  "ruint",
  "serde",
  "smallvec",
-]
-
-[[package]]
-name = "objc2-core-foundation"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
-dependencies = [
- "bitflags 2.9.1",
-]
-
-[[package]]
-name = "objc2-io-kit"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
-dependencies = [
- "libc",
- "objc2-core-foundation",
 ]
 
 [[package]]
@@ -4464,7 +4400,6 @@ dependencies = [
  "az-tdx-vtpm",
  "chrono",
  "clap",
- "coco-provider",
  "dcap-rs",
  "enclave-contract",
  "hex",
@@ -4567,15 +4502,6 @@ dependencies = [
  "itoa",
  "memchr",
  "ryu",
- "serde",
-]
-
-[[package]]
-name = "serde_spanned"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40734c41988f7306bb04f0ecf60ec0f3f1caa34290e4e8ea471dcd3346483b83"
-dependencies = [
  "serde",
 ]
 
@@ -4951,20 +4877,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sysinfo"
-version = "0.35.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c3ffa3e4ff2b324a57f7aeb3c349656c7b127c3c189520251a648102a92496e"
-dependencies = [
- "libc",
- "memchr",
- "ntapi",
- "objc2-core-foundation",
- "objc2-io-kit",
- "windows",
-]
-
-[[package]]
 name = "system-configuration"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5196,34 +5108,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75129e1dc5000bfbaa9fee9d1b21f974f9fbad9daec557a521ee6e080825f6e8"
-dependencies = [
- "indexmap 2.10.0",
- "serde",
- "serde_spanned",
- "toml_datetime 0.7.0",
- "toml_parser",
- "toml_writer",
- "winnow",
-]
-
-[[package]]
 name = "toml_datetime"
 version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
-
-[[package]]
-name = "toml_datetime"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bade1c3e902f58d73d3f294cd7f20391c1cb2fbcb643b73566bc773971df91e3"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "toml_edit"
@@ -5232,24 +5120,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap 2.10.0",
- "toml_datetime 0.6.11",
+ "toml_datetime",
  "winnow",
 ]
-
-[[package]]
-name = "toml_parser"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b551886f449aa90d4fe2bdaa9f4a2577ad2dde302c61ecf262d80b116db95c10"
-dependencies = [
- "winnow",
-]
-
-[[package]]
-name = "toml_writer"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcc842091f2def52017664b53082ecbbeb5c7731092bad69d2c63050401dfd64"
 
 [[package]]
 name = "tower"
@@ -5714,28 +5587,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
-name = "windows"
-version = "0.61.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
-dependencies = [
- "windows-collections",
- "windows-core",
- "windows-future",
- "windows-link",
- "windows-numerics",
-]
-
-[[package]]
-name = "windows-collections"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
-dependencies = [
- "windows-core",
-]
-
-[[package]]
 name = "windows-core"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5746,17 +5597,6 @@ dependencies = [
  "windows-link",
  "windows-result",
  "windows-strings",
-]
-
-[[package]]
-name = "windows-future"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
-dependencies = [
- "windows-core",
- "windows-link",
- "windows-threading",
 ]
 
 [[package]]
@@ -5786,16 +5626,6 @@ name = "windows-link"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
-
-[[package]]
-name = "windows-numerics"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
-dependencies = [
- "windows-core",
- "windows-link",
-]
 
 [[package]]
 name = "windows-result"
@@ -5921,15 +5751,6 @@ dependencies = [
  "windows_x86_64_gnu 0.53.0",
  "windows_x86_64_gnullvm 0.53.0",
  "windows_x86_64_msvc 0.53.0",
-]
-
-[[package]]
-name = "windows-threading"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
-dependencies = [
- "windows-link",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,5 +54,4 @@ tracing-subscriber = { version = "0.3", default-features = false, features = ["e
 #syn = "2.0"
 urlencoding = "2.1"
 zeroize = "1.8.1"
-coco-provider =  { git = "https://github.com/automata-network/coco-provider-sdk", default-features = false}
 x509-parser = "0.15.1"

--- a/crates/enclave-server/Cargo.toml
+++ b/crates/enclave-server/Cargo.toml
@@ -23,7 +23,6 @@ enclave-contract.workspace = true
 
 alloy.workspace = true
 openssl.workspace = true
-coco-provider.workspace = true
 chrono = "0.4.40"
 hex.workspace = true
 hkdf.workspace = true

--- a/crates/enclave-server/src/attestation/mod.rs
+++ b/crates/enclave-server/src/attestation/mod.rs
@@ -5,7 +5,6 @@ pub mod utils;
 use anyhow::{Result, anyhow};
 #[cfg(target_os = "linux")]
 use az_tdx_vtpm::{hcl::HclReport, imds, tdx, vtpm};
-use coco_provider::{coco::CocoDeviceType, get_coco_provider};
 use dcap_rs::{types::quotes::version_4::QuoteV4, utils::quotes::version_4::verify_quote_dcapv4};
 use seismic_enclave::AttestationGetEvidenceResponse;
 
@@ -23,25 +22,23 @@ pub enum CA {
 }
 
 pub struct AttestationAgent {
-    provider: CocoDeviceType,
     pccs: IntelPccs,
 }
 
+// Currently Azure-only. The vTPM-via-IMDS path is the canonical surface on Azure CVMs
+// (paravisor-mediated TDX; /dev/tdx_guest is not exposed to the guest).
+// TODO(samlaf): For GCP support — fully-enlightened TDX with /dev/tdx_guest
+// or /sys/kernel/config/tsm/report. We'll need a cloud-detect step (IMDS probe) and
+// a second `get_attestation_evidence_gcp()` arm.
 impl AttestationAgent {
     pub fn new() -> Result<Self> {
-        let provider = get_coco_provider()?;
         Ok(Self {
-            provider: provider.device_type,
             pccs: IntelPccs::new(),
         })
     }
 
     pub fn get_attestation_evidence(&self) -> Result<AttestationGetEvidenceResponse> {
-        match self.provider {
-            // Azure and other TDX cloud providers use TPM
-            CocoDeviceType::Tpm => self.get_attestation_evidence_tpm(),
-            _ => self.get_attestation_evidence_tpm(), // todo: For some reason on Azure Ubuntu CVM it is going to Mock device type even when the tpm is available
-        }
+        self.get_attestation_evidence_tpm()
     }
 
     // Only this function (and its `az_tdx_vtpm` import above) is gated on Linux


### PR DESCRIPTION
The coco-provider-sdk crate had bugs blocking non-root use on Azure (configfs probe bailed on EACCES before falling through to TPM):
https://github.com/automata-network/coco-provider-sdk/issues/12
https://github.com/automata-network/coco-provider-sdk/issues/13

We only used it for device-type detection anyways; the actual attestation work is done by az-tdx-vtpm (Azure) and dcap-rs (verification). Removed the dep and let AttestationAgent call the TPM path directly.

