### PR TITLE
feat(enclave-server): persist root_key to disk

### DIFF
--- a/crates/enclave-server/src/key_manager/mod.rs
+++ b/crates/enclave-server/src/key_manager/mod.rs
@@ -1,3 +1,5 @@
+pub mod persistence;
+
 use anyhow::Result;
 use hkdf::Hkdf;
 use rand::{TryRngCore as _, rngs::OsRng};

--- a/crates/enclave-server/src/key_manager/persistence.rs
+++ b/crates/enclave-server/src/key_manager/persistence.rs
@@ -1,0 +1,164 @@
+//! Disk persistence for `root_key`.
+//!
+//! `root_key` persists at `<data_dir>/root_key`. Default `data_dir` is
+//! `/var/lib/enclave` (FHS). Production routes that path onto a
+//! LUKS-encrypted mount via a `BindPaths=` entry in the systemd unit;
+//! the binary is unaware of LUKS or `/persistent/`. Tests pass
+//! `--data-dir <tempdir>`.
+//!
+//! # Threat model
+//!
+//! Adversary is a malicious hypervisor. We can't do much against it at
+//! this layer — it can drop writes, lie about `fsync`, roll back the
+//! disk, etc. Defenses against those live above this module (peer-fetch
+//! fallback, future consensus-arbitrated bootstrap; see tee-plan.md
+//! enclave TODO 3).
+//!
+//! This module's responsibility is narrower: write `root_key` once at
+//! genesis (or first peer-fetch), read it on every subsequent boot.
+//! Reads hard-fail on any wrong-size or unreadable file rather than
+//! silently regenerating — silent regeneration is a chain-bricking
+//! action. Writes are in-place (no temp file + rename); a crash in the
+//! brief write window can leave a wrong-size file, which triggers the
+//! same hard-fail. Production TDX VMs have no SSH, so "recovery" means
+//! replacing the VM (Pulumi destroy + up); the fresh VM re-runs the
+//! resolve-or-generate flow from scratch.
+
+use anyhow::{Context as _, Result, anyhow};
+use std::{
+    fs::{self, OpenOptions},
+    io::{self, Write as _},
+    os::unix::fs::{OpenOptionsExt as _, PermissionsExt as _},
+    path::Path,
+};
+
+const ROOT_KEY_FILENAME: &str = "root_key";
+// 0o400 (owner read-only). We never rewrite this file — it's write-once at
+// genesis (or first peer-fetch). The mode mostly defends against a future
+// regression that accidentally opens it O_WRONLY: that would fail loudly
+// with EACCES rather than silently clobbering the network's root key.
+const ROOT_KEY_MODE: u32 = 0o400;
+
+pub fn root_key_path(data_dir: &Path) -> std::path::PathBuf {
+    data_dir.join(ROOT_KEY_FILENAME)
+}
+
+/// Read `root_key` from `data_dir/root_key`.
+///
+/// Returns `Ok(None)` if the file does not exist (first boot). Returns
+/// `Err` on any other I/O failure or if the file is not exactly 32 bytes —
+/// silently regenerating would be a chain-bricking action and demands
+/// operator intervention.
+pub fn read_root_key(data_dir: &Path) -> Result<Option<[u8; 32]>> {
+    let path = root_key_path(data_dir);
+    match fs::read(&path) {
+        Ok(bytes) => {
+            let arr: [u8; 32] = bytes.as_slice().try_into().map_err(|_| {
+                anyhow!(
+                    "root_key at {} has wrong size: expected 32 bytes, got {}",
+                    path.display(),
+                    bytes.len(),
+                )
+            })?;
+            Ok(Some(arr))
+        }
+        Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(None),
+        Err(e) => Err(e).with_context(|| format!("reading root_key at {}", path.display())),
+    }
+}
+
+/// Write `root_key` to `data_dir/root_key` with mode 0400.
+///
+/// Recipe: `open(O_CREAT|O_EXCL)`, write 32 bytes, set mode 0400, fsync
+/// the file, fsync the parent directory. Refuses to overwrite an existing
+/// file (`O_EXCL`) — callers must check `read_root_key` first.
+///
+/// A crash between open and the final fsync can leave a wrong-size file
+/// on disk; `read_root_key` hard-fails in that case and recovery is to
+/// replace the VM (no SSH into production TDX). Acceptable because the
+/// write window is microseconds for a 32-byte one-shot, and no client
+/// has used the key yet at first-create time (the attestation endpoint
+/// isn't serving until after this function returns).
+///
+/// See <https://danluu.com/file-consistency/> for the fsync recipe and
+/// why each step matters.
+pub fn write_root_key(data_dir: &Path, key: &[u8; 32]) -> Result<()> {
+    let path = root_key_path(data_dir);
+
+    let mut file = OpenOptions::new()
+        .create_new(true)
+        .write(true)
+        .mode(ROOT_KEY_MODE)
+        .open(&path)
+        .with_context(|| format!("creating root_key at {}", path.display()))?;
+    file.write_all(key).context("writing root_key bytes")?;
+    // Defensive re-chmod in case the open-time umask widened the perms.
+    file.set_permissions(fs::Permissions::from_mode(ROOT_KEY_MODE))
+        .with_context(|| format!("setting mode {ROOT_KEY_MODE:o}"))?;
+    file.sync_all().context("fsync on root_key")?;
+    drop(file);
+
+    fs::File::open(data_dir)
+        .and_then(|f| f.sync_all())
+        .with_context(|| format!("fsync on parent dir {}", data_dir.display()))?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn read_missing_returns_none() {
+        let dir = tempdir().unwrap();
+        assert!(read_root_key(dir.path()).unwrap().is_none());
+    }
+
+    #[test]
+    fn write_then_read_roundtrips() {
+        let dir = tempdir().unwrap();
+        let key = [0xABu8; 32];
+        write_root_key(dir.path(), &key).unwrap();
+        let read = read_root_key(dir.path()).unwrap().unwrap();
+        assert_eq!(read, key);
+    }
+
+    #[test]
+    fn write_creates_file_with_mode_0400() {
+        let dir = tempdir().unwrap();
+        write_root_key(dir.path(), &[0u8; 32]).unwrap();
+        let mode = fs::metadata(root_key_path(dir.path()))
+            .unwrap()
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(mode, ROOT_KEY_MODE);
+    }
+
+    #[test]
+    fn read_rejects_wrong_size_file() {
+        let dir = tempdir().unwrap();
+        fs::write(root_key_path(dir.path()), b"too short").unwrap();
+        let err = read_root_key(dir.path()).unwrap_err();
+        assert!(err.to_string().contains("wrong size"));
+    }
+
+    #[test]
+    fn write_refuses_to_overwrite_existing() {
+        let dir = tempdir().unwrap();
+        write_root_key(dir.path(), &[0x11u8; 32]).unwrap();
+        // O_EXCL: callers must check read_root_key first; this guards against
+        // accidental clobbering of an existing key.
+        assert!(write_root_key(dir.path(), &[0x22u8; 32]).is_err());
+        assert_eq!(read_root_key(dir.path()).unwrap().unwrap(), [0x11u8; 32]);
+    }
+
+    #[test]
+    fn write_to_missing_dir_errors() {
+        let dir = tempdir().unwrap();
+        let missing = dir.path().join("does-not-exist");
+        assert!(write_root_key(&missing, &[0u8; 32]).is_err());
+    }
+}

