### PR TITLE
feat(enclave-server): write LUKS keys to tmpfs for setup-persistent-luks

### DIFF
--- a/crates/enclave-server/src/key_manager/mod.rs
+++ b/crates/enclave-server/src/key_manager/mod.rs
@@ -29,6 +29,14 @@ pub enum KeyPurpose {
     Snapshot,
     RngPrecompile,
     TxIo,
+    /// LUKS volume unlock key.
+    Storage,
+    /// HMAC key for verifying the LUKS2 header against tampering:
+    /// https://blog.trailofbits.com/2025/10/30/vulnerabilities-in-luks2-disk-encryption-for-confidential-vms/
+    /// Used by setup-persistent-luks to MAC `segments + keyslots + digests`
+    /// and store the result as a custom LUKS2 token; verified on every subsequent boot
+    /// before `cryptsetup open`.
+    LuksHeaderMac,
 }
 
 impl KeyPurpose {
@@ -38,6 +46,8 @@ impl KeyPurpose {
             KeyPurpose::Snapshot => "snapshot",
             KeyPurpose::RngPrecompile => "rng-precompile",
             KeyPurpose::TxIo => "tx-io",
+            KeyPurpose::Storage => "storage",
+            KeyPurpose::LuksHeaderMac => "luks-header-mac",
         }
     }
 

--- a/crates/enclave-server/src/lib.rs
+++ b/crates/enclave-server/src/lib.rs
@@ -1,5 +1,6 @@
 mod attestation;
 mod key_manager;
+mod luks_keys;
 mod server;
 pub mod utils;
 

--- a/crates/enclave-server/src/luks_keys.rs
+++ b/crates/enclave-server/src/luks_keys.rs
@@ -1,0 +1,53 @@
+//! Hand off LUKS-related derived keys to `setup-persistent-luks`
+//! (seismic-images) at startup.
+//!
+//! Writes 64 raw bytes — `storage_key (32B) || header_mac_key (32B)` —
+//! to a tmpfs file owned by the enclave user. The LUKS-setup script
+//! reads the file, uses both keys, and `shred -u`s the file after
+//! `cryptsetup open` succeeds. The directory itself is created by
+//! systemd's `RuntimeDirectory=` in enclave.service before this
+//! process starts.
+
+use crate::key_manager::{KeyManager, KeyPurpose};
+use anyhow::{Context as _, Result};
+use std::{
+    fs::OpenOptions,
+    io::Write as _,
+    os::unix::fs::OpenOptionsExt as _,
+    path::Path,
+};
+use tracing::info;
+
+/// Drop-zone for the LUKS keys. Hardcoded to match the `RuntimeDirectory=`
+/// in enclave.service (seismic-images); the parent dir is created by
+/// systemd before this process starts.
+const LUKS_KEYS_PATH: &str = "/run/seismic/enclave/luks-keys";
+
+/// Storage and header-MAC keys are pinned at epoch 0; they are never rotated.
+const KEYS_EPOCH_0: u64 = 0;
+
+/// Derive `storage_key` + `header_mac_key` from the current root_key
+/// and write them to a tmpfs file for setup-persistent-luks to read.
+/// Errors are fatal: without these keys reaching the LUKS-setup script,
+/// `/persistent` won't mount and the node can't proceed.
+pub fn write_keys_for_luks_setup(km: &KeyManager) -> Result<()> {
+    let storage_key = km.derive_purpose_key(KeyPurpose::Storage, KEYS_EPOCH_0)?;
+    let header_mac_key = km.derive_purpose_key(KeyPurpose::LuksHeaderMac, KEYS_EPOCH_0)?;
+
+    let mut buf = [0u8; 64];
+    buf[..32].copy_from_slice(storage_key.as_ref());
+    buf[32..].copy_from_slice(header_mac_key.as_ref());
+
+    let path = Path::new(LUKS_KEYS_PATH);
+    let mut f = OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .mode(0o400)
+        .open(path)
+        .with_context(|| format!("creating {}", path.display()))?;
+    f.write_all(&buf)?;
+    f.sync_all()?;
+    info!("wrote LUKS keys for setup-persistent-luks at {}", path.display());
+    Ok(())
+}

