### PR TITLE
feat(seismic-attestation): NetworkManifest v1 + network_id-bound transcript bindings

### DIFF
--- a/crates/seismic-attestation/fixtures/network-manifest-v1.json
+++ b/crates/seismic-attestation/fixtures/network-manifest-v1.json
@@ -1,0 +1,20 @@
+{
+  "eth": {
+    "chain_id": 5124,
+    "genesis_hash": "0x78ab9057bb67f95a6182969c5d755ac02802c98c0d2f0d8daeb52f4bddc60be5"
+  },
+  "genesis_nonce": "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "manifest_version": 1,
+  "measurements": {
+    "bootstrap_policy_hash": "0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+    "contracts": {
+      "authority": "0x1000000000000000000000000000000000000002",
+      "registry": "0x1000000000000000000000000000000000000001"
+    }
+  },
+  "name": "seismic-devnet-3",
+  "summit": {
+    "genesis_template_hash": "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    "namespace": "seismic-devnet-3"
+  }
+}

--- a/crates/seismic-attestation/src/bindings.rs
+++ b/crates/seismic-attestation/src/bindings.rs
@@ -1,0 +1,161 @@
+//! Helpers for deriving Seismic protocol-binding digests.
+//!
+//! Every binding is `SHA256(domain || network_id || fixed-length fields ||
+//! optional variable tail)`. The layout rule: domain string first, then only
+//! fixed-length fields (`network_id` 32, nonces 32, compressed secp256k1
+//! points 33, epochs 8 BE), at most one variable-length field and only in tail
+//! position — this keeps plain concatenation injective without length
+//! prefixes. The fixed sizes are enforced by the signatures. Both sides of the
+//! root-key handshake verify the peer's binding against *their own*
+//! [`NetworkId`]; mismatch is a hard reject.
+//!
+//! These helpers return 32-byte SHA-256 digests. Attestation evidence generation
+//! takes a 64-byte input, so use [`binding64_from_digest32`] before calling
+//! [`crate::generate_evidence`] or [`crate::verify_evidence`].
+
+use crate::manifest::NetworkId;
+use sha2::{Digest, Sha256};
+
+/// Binding for TxSeismic tx_io public key evidence.
+pub fn tx_io_binding(network_id: &NetworkId, tx_io_pk: &[u8; 33], epoch: u64) -> [u8; 32] {
+    let mut hasher = Sha256::new();
+    hasher.update(b"seismic-tx-io-v1:");
+    hasher.update(network_id.as_bytes());
+    hasher.update(tx_io_pk);
+    hasher.update(epoch.to_be_bytes());
+    hasher.finalize().into()
+}
+
+/// Binding for a root-key bootstrap requester quote.
+pub fn root_key_request_binding(
+    network_id: &NetworkId,
+    nonce_b: &[u8; 32],
+    eph_pk_b: &[u8; 33],
+) -> [u8; 32] {
+    let mut hasher = Sha256::new();
+    hasher.update(b"seismic-root-key-req-v1:");
+    hasher.update(network_id.as_bytes());
+    hasher.update(nonce_b);
+    hasher.update(eph_pk_b);
+    hasher.finalize().into()
+}
+
+/// Binding for a root-key bootstrap responder quote.
+pub fn root_key_response_binding(
+    network_id: &NetworkId,
+    nonce_b: &[u8; 32],
+    eph_pk_a: &[u8; 33],
+    wrapped: &[u8],
+) -> [u8; 32] {
+    let mut hasher = Sha256::new();
+    hasher.update(b"seismic-root-key-resp-v1:");
+    hasher.update(network_id.as_bytes());
+    hasher.update(nonce_b);
+    hasher.update(eph_pk_a);
+    hasher.update(wrapped);
+    hasher.finalize().into()
+}
+
+/// Binding for deploy-preflight verification of a candidate node.
+///
+/// The deploy tool checks a freshly provisioned VM before wiring it into the
+/// network: it sends a fresh `deployment_nonce`, the node quotes over this
+/// binding using the `network_id` of the manifest it booted with, and the
+/// deploy tool recomputes the binding from its own copies of all three fields.
+/// A passing quote proves the node holds the expected manifest (right network,
+/// not a clone or wrong fork) and minted the evidence for this exact request
+/// (`deployment_nonce` is per-request — distinct from the manifest's
+/// `genesis_nonce` — so captured quotes can't be replayed).
+///
+/// `context` identifies what is being preflighted, so an answer to one
+/// question can't be repurposed for another — e.g. a hash of the exact
+/// `node.toml` being POSTed to tdx-init, which makes the quote an attested
+/// acknowledgement of the delivered config.
+pub fn deploy_preflight_binding(
+    network_id: &NetworkId,
+    deployment_nonce: &[u8; 32],
+    context: &[u8],
+) -> [u8; 32] {
+    let mut hasher = Sha256::new();
+    hasher.update(b"seismic-deploy-v1:");
+    hasher.update(network_id.as_bytes());
+    hasher.update(deployment_nonce);
+    hasher.update(context);
+    hasher.finalize().into()
+}
+
+/// Expand a shorter protocol digest into the 64-byte attestation input.
+pub fn binding64_from_digest32(digest: [u8; 32]) -> [u8; 64] {
+    let mut binding = [0u8; 64];
+    binding[..32].copy_from_slice(&digest);
+    binding
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Stable wire-format vectors: any change to a domain string or field
+    // layout breaks cross-implementation transcript verification, so these
+    // digests must never change. Cross-checked against an independent
+    // computation (python hashlib over the concatenated layout).
+    #[test]
+    fn binding_helpers_are_stable() {
+        let network_id = NetworkId::from_bytes([0x11; 32]);
+        let nonce = [0x33; 32];
+
+        let mut tx_io_pk = [0x22; 33];
+        tx_io_pk[0] = 0x02;
+        let mut eph_pk_b = [0x44; 33];
+        eph_pk_b[0] = 0x02;
+        let mut eph_pk_a = [0x55; 33];
+        eph_pk_a[0] = 0x02;
+
+        assert_eq!(
+            hex::encode(tx_io_binding(&network_id, &tx_io_pk, 7)),
+            "226d77df41e0a51c6173fdbc58df2302aeea627a9051c051afc861ebc4a16f46"
+        );
+        assert_eq!(
+            hex::encode(root_key_request_binding(&network_id, &nonce, &eph_pk_b)),
+            "1c4e440a61093dcbc3574a938cc545b8807cdd87529202e6761d01c58aae0184"
+        );
+        assert_eq!(
+            hex::encode(root_key_response_binding(
+                &network_id,
+                &nonce,
+                &eph_pk_a,
+                b"wrapped"
+            )),
+            "2ac4df85ca3f07ca8f279bd6aea9db824e8481f776178e051439c92118782eee"
+        );
+        assert_eq!(
+            hex::encode(deploy_preflight_binding(
+                &network_id,
+                &[0x66; 32],
+                b"deploy-context"
+            )),
+            "780975fd8a3e5a2730261c967db281fc639360ecbc2f166fed1465f5dfae81d7"
+        );
+    }
+
+    #[test]
+    fn bindings_diverge_across_networks() {
+        let nonce = [0x33; 32];
+        let mut eph_pk_b = [0x44; 33];
+        eph_pk_b[0] = 0x02;
+
+        let binding_net_a =
+            root_key_request_binding(&NetworkId::from_bytes([0xAA; 32]), &nonce, &eph_pk_b);
+        let binding_net_b =
+            root_key_request_binding(&NetworkId::from_bytes([0xBB; 32]), &nonce, &eph_pk_b);
+        assert_ne!(binding_net_a, binding_net_b);
+    }
+
+    #[test]
+    fn binding64_zero_pads_digest32() {
+        let digest = [7u8; 32];
+        let binding = binding64_from_digest32(digest);
+        assert_eq!(&binding[..32], &digest);
+        assert_eq!(&binding[32..], &[0u8; 32]);
+    }
+}