--- a/crates/enclave-server/src/lib.rs
+++ b/crates/enclave-server/src/lib.rs
@@ -5,11 +5,12 @@ pub mod utils;
 
 const ENCLAVE_DEFAULT_ENDPOINT_IP: &str = "127.0.0.1";
 pub const ENCLAVE_DEFAULT_ENDPOINT_PORT: u16 = 7878;
+const ENCLAVE_DEFAULT_DATA_DIR: &str = "/var/lib/enclave";
 
 use anyhow::Result;
 use clap::Parser;
 use seismic_enclave::mock::start_mock_server;
-use std::net::SocketAddr;
+use std::{net::SocketAddr, path::PathBuf};
 use tracing::info;
 
 /// Command line arguments for the enclave server
@@ -32,6 +33,19 @@ pub struct Args {
     /// Required when `genesis_node` is false.
     #[arg(long, env = "SEISMIC_ENCLAVE_PEERS", value_delimiter = ',')]
     pub peers: Vec<String>,
+
+    /// Directory for service-managed persistent state (currently just `root_key`).
+    ///
+    /// FHS-shaped default (`/var/lib/enclave`); production routes this onto a
+    /// LUKS-encrypted mount via a `BindPaths=` entry in the systemd unit so the
+    /// binary stays unaware of the underlying storage layout. Tests inject a
+    /// `tempfile::tempdir()`; local dev can point at any writable path.
+    #[arg(
+        long,
+        env = "SEISMIC_ENCLAVE_DATA_DIR",
+        default_value = ENCLAVE_DEFAULT_DATA_DIR,
+    )]
+    pub data_dir: PathBuf,
 
     /// Run the dev-only mock server instead of the real enclave.
     ///