--- a/crates/enclave-server/src/luks_keys.rs
+++ b/crates/enclave-server/src/luks_keys.rs
@@ -10,12 +10,7 @@
 
 use crate::key_manager::{KeyManager, KeyPurpose};
 use anyhow::{Context as _, Result};
-use std::{
-    fs::OpenOptions,
-    io::Write as _,
-    os::unix::fs::OpenOptionsExt as _,
-    path::Path,
-};
+use std::{fs::OpenOptions, io::Write as _, os::unix::fs::OpenOptionsExt as _, path::Path};
 use tracing::info;
 
 /// Drop-zone for the LUKS keys. Hardcoded to match the `RuntimeDirectory=`
@@ -48,6 +43,9 @@ pub fn write_keys_for_luks_setup(km: &KeyManager) -> Result<()> {
         .with_context(|| format!("creating {}", path.display()))?;
     f.write_all(&buf)?;
     f.sync_all()?;
-    info!("wrote LUKS keys for setup-persistent-luks at {}", path.display());
+    info!(
+        "wrote LUKS keys for setup-persistent-luks at {}",
+        path.display()
+    );
     Ok(())
 }

--- a/crates/enclave-server/src/server.rs
+++ b/crates/enclave-server/src/server.rs
@@ -1,5 +1,6 @@
 use crate::{
-    Args, attestation::AttestationAgent, key_manager::KeyManager, utils::anyhow_to_rpc_error,
+    Args, attestation::AttestationAgent, key_manager::KeyManager, luks_keys,
+    utils::anyhow_to_rpc_error,
 };
 use dcap_rs::types::quotes::version_4::QuoteV4;
 use jsonrpsee::{
@@ -105,6 +106,12 @@ pub async fn start_server(addr: SocketAddr, args: Args) -> anyhow::Result<()> {
         );
         fetch_root_key_from_peers(args.peers, &attestation_agent).await
     };
+
+    // Hand off the LUKS storage + header-MAC keys to setup-persistent-luks
+    // (seismic-images script) via a tmpfs file. Fatal on failure — without
+    // these keys reaching the LUKS-setup script, /persistent can't
+    // mount and the node can't proceed past this boot.
+    luks_keys::write_keys_for_luks_setup(&key_manager)?;
 
     let server = ServerBuilder::default().build(addr).await?;
 


### PR DESCRIPTION
In the no-on-disk-root_key architecture, /persistent's LUKS unlock key must be derived from root_key in RAM and handed to setup-persistent-luks (seismic-images). This commit adds the enclave-server side.

In start_server, before the JSON-RPC server binds, derive two keys from root_key and write 64 raw bytes to /run/seismic/enclave/luks-keys (tmpfs, mode 0400):
- storage_key (KeyPurpose::Storage) — LUKS volume unlock key.
- header_mac_key (KeyPurpose::LuksHeaderMac) — userspace MAC defending against CVE-2025-59054 / CVE-2025-58356 (LUKS2 header tampering → cipher_null plaintext writes). setup-persistent-luks will HMAC segments+keyslots+digests and verify against a LUKS2 token. See https://blog.trailofbits.com/2025/10/30/vulnerabilities-in-luks2-disk-encryption-for-confidential-vms/

Both keys are pinned at epoch 0: LUKS rekey is painful and the on-disk MAC token would invalidate on any root_key rotation. Write failure is fatal — start_server returns Err before binding the JSON-RPC port so systemd surfaces it rather than running a broken node.

File chosen over Unix socket: setup-persistent-luks reads once at boot, never reconnects. Socket would need a long-running accept loop or explicit "done" signaling. Both transit tmpfs (RAM); the file's exposure ends when setup-persistent-luks shreds it post-open.

The seismic-images counterpart (RuntimeDirectory= on enclave.service, setup-persistent-luks rewrite, boot-order inversion) lands in a follow-up; until then the file is written but unread.