### PR TITLE
build(seismic-attestation): pin attested-tls to flashbots upstream

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1098,7 +1098,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 [[package]]
 name = "attestation"
 version = "0.0.1"
-source = "git+https://github.com/SeismicSystems/attested-tls?branch=fix%2Fazure-vtpm-aia-intermediates-clean#79a0b65dd61aaac3812f3c7cd6d8360668d6951d"
+source = "git+https://github.com/flashbots/attested-tls?rev=05a79a3f16a6d074bc10ce7aa29a3cd804fdc613#05a79a3f16a6d074bc10ce7aa29a3cd804fdc613"
 dependencies = [
  "anyhow",
  "az-tdx-vtpm",
@@ -2985,7 +2985,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.0",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -4046,7 +4046,7 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 [[package]]
 name = "pccs"
 version = "0.0.1"
-source = "git+https://github.com/SeismicSystems/attested-tls?branch=fix%2Fazure-vtpm-aia-intermediates-clean#79a0b65dd61aaac3812f3c7cd6d8360668d6951d"
+source = "git+https://github.com/flashbots/attested-tls?rev=05a79a3f16a6d074bc10ce7aa29a3cd804fdc613#05a79a3f16a6d074bc10ce7aa29a3cd804fdc613"
 dependencies = [
  "anyhow",
  "dcap-qvl",
@@ -4332,7 +4332,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.0",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -4369,7 +4369,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.0",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -6460,7 +6460,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ seismic-enclave = {path = "crates/enclave" }
 alloy = "1.0"
 aes-gcm = "0.10"
 anyhow = "1.0"
+attestation = { git = "https://github.com/flashbots/attested-tls", rev = "05a79a3f16a6d074bc10ce7aa29a3cd804fdc613" }
 az-cvm-vtpm = { version = "0.7.4", default-features = false }
 az-tdx-vtpm = "0.7.4"
 bincode = "1.3.3"

--- a/crates/seismic-attestation/Cargo.toml
+++ b/crates/seismic-attestation/Cargo.toml
@@ -9,18 +9,23 @@ license.workspace = true
 description = "Seismic attestation evidence types and policy checks"
 
 [dependencies]
-attestation = { git = "https://github.com/SeismicSystems/attested-tls", branch = "fix/azure-vtpm-aia-intermediates-clean" }
 hex.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
+attestation.workspace = true # all platforms; the Linux block below adds the `azure` feature
 
+# Linux-only: the `azure` feature turns on attestation *evidence generation*
+# (Intel TDX quote + Azure vTPM quote), which depends on crates that only
+# compile on Linux — notably the `tss-esapi` TPM stack.
 [target.'cfg(target_os = "linux")'.dependencies]
-attestation = { git = "https://github.com/SeismicSystems/attested-tls", branch = "fix/azure-vtpm-aia-intermediates-clean", features = [
-    "azure",
-] }
+attestation = { workspace = true, features = ["azure"] }
 
+# Linux-only for the same reason: the examples here (`azure_vtpm_roundtrip`,
+# `capture_azure_tdx_fixture`) produce real Azure TDX + vTPM evidence, pulling
+# the Azure device crates (`az-tdx-vtpm`, `az-cvm-vtpm`) and `dcap-rs`, which
+# only compile on Linux.
 [target.'cfg(target_os = "linux")'.dev-dependencies]
 anyhow.workspace = true
 az-tdx-vtpm.workspace = true


### PR DESCRIPTION
The Azure vTPM AIA-intermediate fix (flashbots/attested-tls#49) and the follow-ups we upstreamed (through flashbots/attested-tls#52) are merged on flashbots main, so drop the SeismicSystems/attested-tls fork branch and pin to upstream rev 05a79a3.

Hoist the `attestation` source into [workspace.dependencies] so the git/rev pin lives in one place. Two declarations are still required — a base featureless dep for all platforms plus a Linux-only one enabling the `azure` evidence-generation feature — because Cargo gates dep features by target cfg, not within a single entry. Both now reference the workspace pin via `workspace = true`, removing the duplicated git/rev.