--- a/crates/seismic-attestation/src/lib.rs
+++ b/crates/seismic-attestation/src/lib.rs
@@ -10,17 +10,17 @@
 //! Production callers usually only need these APIs:
 //!
 //! - [`generate_evidence`] to produce local attestation evidence for a
-//!   caller-supplied 64-byte protocol binding.
+//!   caller-supplied 64-byte protocol binding (see [`bindings`]).
 //! - [`verify_evidence`] to verify remote evidence against a
 //!   [`SeismicMeasurementPolicy`].
 //! - [`SeismicMeasurementPolicy::from_json_bytes`] or
-//!   [`SeismicMeasurementPolicy::from_file`] to load Flashbots-compatible
-//!   measurement artifacts, such as `seismic-images build/measurements.json`.
-//!
-//! The [`bindings`] module contains helper digests for Seismic protocol
-//! transcripts. These helpers are not complete protocols by themselves; callers
-//! should feed the resulting 32-byte digest through
-//! [`bindings::binding64_from_digest32`] before attestation.
+//!   [`SeismicMeasurementPolicy::from_file`] to load measurement policies,
+//!   such as seismic-images' `build/measurements.json`.
+
+pub mod bindings;
+pub mod manifest;
+
+pub use manifest::{ManifestError, NetworkId, NetworkManifestV1};
 
 /// Backend measurement types returned after successful verification.
 pub use attestation::measurements::{DcapMeasurementRegister, MultiMeasurements};