--- a/crates/enclave-server/src/server.rs
+++ b/crates/enclave-server/src/server.rs
@@ -1,5 +1,8 @@
 use crate::{
-    Args, attestation::AttestationAgent, key_manager::KeyManager, utils::anyhow_to_rpc_error,
+    Args,
+    attestation::AttestationAgent,
+    key_manager::{KeyManager, persistence},
+    utils::anyhow_to_rpc_error,
 };
 use dcap_rs::types::quotes::version_4::QuoteV4;
 use jsonrpsee::{
@@ -84,26 +87,46 @@ impl TdxQuoteRpcServer for TdxQuoteServer {
 pub async fn start_server(addr: SocketAddr, args: Args) -> anyhow::Result<()> {
     let attestation_agent = AttestationAgent::new().unwrap();
 
-    let key_manager = if args.genesis_node {
-        info!("Starting as genesis node; generating fresh network root key");
-        KeyManager::new_as_genesis()?
-    } else {
-        if args.peers.is_empty() {
-            anyhow::bail!(
-                "Non-genesis enclave started with no peers. Either:\n  \
-                 - set SEISMIC_ENCLAVE_PEERS to a comma-separated list of \
-                 peer enclave URLs (e.g. http://10.0.0.1:7878) to fetch \
-                 the root_key from an existing peer, OR\n  \
-                 - set SEISMIC_ENCLAVE_GENESIS_NODE=true to bootstrap a new \
-                 chain (set this on exactly one node in the deployment; \
-                 setting it on multiple nodes causes a silent network split)."
+    let key_manager = match persistence::read_root_key(&args.data_dir)? {
+        Some(bytes) => {
+            // Non-destructive: if a key file exists, use it regardless of
+            // --genesis-node. Closes the "operator forgot to unset
+            // --genesis-node between reboots" footgun.
+            info!(
+                "Loaded persisted root_key from {}",
+                args.data_dir.display()
             );
+            if args.genesis_node {
+                warn!("--genesis-node set but a persisted root_key already exists; ignoring the flag");
+            }
+            KeyManager::new(bytes)
         }
-        info!(
-            "Starting as peer node; fetching root key from {} peer(s)",
-            args.peers.len()
-        );
-        fetch_root_key_from_peers(args.peers, &attestation_agent).await
+        None => {
+            let km = if args.genesis_node {
+                info!("No persisted root_key; generating a fresh network root key as genesis node");
+                KeyManager::new_as_genesis()?
+            } else {
+                if args.peers.is_empty() {
+                    anyhow::bail!(
+                        "Non-genesis enclave started with no persisted root_key and no peers. Either:\n  \
+                         - set SEISMIC_ENCLAVE_PEERS to a comma-separated list of \
+                         peer enclave URLs (e.g. http://10.0.0.1:7878) to fetch \
+                         the root_key from an existing peer, OR\n  \
+                         - set SEISMIC_ENCLAVE_GENESIS_NODE=true to bootstrap a new \
+                         chain (set this on exactly one node in the deployment; \
+                         setting it on multiple nodes causes a silent network split)."
+                    );
+                }
+                info!(
+                    "No persisted root_key; fetching from {} peer(s)",
+                    args.peers.len()
+                );
+                fetch_root_key_from_peers(args.peers, &attestation_agent).await
+            };
+            persistence::write_root_key(&args.data_dir, &km.get_root_key())?;
+            info!("Persisted root_key under {}", args.data_dir.display());
+            km
+        }
     };
 
     let server = ServerBuilder::default().build(addr).await?;

--- a/crates/enclave-server/src/server.rs
+++ b/crates/enclave-server/src/server.rs
@@ -92,12 +92,11 @@ pub async fn start_server(addr: SocketAddr, args: Args) -> anyhow::Result<()> {
             // Non-destructive: if a key file exists, use it regardless of
             // --genesis-node. Closes the "operator forgot to unset
             // --genesis-node between reboots" footgun.
-            info!(
-                "Loaded persisted root_key from {}",
-                args.data_dir.display()
-            );
+            info!("Loaded persisted root_key from {}", args.data_dir.display());
             if args.genesis_node {
-                warn!("--genesis-node set but a persisted root_key already exists; ignoring the flag");
+                warn!(
+                    "--genesis-node set but a persisted root_key already exists; ignoring the flag"
+                );
             }
             KeyManager::new(bytes)
         }

--- a/crates/enclave-server/tests/integration/integration.rs
+++ b/crates/enclave-server/tests/integration/integration.rs
@@ -16,8 +16,13 @@ async fn test_boot_share_root_key() {
         panic!("test_boot_share_root_key: skipped (requires sudo privileges)");
     }
 
+    // Each enclave needs its own data_dir for root_key persistence.
+    // Tempdirs must outlive the spawned tasks; bind them in the test scope.
+    let data_dir1 = tempfile::tempdir().unwrap();
+    let data_dir2 = tempfile::tempdir().unwrap();
+
     // Start first enclave as genesis node
-    let args1 = get_args(0, true, Default::default());
+    let args1 = get_args(0, true, Default::default(), data_dir1.path().to_path_buf());
     let enclave_one_url = format!("http://localhost:{}", args1.port);
     let node1_handle = tokio::spawn(args1.start());
 
@@ -25,7 +30,12 @@ async fn test_boot_share_root_key() {
     tokio::time::sleep(Duration::from_secs(1)).await;
 
     // start second enclave with node1 as his peer
-    let args2 = get_args(1, false, vec![enclave_one_url.clone()]);
+    let args2 = get_args(
+        1,
+        false,
+        vec![enclave_one_url.clone()],
+        data_dir2.path().to_path_buf(),
+    );
     let enclave_two_url = format!("http://localhost:{}", args2.port);
     let node2_handle = tokio::spawn(args2.start());
     // sleep some time to allow them to share keys

--- a/crates/enclave-server/tests/integration/utils.rs
+++ b/crates/enclave-server/tests/integration/utils.rs
@@ -1,6 +1,7 @@
 use seismic_enclave_server::Args;
+use std::path::PathBuf;
 
-pub fn get_args(n: u16, genesis_node: bool, peers: Vec<String>) -> Args {
+pub fn get_args(n: u16, genesis_node: bool, peers: Vec<String>, data_dir: PathBuf) -> Args {
     let port = 7878 + n;
     Args {
         ip: "0.0.0.0".to_string(),
@@ -8,5 +9,6 @@ pub fn get_args(n: u16, genesis_node: bool, peers: Vec<String>) -> Args {
         genesis_node,
         peers,
         mock: false,
+        data_dir,
     }
 }


### PR DESCRIPTION
Adds --data-dir CLI flag (default /var/lib/enclave) and persists root_key as <data_dir>/root_key (mode 0400). start_server uses a resolve-or-generate flow: load the existing key if present, else dispatch to genesis or peer-fetch and persist. --genesis-node is non-destructive when a key file already exists, closing the "operator forgot to unset the flag between reboots" footgun.

Plan is to change seismic-images to bind-mount /var/lib/enclave/ onto /persistent/secrets/enclave/ (LUKS-encrypted) via BindPaths= in the systemd unit; this way enclave binary stays unaware of LUKS or the /persistent layout.