### PR TITLE
docs(attestation): clarify Azure TDX vTPM trust model

### DIFF
--- a/crates/enclave-server/src/attestation/mod.rs
+++ b/crates/enclave-server/src/attestation/mod.rs
@@ -27,6 +27,12 @@ pub struct AttestationAgent {
 
 // Currently Azure-only. The vTPM-via-IMDS path is the canonical surface on Azure CVMs
 // (paravisor-mediated TDX; /dev/tdx_guest is not exposed to the guest).
+//
+// Important: Azure's raw TDX quote measurements primarily attest the Microsoft
+// OpenHCL/OpenVMM paravisor TD, not Seismic's nested guest OS image. Production
+// Azure guest attestation also needs vTPM AK/PCR quote + event-log verification
+// or equivalent MAA JWT claim verification. The current HCL+TDX envelope is only
+// a platform endorsement and protocol-binding primitive.
 // TODO(samlaf): For GCP support — fully-enlightened TDX with /dev/tdx_guest
 // or /sys/kernel/config/tsm/report. We'll need a cloud-detect step (IMDS probe) and
 // a second `get_attestation_evidence_gcp()` arm.
@@ -89,6 +95,11 @@ impl AttestationAgent {
         ))
     }
 
+    /// Verifies the current raw DCAP quote path.
+    ///
+    /// Azure caveat: this checks Intel DCAP collateral and current TDX fields
+    /// only. It does not verify Seismic guest PCRs/event logs, so it is not a
+    /// complete Azure CVM guest attestation verifier.
     pub async fn verify_attestation_report(&self, quote: QuoteV4) -> Result<()> {
         let collaterals = self.pccs.get_collateral(&quote).await?;
         let current_time = chrono::Utc::now().timestamp() as u64;

--- a/crates/enclave-server/src/attestation/upgrade_contract.rs
+++ b/crates/enclave-server/src/attestation/upgrade_contract.rs
@@ -2,6 +2,11 @@ use anyhow::{Result, anyhow};
 use dcap_rs::types::quotes::{body::QuoteBody, version_4::QuoteV4};
 use enclave_contract::UpgradeOperator;
 
+/// Checks TDX quote fields against the current UpgradeOperator policy.
+///
+/// Azure caveat: for Azure CVMs these fields are platform/paravisor
+/// measurements, not sufficient Seismic guest OS measurements. Do not use this
+/// as the sole Azure production allowlist once vTPM/MAA verification is added.
 pub async fn verify_measurements_against_contract(quote: &QuoteV4) -> Result<()> {
     let QuoteBody::TD10QuoteBody(quote_body) = quote.quote_body else {
         return Err(anyhow!("Not a tdx quote"));
@@ -32,6 +37,6 @@ pub async fn verify_measurements_against_contract(quote: &QuoteV4) -> Result<()>
     {
         Ok(())
     } else {
-        Err(anyhow!("Now approved"))
+        Err(anyhow!("Not approved"))
     }
 }

--- a/crates/seismic-attestation/src/lib.rs
+++ b/crates/seismic-attestation/src/lib.rs
@@ -4,6 +4,13 @@
 //! Seismic-specific semantics around evidence envelopes, protocol bindings,
 //! measurements, and provider-specific binding checks. The underlying QVL can be
 //! swapped later behind this crate's public types.
+//!
+//! Azure caveat: Azure CVMs run the guest under Microsoft OpenHCL/OpenVMM
+//! paravisor/nested virtualization. The raw TDX quote measurements surfaced here
+//! are therefore platform/paravisor measurements, not sufficient Seismic guest OS
+//! identity. Azure production policy also needs vTPM PCR quote/event-log (or MAA
+//! JWT claim) verification before treating an enclave as running the expected
+//! Seismic image.
 
 use az_cvm_vtpm::hcl::{HclReport, ReportType};
 use dcap_rs::types::quotes::{body::QuoteBody, version_4::QuoteV4};
@@ -30,13 +37,20 @@ pub struct AzureTdxEvidence {
 }
 
 /// Minimal verified quote fields needed by Seismic policy.
+///
+/// On Azure these fields describe the paravisor-backed TDX platform evidence.
+/// They must not be used as the only guest image measurement policy.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct VerifiedQuoteFields {
     pub report_data: [u8; 64],
     pub measurements: TdxMeasurements,
 }
 
-/// TDX measurement identity surfaced to Seismic policy.
+/// TDX platform/paravisor measurements surfaced to Seismic policy.
+///
+/// TODO(attestation): split this into `TdxPlatformMeasurements` and add an
+/// Azure `GuestMeasurements`/PCR policy type. The old name is kept temporarily
+/// to avoid churn while callers migrate.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct TdxMeasurements {
     pub mrtd: [u8; 48],
@@ -47,7 +61,10 @@ pub struct TdxMeasurements {
     pub rtmr3: [u8; 48],
 }
 
-/// Static measurement policy for fixtures and initial deploy checks.
+/// Static TDX platform measurement policy for fixtures.
+///
+/// On Azure this is not sufficient for production guest allowlisting; use vTPM
+/// PCR/event-log or MAA claims once those evidence types are added.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum MeasurementPolicy {
     Any,
@@ -82,12 +99,15 @@ pub enum AttestationError {
 
 // === Public API ===
 
-/// Main entrypoint for verifying the Seismic policy around the current Azure
-/// TDX evidence envelope.
+/// Main entrypoint for checking bindings around the current Azure HCL + TDX
+/// evidence envelope.
 ///
 /// This currently performs parsing/extraction and Seismic policy checks. Full
 /// DCAP cryptographic verification is still done by the caller and will move
 /// behind this API when we migrate to the chosen QVL.
+///
+/// Azure caveat: this does not verify guest PCRs/event logs or an MAA JWT. A
+/// successful result is not by itself proof of the Seismic guest OS image.
 pub fn verify_azure_tdx_policy(
     evidence: &AzureTdxEvidence,
     expected_binding: &[u8],


### PR DESCRIPTION
Document that Azure CVMs run under Microsoft OpenHCL/OpenVMM with nested virtualization, so raw TDX MRTD/RTMR values attest the Azure platform/paravisor layer rather than the Seismic guest image.                                 
                                                                                             
Update the attestation plan and inventory to make Azure vTPM PCR                              
quotes/event-log replay or MAA claims the required source of guest                            
measurement policy. Call out current gaps in enclave-server and                               
seismic-attestation, including quote-only root-key bootstrap,                                 
ignored HCL reports, placeholder report data, panic-prone parsing, and                        
UpgradeOperator checks over TDX fields.                                                       
                                                                                             
Add code comments warning that current TDX quote verification is only a                       
platform/paravisor check on Azure and is not sufficient production guest                      
attestation. Also fix the UpgradeOperator rejection error typo.