@@ -129,7 +129,7 @@ pub async fn verify_azure_evidence_with_options(
 
 // === Public policy and output types ===
 
-/// Seismic-safe wrapper around Flashbots measurement policy.
+/// Seismic-safe wrapper around the attestation backend's measurement policy.
 ///
 /// The underlying JSON/file format is the backend's format. This wrapper exists
 /// to keep production constructors explicit and to avoid spreading backend
@@ -140,16 +140,17 @@ pub struct SeismicMeasurementPolicy {
 }
 
 impl SeismicMeasurementPolicy {
-    /// Parse a Flashbots-compatible measurement policy JSON document.
+    /// Parse a measurement policy JSON document.
     ///
-    /// This is the expected path for `seismic-images build/measurements.json`.
+    /// This is the expected path for seismic-images' `build/measurements.json`
+    /// (the `make measure` output).
     pub fn from_json_bytes(bytes: &[u8]) -> Result<Self, AttestationError> {
         Ok(Self {
             backend_policy: BackendMeasurementPolicy::from_json_bytes(bytes.to_vec())?,
         })
     }
 
-    /// Load a Flashbots-compatible measurement policy from a file.
+    /// Load a measurement policy from a file.
     pub async fn from_file(path: impl Into<PathBuf>) -> Result<Self, AttestationError> {
         Ok(Self {
             backend_policy: BackendMeasurementPolicy::from_file(path.into()).await?,
@@ -319,77 +320,9 @@ pub enum AttestationError {
     },
 }
 
-/// Helpers for deriving Seismic protocol-binding digests.
-///
-/// These helpers return 32-byte SHA-256 digests. Attestation evidence generation
-/// takes a 64-byte input, so use [`binding64_from_digest32`] before calling
-/// [`crate::generate_evidence`] or [`crate::verify_evidence`].
-pub mod bindings {
-    use sha2::{Digest, Sha256};
-
-    /// Binding for TxSeismic tx_io public key evidence.
-    pub fn tx_io_binding(tx_io_pk: &[u8], epoch: u64) -> [u8; 32] {
-        let mut hasher = Sha256::new();
-        hasher.update(b"seismic-tx-io:");
-        hasher.update(tx_io_pk);
-        hasher.update(epoch.to_be_bytes());
-        hasher.finalize().into()
-    }
-
-    /// Binding for a root-key bootstrap requester quote.
-    pub fn root_key_request_binding(nonce_b: &[u8], eph_pk_b: &[u8]) -> [u8; 32] {
-        let mut hasher = Sha256::new();
-        hasher.update(nonce_b);
-        hasher.update(eph_pk_b);
-        hasher.finalize().into()
-    }
-
-    /// Binding for a root-key bootstrap responder quote.
-    pub fn root_key_response_binding(nonce_b: &[u8], eph_pk_a: &[u8], wrapped: &[u8]) -> [u8; 32] {
-        let mut hasher = Sha256::new();
-        hasher.update(nonce_b);
-        hasher.update(eph_pk_a);
-        hasher.update(wrapped);
-        hasher.finalize().into()
-    }
-
-    /// Expand a shorter protocol digest into the 64-byte attestation input.
-    pub fn binding64_from_digest32(digest: [u8; 32]) -> [u8; 64] {
-        let mut binding = [0u8; 64];
-        binding[..32].copy_from_slice(&digest);
-        binding
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn binding_helpers_are_stable() {
-        assert_eq!(
-            hex::encode(bindings::tx_io_binding(b"pk", 7)),
-            "0cf7d05bc0019123fdf7a69cb91ad265625f9673172508b4f682e3d917b0f11c"
-        );
-        assert_eq!(
-            hex::encode(bindings::root_key_request_binding(b"nonce", b"pk_b")),
-            "3375ae192a636e95828a472e73d218576813c66fb67bd42f123f810c1953ca6d"
-        );
-        assert_eq!(
-            hex::encode(bindings::root_key_response_binding(
-                b"nonce", b"pk_a", b"wrapped"
-            )),
-            "d2ac32239b55995fb355fc426dc0876d629d00abdcf244359dee2c0f2b6c2681"
-        );
-    }
-
-    #[test]
-    fn binding64_zero_pads_digest32() {
-        let digest = [7u8; 32];
-        let binding = bindings::binding64_from_digest32(digest);
-        assert_eq!(&binding[..32], &digest);
-        assert_eq!(&binding[32..], &[0u8; 32]);
-    }
 
     #[test]
     fn backend_policy_parses_flashbots_measurement_json_and_preserves_record_correlation() {

--- a/crates/seismic-attestation/src/manifest.rs
+++ b/crates/seismic-attestation/src/manifest.rs
@@ -1,0 +1,342 @@
+//! The manifest module parses `network-manifest.json` and derives the
+//! [`NetworkId`] that every transcript binding consumes.
+//!
+//! The manifest is the deploy-time artifact that defines a network's identity:
+//! `network_id = SHA-256(exact file bytes)`. The file travels as opaque bytes
+//! through every hop (deploy artifact → node.toml embed → tdx-init → network-manifest.json).
+//! Consumers hash the bytes they read themselves rather than trusting a precomputed id.
+//!
+//! This module deliberately implements `Deserialize` only. The deploy tool is
+//! the manifest's sole emitter; nothing on the node side may
+//! parse-and-re-serialize the file, because any re-rendering risks changing the
+//! bytes and therefore the `network_id`. The emitter renders deterministically
+//! (2-space indent, key-sorted, single trailing newline); the parser accepts
+//! any key order — ordering matters only because the bytes are hashed.
+
+use serde::{Deserialize, Deserializer};
+use sha2::{Digest, Sha256};
+use std::fmt;
+use thiserror::Error;
+
+/// A network's identity: SHA-256 of the exact bytes of its
+/// `network-manifest.json`.
+///
+/// Transcript form is the raw 32 bytes ([`NetworkId::as_bytes`]).
+/// Presentation form is lowercase 0x-hex ([`fmt::Display`]).
+/// Equivalently: `sha256sum network-manifest.json`.
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+pub struct NetworkId([u8; 32]);
+
+impl NetworkId {
+    /// Derive the id from manifest file bytes. Hash the same bytes you parse.
+    pub fn from_manifest_bytes(bytes: &[u8]) -> Self {
+        Self(Sha256::digest(bytes).into())
+    }
+
+    /// Wrap an already-computed id (e.g. received in an addendum or test vector).
+    pub const fn from_bytes(bytes: [u8; 32]) -> Self {
+        Self(bytes)
+    }
+
+    pub const fn as_bytes(&self) -> &[u8; 32] {
+        &self.0
+    }
+}
+
+impl fmt::Display for NetworkId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "0x{}", hex::encode(self.0))
+    }
+}
+
+impl fmt::Debug for NetworkId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "NetworkId({self})")
+    }
+}
+
+/// Parsed `network-manifest.json` (schema v1).
+///
+/// A network's identity must be unique at every layer where signatures or
+/// transcripts could leak across chains, and the manifest carries one
+/// separator per layer:
+///
+/// - `eth.chain_id` — kills transaction replay (EIP-155): a tx signed for one
+///   network is invalid on another.
+/// - `genesis_nonce` (via `network_id`) — kills attestation-transcript
+///   replay: quotes and root-key handshake bindings from one network can't
+///   verify on a clone deployment.
+/// - `summit.namespace` — kills BLS consensus-signature replay: without a
+///   distinct signing domain, a validator key active on two chains (cloned
+///   devnets, a fork) produces votes valid on both — manufactured
+///   equivocation.
+///
+/// Only `genesis_nonce` is guaranteed to differ between clone deployments;
+/// operators must vary `eth.chain_id` and `summit.namespace` too for the
+/// other two layers to hold.
+///
+/// Parsing is strict: unknown keys are rejected, so two verifiers can never
+/// disagree on field semantics. New fields require `manifest_version = 2` and
+/// a `NetworkManifestV2` type. Strictness is about semantics only —
+/// `network_id` hashes raw bytes, so an unknown field could never silently
+/// change the id.
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct NetworkManifestV1 {
+    pub manifest_version: u64,
+    /// Human label; intentionally part of the hash (intent is identity).
+    pub name: String,
+    /// Fresh per deployment ceremony; the clone-deployment uniquifier.
+    #[serde(deserialize_with = "hex_32")]
+    pub genesis_nonce: [u8; 32],
+    pub eth: EthManifest,
+    pub summit: SummitManifest,
+    pub measurements: MeasurementsManifest,
+}
+
+/// Execution-layer (reth) identity.
+///
+/// Both fields are needed: `genesis_hash` covers the header (state root,
+/// alloc) but not `config.chainId`, which lives outside the header — so the
+/// chain id is an independent commitment, not derivable from the hash.
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct EthManifest {
+    /// Must equal `config.chainId` inside the reth genesis JSON (deploy-time
+    /// cross-artifact validation; not checked here).
+    pub chain_id: u64,
+    /// `keccak(rlp(header(reth-genesis.json)))`; commits to the full genesis
+    /// alloc including `UpgradeOperator` initial measurements.
+    #[serde(deserialize_with = "hex_32")]
+    pub genesis_hash: [u8; 32],
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SummitManifest {
+    /// SHA-256 of the summit network-params template file bytes (the
+    /// pre-`fill-genesis-template` artifact, no `[[validators]]`).
+    #[serde(deserialize_with = "hex_32")]
+    pub genesis_template_hash: [u8; 32],
+    /// BLS signature domain separator; duplicated from the template so
+    /// verifiers don't need to parse TOML.
+    pub namespace: String,
+}
+
+/// The TEE admission policy: which measurements may join, and who decides.
+///
+/// The same measurement set exists in two representations: the bootstrap
+/// artifact pinned by `bootstrap_policy_hash` (the joiner's source — readable
+/// before it can read any chain state) and `UpgradeOperator` genesis storage
+/// (the responder's source). Their consistency at genesis is a deploy-time
+/// validation; afterwards the contract carries the live policy while the
+/// artifact stays frozen.
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct MeasurementsManifest {
+    /// SHA-256 of the measurement-policy artifact bytes, eg:
+    /// https://github.com/flashbots/attested-tls/blob/f3b47739d17650a9489c8707cd94d0e80751ec40/crates/attestation/test-assets/measurements.json
+    /// Produced by seismic-images' `make measure`, and lands under `build/measurements.json`.
+    /// [`crate::SeismicMeasurementPolicy`] parses this file.
+    ///
+    /// Pins the *bootstrap* policy only — the measurement set in force at
+    /// genesis, frozen forever by this hash. Post-genesis additions and
+    /// deprecations happen on-chain in `contracts.registry`; read the
+    /// contract, not this artifact, for the current allowlist.
+    #[serde(deserialize_with = "hex_32")]
+    pub bootstrap_policy_hash: [u8; 32],
+    pub contracts: ContractsManifest,
+}
+
+/// Addresses of the admission-policy contracts, duplicated from the genesis
+/// alloc for verifiers that don't hold the genesis file.
+///
+/// Fields are named by role, not by contract class name, so the hashed
+/// artifact schema survives contract renames. Both contracts exist in this
+/// repo's `enclave-contract` crate and have well-known addresses there
+/// (`UPGRADE_OPERATOR_ADDRESS`, `UPGRADE_MULTISIG_ADDRESS`).
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ContractsManifest {
+    /// The measurement registry (today `UpgradeOperator.sol`): the allowlist
+    /// new Seismic nodes are checked against (`isAccepted()`). This is the
+    /// *live* policy, updated on-chain over the network's lifetime —
+    /// `bootstrap_policy_hash` freezes only the genesis-time set.
+    #[serde(deserialize_with = "hex_20")]
+    pub registry: [u8; 20],
+    /// The authority allowed to mutate the registry (today
+    /// `MultisigUpgradeOperator.sol`).
+    #[serde(deserialize_with = "hex_20")]
+    pub authority: [u8; 20],
+}
+
+impl NetworkManifestV1 {
+    /// The `manifest_version` value this schema corresponds to.
+    pub const VERSION: u64 = 1;
+
+    /// Strictly parse manifest bytes against the v1 schema.
+    ///
+    /// Callers that also need the `network_id` must derive it from the same
+    /// bytes via [`NetworkId::from_manifest_bytes`] — never from a
+    /// re-serialization of the parsed value.
+    pub fn from_json_bytes(bytes: &[u8]) -> Result<Self, ManifestError> {
+        // Probe the version before the strict parse: a future-version manifest
+        // carries fields this schema doesn't know, and "unsupported
+        // manifest_version 2" is the actionable error, not "unknown field".
+        #[derive(Deserialize)]
+        struct VersionProbe {
+            manifest_version: u64,
+        }
+        let probe: VersionProbe = serde_json::from_slice(bytes)?;
+        if probe.manifest_version != Self::VERSION {
+            return Err(ManifestError::UnsupportedVersion {
+                found: probe.manifest_version,
+            });
+        }
+        Ok(serde_json::from_slice(bytes)?)
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum ManifestError {
+    #[error(
+        "manifest does not match schema v{version}: {0}",
+        version = NetworkManifestV1::VERSION
+    )]
+    Json(#[from] serde_json::Error),
+    #[error(
+        "unsupported manifest_version {found}; this parser implements v{}",
+        NetworkManifestV1::VERSION
+    )]
+    UnsupportedVersion { found: u64 },
+}
+
+fn hex_32<'de, D: Deserializer<'de>>(deserializer: D) -> Result<[u8; 32], D::Error> {
+    decode_fixed_hex(deserializer)
+}
+
+fn hex_20<'de, D: Deserializer<'de>>(deserializer: D) -> Result<[u8; 20], D::Error> {
+    decode_fixed_hex(deserializer)
+}
+
+fn decode_fixed_hex<'de, D: Deserializer<'de>, const N: usize>(
+    deserializer: D,
+) -> Result<[u8; N], D::Error> {
+    let s = String::deserialize(deserializer)?;
+    let digits = s.strip_prefix("0x").ok_or_else(|| {
+        serde::de::Error::custom(format!("expected 0x-prefixed hex string, got {s:?}"))
+    })?;
+    let mut bytes = [0u8; N];
+    hex::decode_to_slice(digits, &mut bytes).map_err(|err| {
+        serde::de::Error::custom(format!("expected {N}-byte hex string, got {s:?}: {err}"))
+    })?;
+    Ok(bytes)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Rendered the way the deploy tool emits manifests: 2-space indent,
+    /// key-sorted, single trailing newline — i.e.
+    /// `json.dumps(manifest, indent=2, sort_keys=True) + "\n"`. Key order is
+    /// irrelevant to the parser but is part of the hashed bytes; regenerate
+    /// the pinned `network_id` below whenever the fixture changes.
+    const FIXTURE: &[u8] = include_bytes!("../fixtures/network-manifest-v1.json");
+
+    #[test]
+    fn parses_v1_fixture_and_derives_network_id() {
+        let manifest = NetworkManifestV1::from_json_bytes(FIXTURE).unwrap();
+
+        assert_eq!(manifest.manifest_version, 1);
+        assert_eq!(manifest.name, "seismic-devnet-3");
+        assert_eq!(manifest.genesis_nonce, [0xAA; 32]);
+        assert_eq!(manifest.eth.chain_id, 5124);
+        assert_eq!(
+            hex::encode(manifest.eth.genesis_hash),
+            "78ab9057bb67f95a6182969c5d755ac02802c98c0d2f0d8daeb52f4bddc60be5"
+        );
+        assert_eq!(manifest.summit.genesis_template_hash, [0xBB; 32]);
+        assert_eq!(manifest.summit.namespace, "seismic-devnet-3");
+        assert_eq!(manifest.measurements.bootstrap_policy_hash, [0xCC; 32]);
+        assert_eq!(
+            hex::encode(manifest.measurements.contracts.registry),
+            "1000000000000000000000000000000000000001"
+        );
+        assert_eq!(
+            hex::encode(manifest.measurements.contracts.authority),
+            "1000000000000000000000000000000000000002"
+        );
+
+        // Stable vector: sha256sum of the fixture file. Display is the
+        // presentation form (lowercase 0x-hex).
+        let network_id = NetworkId::from_manifest_bytes(FIXTURE);
+        assert_eq!(
+            network_id.to_string(),
+            "0xc4d4721b2e287df26022e6d27c8cf772841a872b6be08b1938cbc76d88703747"
+        );
+    }
+
+    // The byte-exactness rule: network_id is a hash of bytes, not of parsed
+    // content, so a cosmetic edit (trailing newline) is a different network.
+    #[test]
+    fn network_id_is_over_raw_bytes_not_parsed_content() {
+        let mut edited = FIXTURE.to_vec();
+        edited.push(b'\n');
+        assert_eq!(
+            NetworkManifestV1::from_json_bytes(&edited).unwrap(),
+            NetworkManifestV1::from_json_bytes(FIXTURE).unwrap()
+        );
+        assert_ne!(
+            NetworkId::from_manifest_bytes(&edited),
+            NetworkId::from_manifest_bytes(FIXTURE)
+        );
+    }
+
+    /// Parse the fixture after applying `mutate` to its JSON value.
+    fn parse_mutated(
+        mutate: impl FnOnce(&mut serde_json::Value),
+    ) -> Result<NetworkManifestV1, ManifestError> {
+        let mut value: serde_json::Value = serde_json::from_slice(FIXTURE).unwrap();
+        mutate(&mut value);
+        NetworkManifestV1::from_json_bytes(&serde_json::to_vec(&value).unwrap())
+    }
+
+    #[test]
+    fn rejects_unknown_fields() {
+        let result = parse_mutated(|v| v["tx_io_pk"] = "0x02ab".into());
+        assert!(matches!(result, Err(ManifestError::Json(_))));
+    }
+
+    #[test]
+    fn reports_unsupported_version_before_unknown_fields() {
+        // A v2 manifest carries fields this schema doesn't know; the error
+        // must name the version, not the first unknown field.
+        let result = parse_mutated(|v| {
+            v["manifest_version"] = 2.into();
+            v["some_v2_field"] = "new".into();
+        });
+        assert!(matches!(
+            result,
+            Err(ManifestError::UnsupportedVersion { found: 2 })
+        ));
+    }
+
+    #[test]
+    fn rejects_malformed_hex_fields() {
+        // wrong length for a 32-byte field
+        let result =
+            parse_mutated(|v| v["genesis_nonce"] = format!("0x{}", "aa".repeat(31)).into());
+        assert!(matches!(result, Err(ManifestError::Json(_))));
+
+        // missing 0x prefix
+        let result = parse_mutated(|v| v["eth"]["genesis_hash"] = "ab".repeat(32).into());
+        assert!(matches!(result, Err(ManifestError::Json(_))));
+
+        // non-hex digits
+        let result = parse_mutated(|v| {
+            v["measurements"]["bootstrap_policy_hash"] = format!("0x{}", "zz".repeat(32)).into()
+        });
+        assert!(matches!(result, Err(ManifestError::Json(_))));
+    }
+}


### PR DESCRIPTION
Introduce the deploy-time network manifest that defines a network's identity, and the transcript-binding layouts that consume it.
- manifest: strict NetworkManifestV1 parser (deny_unknown_fields; a version probe runs before the strict parse so future-version files fail with "unsupported manifest_version", not "unknown field") and NetworkId = SHA-256 of the exact file bytes. Deserialize-only on purpose: the deploy tool is the sole emitter, and nothing node-side may parse-and-re-serialize the hashed artifact. Schema groups by concern - eth.*, summit.*, measurements.* (bootstrap policy hash + contract addresses, role-named registry/authority so contract renames never touch the schema).
- bindings (own module now): replace the unwired placeholder helpers with domain-separated layouts that bind network_id first ("seismic-tx-io-v1:", "seismic-root-key-req-v1:", ...). Fixed-size fields are enforced by the signatures with at most one variable- length tail, keeping plain concatenation injective without length prefixes. Adds deploy_preflight_binding for the deploy tool's pre-wire-up attestation check. No compat shims: pre-launch and the old helpers had no consumers.
- fixture network-manifest-v1.json rendered exactly as the deploy tool will emit (key-sorted, 2-space indent, trailing newline), with the pinned network_id and binding digests cross-checked against an independent python hashlib computation.