### PR TITLE
feat(enclave): add network-bound wrapped root-key bootstrap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5173,6 +5173,7 @@ dependencies = [
  "reqwest 0.11.27",
  "schnorrkel",
  "secp256k1",
+ "seismic-attestation",
  "seismic-enclave",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ readme = "README.md"
 
 [workspace.dependencies]
 enclave-contract = { path = "crates/enclave-contract" }
+seismic-attestation = { path = "crates/seismic-attestation" }
 seismic-enclave = {path = "crates/enclave" }
 
 # Other deps

--- a/crates/enclave-contract/tests/multisig_test.rs
+++ b/crates/enclave-contract/tests/multisig_test.rs
@@ -106,7 +106,7 @@ pub async fn test_multisig_upgrade_operator_workflow() -> Result<(), anyhow::Err
     //   - `MULTISIG_RPC=<url>` set (self-hosted `run_integration_tests.sh`): run
     //     against that node instead. There the contracts already exist at genesis
     //     (seismic-reth's dev alloc), so we skip the spawn + `anvil_setCode`. This
-    //     run is the on-chain allowlist *setup* that `test_boot_share_root_key`
+    //     run is the on-chain allowlist *setup* that `test_get_wrapped_root_key_bootstrap`
     //     later reads from reth at :8545.
     let _anvil; // keep the spawned node alive for the whole test in default mode
     let endpoint;

--- a/crates/enclave-server/Cargo.toml
+++ b/crates/enclave-server/Cargo.toml
@@ -19,6 +19,7 @@ path = "src/main.rs"
 
 [dependencies]
 seismic-enclave.workspace = true
+seismic-attestation.workspace = true
 enclave-contract.workspace = true
 
 alloy.workspace = true

--- a/crates/enclave-server/src/attestation/mod.rs
+++ b/crates/enclave-server/src/attestation/mod.rs
@@ -43,8 +43,25 @@ impl AttestationAgent {
         })
     }
 
-    pub fn get_attestation_evidence(&self) -> Result<AttestationGetEvidenceResponse> {
-        self.get_attestation_evidence_tpm()
+    /// Generate Azure TDX + vTPM evidence bound to a Seismic protocol binding.
+    ///
+    /// `binding` is a 32-byte domain-separated transcript digest from
+    /// `seismic_attestation::bindings` (e.g. [`tx_io_binding`] for the standalone
+    /// evidence endpoint, or the root-key handshake bindings). The evidence
+    /// commits to this digest through Azure HCL/vTPM report data; verifiers
+    /// recompute the expected binding and reject mismatches.
+    ///
+    /// TODO(attestation-v2): this helper serves the current
+    /// `AttestationGetEvidenceResponse { hcl_report, quote }` RPC shape. Add the
+    /// planned `getAttestationEvidenceV2(binding) -> AttestationExchangeMessage`
+    /// endpoint and route RPC evidence generation through `seismic-attestation`.
+    ///
+    /// [`tx_io_binding`]: seismic_attestation::bindings::tx_io_binding
+    pub fn get_attestation_evidence(
+        &self,
+        binding: [u8; 32],
+    ) -> Result<AttestationGetEvidenceResponse> {
+        self.get_attestation_evidence_tpm(binding)
     }
 
     // Only this function (and its `az_tdx_vtpm` import above) is gated on Linux
@@ -53,12 +70,13 @@ impl AttestationAgent {
     // on Linux and exercises the gated body. See the matching `[target.'cfg(...)'.dependencies]`
     // comment in Cargo.toml for why the dep itself is Linux-only.
     #[cfg(target_os = "linux")]
-    fn get_attestation_evidence_tpm(&self) -> Result<AttestationGetEvidenceResponse> {
-        // TODO(attestation): replace this placeholder with a protocol-bound value
-        // (for example, a nonce/public-key/tx_io_pk binding). Azure's vTPM report-data
-        // NV index is 64 bytes, so we may pass either a 32-byte digest or a full 64-byte
-        // value. Seismic bindings should normally be 32-byte domain-separated hashes,
-        // leaving the remaining capacity unused unless a protocol explicitly needs it.
+    fn get_attestation_evidence_tpm(
+        &self,
+        binding: [u8; 32],
+    ) -> Result<AttestationGetEvidenceResponse> {
+        // Azure's vTPM report-data NV index is 64 bytes, so we may pass either a
+        // 32-byte digest or a full 64-byte value. Seismic bindings are 32-byte
+        // domain-separated hashes, leaving the remaining capacity unused.
         //
         // Azure TDX evidence is generated through the Azure vTPM/HCL path rather than
         // by writing directly to a native TDX quote device. The input written via
@@ -69,7 +87,7 @@ impl AttestationAgent {
         //   2. quote.report_data[..32] == hcl_report.var_data_sha256().
         // See https://learn.microsoft.com/en-us/azure/confidential-computing/guest-attestation-confidential-virtual-machines-design
         // A fixture test should assert this on real Azure evidence.
-        let report_data = [1u8; 32];
+        let report_data = binding;
 
         // Get Azure HCL/vTPM report containing the caller-supplied report data.
         let hcl_report_bytes = vtpm::get_report_with_report_data(&report_data)?;
@@ -89,7 +107,10 @@ impl AttestationAgent {
     }
 
     #[cfg(not(target_os = "linux"))]
-    fn get_attestation_evidence_tpm(&self) -> Result<AttestationGetEvidenceResponse> {
+    fn get_attestation_evidence_tpm(
+        &self,
+        _binding: [u8; 32],
+    ) -> Result<AttestationGetEvidenceResponse> {
         Err(anyhow!(
             "TPM attestation requires az-tdx-vtpm, which is only available on Linux"
         ))

--- a/crates/enclave-server/src/bootstrap.rs
+++ b/crates/enclave-server/src/bootstrap.rs
@@ -1,0 +1,398 @@
+//! Phase P: the protocol-first, encrypted root-key bootstrap.
+//!
+//! A booting non-genesis node (the *requester*, side `b` in the binding
+//! helpers) needs the network root key. A node that already holds it (the
+//! *responder*, side `a`) returns it AEAD-wrapped to the requester's attested
+//! ephemeral key.
+//! The exchange is a one-round handshake, both halves attested and bound to the
+//! same `network_id = H(network-manifest.json)`:
+//!
+//! ```text
+//!   requester                                            responder
+//!   ---------                                            ---------
+//!   eph (sk_b, pk_b); nonce_b
+//!   q_b = quote over root_key_request_binding(
+//!             network_id, nonce_b, eph_pk_b)
+//!   ----  RootKeyRequest { nonce_b, eph_pk_b, q_b } --->
+//!                                          verify q_b against requester policy,
+//!                                          recompute its binding from our own
+//!                                          network_id + the request fields
+//!                                          eph (sk_a, pk_a)
+//!                                          wrapped = AEAD_ECDH(eph_sk_a, eph_pk_b,
+//!                                                    root_key; aad = request binding)
+//!                                          q_a = quote over root_key_response_binding(
+//!                                                    network_id, nonce_b, eph_pk_a, wrapped)
+//!   <---  RootKeyResponse { eph_pk_a, wrapped, q_a }  ----
+//!   verify q_a; recompute response binding from
+//!   our network_id + nonce_b + eph_pk_a + wrapped;
+//!   ECDH(eph_sk_b, eph_pk_a) -> unwrap root_key
+//! ```
+//!
+//! Why each field is in the transcript:
+//! - `network_id` — both sides verify the peer's binding against *their own*
+//!   id, so a quote minted on a clone network can't satisfy this one.
+//! - `nonce_b` — requester-fresh; ties the responder's quote to this exact
+//!   request so a captured response can't be replayed.
+//! - `eph_pk_b` / `eph_pk_a` — bind the ECDH inputs into the attested
+//!   transcript, so a MITM can't substitute its own ephemeral key and learn the
+//!   wrapped key.
+//! - `wrapped` (in the response binding) and the request binding (as AEAD AAD)
+//!   — bind the ciphertext to the handshake it belongs to.
+//!
+//! The root key itself only ever crosses the wire AEAD-sealed under the
+//! ECDH-derived key; the AEAD tag plus the responder quote let the requester
+//! reject anything not produced by a genuine peer enclave for this request.
+
+use anyhow::{Context, Result, anyhow};
+use rand::{TryRngCore as _, rngs::OsRng};
+use seismic_attestation::{
+    AttestationExchangeMessage, AttestationType, NetworkId, SeismicMeasurementPolicy,
+    bindings::{binding64_from_digest32, root_key_request_binding, root_key_response_binding},
+    generate_evidence, verify_evidence,
+};
+use seismic_enclave::{
+    AESGCM_NONCE_SIZE, Nonce, aes_decrypt_aead, aes_encrypt_aead, derive_aes_key,
+    secp256k1::{PublicKey, Secp256k1, SecretKey, ecdh::SharedSecret},
+};
+use serde::{Deserialize, Serialize};
+
+/// A freshly minted ephemeral secp256k1 ECDH keypair for one handshake.
+///
+/// Held only for the lifetime of a single exchange and dropped after; never
+/// derived from or mixed with the root key, so a leak reveals nothing about it.
+struct EphemeralKeypair {
+    sk: SecretKey,
+    pk: PublicKey,
+}
+
+impl EphemeralKeypair {
+    /// Draw the scalar from the OS CSPRNG (like `KeyManager::new_as_genesis`),
+    /// retrying on the negligible chance of an out-of-range scalar. We seed from
+    /// bytes rather than secp256k1's own `generate_keypair` because that helper
+    /// wants a `rand` 0.8 RNG, while this workspace is on `rand` 0.9.
+    fn generate() -> Self {
+        let secp = Secp256k1::new();
+        loop {
+            let mut bytes = [0u8; 32];
+            OsRng
+                .try_fill_bytes(&mut bytes)
+                .expect("OS RNG must produce ephemeral key material");
+            if let Ok(sk) = SecretKey::from_byte_array(&bytes) {
+                let pk = PublicKey::from_secret_key(&secp, &sk);
+                return Self { sk, pk };
+            }
+        }
+    }
+
+    /// Compressed 33-byte SEC1 encoding, the form the binding helpers hash.
+    fn pk_compressed(&self) -> [u8; 33] {
+        self.pk.serialize()
+    }
+}
+
+/// The requester's half of the handshake: a fresh nonce + ephemeral pubkey,
+/// attested by `evidence` over [`root_key_request_binding`].
+///
+/// The ephemeral key travels as a `secp256k1::PublicKey` (compressed on the
+/// wire); the binding helpers consume its 33-byte SEC1 form via `.serialize()`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RootKeyRequest {
+    /// Requester-fresh replay protection, bound into both quotes.
+    pub nonce_b: [u8; 32],
+    /// Requester ephemeral ECDH pubkey.
+    pub eph_pk_b: PublicKey,
+    /// Requester attestation over `root_key_request_binding(network_id,
+    /// nonce_b, eph_pk_b)`.
+    pub evidence: AttestationExchangeMessage,
+}
+
+/// The responder's half: its ephemeral pubkey, the AEAD-wrapped root key, and
+/// its attestation over [`root_key_response_binding`].
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RootKeyResponse {
+    /// Responder ephemeral ECDH pubkey.
+    pub eph_pk_a: PublicKey,
+    /// `nonce(12) || AES-256-GCM(root_key)`; see [`wrap_root_key_for_peer`].
+    pub wrapped: Vec<u8>,
+    /// Responder attestation over `root_key_response_binding(network_id,
+    /// nonce_b, eph_pk_a, wrapped)`.
+    pub evidence: AttestationExchangeMessage,
+}
+
+/// Requester step 1: build the request the booting node POSTs to a peer.
+///
+/// Returns the wire request plus the ephemeral secret the caller must keep to
+/// unwrap the response (see [`unwrap_root_key_from_response`]).
+pub fn build_root_key_request(
+    network_id: &NetworkId,
+    attestation_type: AttestationType,
+) -> Result<(RootKeyRequest, SecretKey)> {
+    let eph = EphemeralKeypair::generate();
+
+    let mut nonce_b = [0u8; 32];
+    OsRng
+        .try_fill_bytes(&mut nonce_b)
+        .expect("OS RNG must produce a handshake nonce");
+
+    let binding = root_key_request_binding(network_id, &nonce_b, &eph.pk_compressed());
+    let evidence = generate_evidence(attestation_type, binding64_from_digest32(binding))
+        .context("generating requester attestation evidence")?;
+
+    let request = RootKeyRequest {
+        nonce_b,
+        eph_pk_b: eph.pk,
+        evidence,
+    };
+    Ok((request, eph.sk))
+}
+
+/// Responder step: verify the requester's evidence, then return the root key
+/// AEAD-wrapped under a fresh ECDH key and the responder's own attestation.
+///
+/// `root_key` is consumed only to seal it; it never leaves this function in the
+/// clear. `policy` is the responder's measurement allowlist (the requester must
+/// be running an admitted image). `network_id` is the responder's own —
+/// verification recomputes the requester's binding from it, so a quote for a
+/// different network fails the binding check.
+pub async fn answer_root_key_request(
+    request: &RootKeyRequest,
+    network_id: &NetworkId,
+    root_key: &[u8; 32],
+    policy: SeismicMeasurementPolicy,
+    attestation_type: AttestationType,
+) -> Result<RootKeyResponse> {
+    // 1. Verify the requester's quote against our policy, recomputing the
+    //    expected binding from *our* network_id + the request's claimed fields.
+    let expected =
+        root_key_request_binding(network_id, &request.nonce_b, &request.eph_pk_b.serialize());
+    verify_evidence(
+        request.evidence.clone(),
+        binding64_from_digest32(expected),
+        policy,
+    )
+    .await
+    .context("verifying requester attestation evidence")?;
+
+    // 2. Wrap the root key for the requester's attested ephemeral key.
+    let eph_a = EphemeralKeypair::generate();
+    let wrapped =
+        wrap_root_key_for_peer(&eph_a.sk, &request.eph_pk_b, root_key, network_id, request)?;
+
+    // 3. Attest over the response transcript, committing to the ciphertext.
+    let binding = root_key_response_binding(
+        network_id,
+        &request.nonce_b,
+        &eph_a.pk_compressed(),
+        &wrapped,
+    );
+    let evidence = generate_evidence(attestation_type, binding64_from_digest32(binding))
+        .context("generating responder attestation evidence")?;
+
+    Ok(RootKeyResponse {
+        eph_pk_a: eph_a.pk,
+        wrapped,
+        evidence,
+    })
+}
+
+/// Requester step 2: verify the responder's evidence and unwrap the root key.
+///
+/// `eph_sk_b` is the secret returned by [`build_root_key_request`]; `request`
+/// is the matching request (we re-derive bindings from it rather than trusting
+/// the response to echo them). `policy` is the requester's allowlist for the
+/// responder. The wrapped root key is opened only after the responder quote
+/// verifies and the AEAD tag validates under the requester's ephemeral key.
+pub async fn unwrap_root_key_from_response(
+    response: &RootKeyResponse,
+    request: &RootKeyRequest,
+    eph_sk_b: &SecretKey,
+    network_id: &NetworkId,
+    policy: SeismicMeasurementPolicy,
+) -> Result<[u8; 32]> {
+    // 1. Verify the responder's quote: recompute the response binding from our
+    //    own network_id + the nonce we chose + the responder's ephemeral key +
+    //    the exact ciphertext. A tampered field or a foreign network fails here.
+    let expected = root_key_response_binding(
+        network_id,
+        &request.nonce_b,
+        &response.eph_pk_a.serialize(),
+        &response.wrapped,
+    );
+    verify_evidence(
+        response.evidence.clone(),
+        binding64_from_digest32(expected),
+        policy,
+    )
+    .await
+    .context("verifying responder attestation evidence")?;
+
+    // 2. ECDH to the responder's ephemeral key, then AEAD-open.
+    unwrap_root_key(
+        eph_sk_b,
+        &response.eph_pk_a,
+        &response.wrapped,
+        network_id,
+        request,
+    )
+}
+
+/// AEAD-seal `root_key` for a peer's ephemeral ECDH key.
+///
+/// Output layout: `nonce(12 bytes) || AES-256-GCM ciphertext+tag`. The AEAD AAD
+/// is the [`root_key_request_binding`] digest, so the sealed key is
+/// cryptographically tied to this exact request transcript (network_id,
+/// nonce_b, eph_pk_b) — a wrapped blob can't be lifted onto a different
+/// handshake even before the responder quote is checked.
+fn wrap_root_key_for_peer(
+    eph_sk_a: &SecretKey,
+    eph_pk_b: &PublicKey,
+    root_key: &[u8; 32],
+    network_id: &NetworkId,
+    request: &RootKeyRequest,
+) -> Result<Vec<u8>> {
+    let aes_key = derive_handshake_key(eph_sk_a, eph_pk_b)?;
+    let aad = root_key_request_binding(network_id, &request.nonce_b, &request.eph_pk_b.serialize());
+
+    let nonce = Nonce::new_rand();
+    let ciphertext = aes_encrypt_aead(&aes_key, root_key, nonce.clone(), &aad)
+        .context("sealing root key for peer")?;
+
+    let mut wrapped = Vec::with_capacity(AESGCM_NONCE_SIZE + ciphertext.len());
+    wrapped.extend_from_slice(&nonce.0);
+    wrapped.extend_from_slice(&ciphertext);
+    Ok(wrapped)
+}
+
+/// Inverse of [`wrap_root_key_for_peer`]: ECDH + AEAD-open, with the same
+/// request-binding AAD recomputed from the requester's own copies.
+fn unwrap_root_key(
+    eph_sk_b: &SecretKey,
+    eph_pk_a: &PublicKey,
+    wrapped: &[u8],
+    network_id: &NetworkId,
+    request: &RootKeyRequest,
+) -> Result<[u8; 32]> {
+    if wrapped.len() < AESGCM_NONCE_SIZE {
+        return Err(anyhow!("wrapped root key too short to contain a nonce"));
+    }
+    let (nonce_bytes, ciphertext) = wrapped.split_at(AESGCM_NONCE_SIZE);
+    let nonce: [u8; AESGCM_NONCE_SIZE] = nonce_bytes.try_into().expect("checked length above");
+
+    let aes_key = derive_handshake_key(eph_sk_b, eph_pk_a)?;
+    let aad = root_key_request_binding(network_id, &request.nonce_b, &request.eph_pk_b.serialize());
+
+    let plaintext = aes_decrypt_aead(&aes_key, ciphertext, nonce, &aad)
+        .context("opening wrapped root key (AEAD tag mismatch)")?;
+    plaintext
+        .try_into()
+        .map_err(|_| anyhow!("unwrapped root key is not 32 bytes"))
+}
+
+/// Derive the symmetric handshake key from an ECDH shared secret.
+///
+/// Reuses [`derive_aes_key`] so wrap and unwrap stay in lockstep with the rest
+/// of the enclave's ECDH-AES key schedule.
+fn derive_handshake_key(
+    sk: &SecretKey,
+    pk: &PublicKey,
+) -> Result<aes_gcm::Key<aes_gcm::Aes256Gcm>> {
+    let shared = SharedSecret::new(pk, sk);
+    derive_aes_key(&shared).map_err(|e| anyhow!("deriving handshake AES key: {e}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // End-to-end wrap/unwrap with matching transcripts recovers the key; this
+    // exercises the ECDH + AEAD path without needing real attestation evidence.
+    #[test]
+    fn wrap_then_unwrap_roundtrips() {
+        let network_id = NetworkId::from_bytes([0x11; 32]);
+        let root_key = [0x42u8; 32];
+
+        let requester = EphemeralKeypair::generate();
+        let request = RootKeyRequest {
+            nonce_b: [0x33; 32],
+            eph_pk_b: requester.pk,
+            evidence: AttestationExchangeMessage::without_attestation(),
+        };
+
+        let responder = EphemeralKeypair::generate();
+        let wrapped = wrap_root_key_for_peer(
+            &responder.sk,
+            &requester.pk,
+            &root_key,
+            &network_id,
+            &request,
+        )
+        .unwrap();
+
+        let recovered = unwrap_root_key(
+            &requester.sk,
+            &responder.pk,
+            &wrapped,
+            &network_id,
+            &request,
+        )
+        .unwrap();
+        assert_eq!(recovered, root_key);
+    }
+
+    // A wrapped blob is bound to its request transcript via the AEAD AAD: open
+    // it under a different nonce_b and the tag check must fail.
+    #[test]
+    fn unwrap_rejects_foreign_request_binding() {
+        let network_id = NetworkId::from_bytes([0x11; 32]);
+        let root_key = [0x42u8; 32];
+
+        let requester = EphemeralKeypair::generate();
+        let request = RootKeyRequest {
+            nonce_b: [0x33; 32],
+            eph_pk_b: requester.pk,
+            evidence: AttestationExchangeMessage::without_attestation(),
+        };
+        let responder = EphemeralKeypair::generate();
+        let wrapped = wrap_root_key_for_peer(
+            &responder.sk,
+            &requester.pk,
+            &root_key,
+            &network_id,
+            &request,
+        )
+        .unwrap();
+
+        let mut tampered = request.clone();
+        tampered.nonce_b = [0xFF; 32];
+        let err = unwrap_root_key(
+            &requester.sk,
+            &responder.pk,
+            &wrapped,
+            &network_id,
+            &tampered,
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("AEAD tag mismatch"));
+    }
+
+    // Wrong network_id changes the AAD just like a wrong nonce does.
+    #[test]
+    fn unwrap_rejects_foreign_network() {
+        let net_a = NetworkId::from_bytes([0x11; 32]);
+        let net_b = NetworkId::from_bytes([0x22; 32]);
+        let root_key = [0x42u8; 32];
+
+        let requester = EphemeralKeypair::generate();
+        let request = RootKeyRequest {
+            nonce_b: [0x33; 32],
+            eph_pk_b: requester.pk,
+            evidence: AttestationExchangeMessage::without_attestation(),
+        };
+        let responder = EphemeralKeypair::generate();
+        let wrapped =
+            wrap_root_key_for_peer(&responder.sk, &requester.pk, &root_key, &net_a, &request)
+                .unwrap();
+
+        assert!(unwrap_root_key(&requester.sk, &responder.pk, &wrapped, &net_b, &request).is_err());
+    }
+}

--- a/crates/enclave-server/src/lib.rs
+++ b/crates/enclave-server/src/lib.rs
@@ -1,6 +1,8 @@
 mod attestation;
+mod bootstrap;
 mod key_manager;
 mod luks_keys;
+mod network;
 mod server;
 pub mod utils;
 

--- a/crates/enclave-server/src/network.rs
+++ b/crates/enclave-server/src/network.rs
@@ -1,0 +1,66 @@
+//! Startup derivation of this node's [`NetworkId`] from the network manifest.
+//!
+//! tdx-init writes the network's `network-manifest.json` verbatim to
+//! [`NETWORK_MANIFEST_PATH`] (tmpfs, re-supplied every boot by deploy tooling).
+//! The enclave hashes *those exact bytes* — `network_id = SHA-256(file bytes)`
+//! — and threads the result through every attestation binding, so a quote
+//! minted on one network can never satisfy a handshake on a clone.
+//!
+//! We hash the raw bytes we read rather than trusting any precomputed id, and
+//! deliberately never parse-and-re-serialize: re-rendering could change the
+//! bytes and therefore the id. We still parse once (strict v1) to fail fast
+//! with an actionable error on a malformed or wrong-version manifest, but the
+//! id always comes from [`NetworkId::from_manifest_bytes`] over the file bytes.
+
+use anyhow::{Context, Result};
+use seismic_attestation::{NetworkId, NetworkManifestV1};
+
+/// Where tdx-init drops the verbatim manifest. Mirrors tdx-init's
+/// `CONF_DIR`/`network-manifest.json`; see that crate's README.
+pub const NETWORK_MANIFEST_PATH: &str = "/run/seismic/conf/network-manifest.json";
+
+/// Read the manifest from `path`, validate it parses as v1, and derive the
+/// [`NetworkId`] from the exact file bytes.
+pub fn load_network_id(path: &str) -> Result<NetworkId> {
+    let bytes =
+        std::fs::read(path).with_context(|| format!("reading network manifest from {path}"))?;
+
+    // Strict parse for a fast, actionable error; the id is over the bytes, not
+    // the parsed value.
+    NetworkManifestV1::from_json_bytes(&bytes)
+        .with_context(|| format!("parsing network manifest at {path}"))?;
+
+    Ok(NetworkId::from_manifest_bytes(&bytes))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    const FIXTURE: &[u8] =
+        include_bytes!("../../seismic-attestation/fixtures/network-manifest-v1.json");
+
+    #[test]
+    fn derives_network_id_from_manifest_file() {
+        let mut tmp = tempfile::NamedTempFile::new().unwrap();
+        tmp.write_all(FIXTURE).unwrap();
+        let path = tmp.path().to_str().unwrap();
+
+        let network_id = load_network_id(path).unwrap();
+        // Same vector as seismic-attestation's manifest test over the fixture.
+        assert_eq!(network_id, NetworkId::from_manifest_bytes(FIXTURE));
+    }
+
+    #[test]
+    fn rejects_malformed_manifest() {
+        let mut tmp = tempfile::NamedTempFile::new().unwrap();
+        tmp.write_all(b"{ not valid json").unwrap();
+        assert!(load_network_id(tmp.path().to_str().unwrap()).is_err());
+    }
+
+    #[test]
+    fn errors_when_manifest_missing() {
+        assert!(load_network_id("/nonexistent/network-manifest.json").is_err());
+    }
+}

--- a/crates/enclave-server/src/server.rs
+++ b/crates/enclave-server/src/server.rs
@@ -1,5 +1,13 @@
 use crate::{
-    Args, attestation::AttestationAgent, key_manager::KeyManager, luks_keys,
+    Args,
+    attestation::AttestationAgent,
+    bootstrap::{
+        RootKeyRequest, RootKeyResponse, answer_root_key_request, build_root_key_request,
+        unwrap_root_key_from_response,
+    },
+    key_manager::KeyManager,
+    luks_keys,
+    network::{NETWORK_MANIFEST_PATH, load_network_id},
     utils::anyhow_to_rpc_error,
 };
 use dcap_rs::types::quotes::version_4::QuoteV4;
@@ -8,23 +16,39 @@ use jsonrpsee::{
     http_client::HttpClientBuilder,
     server::ServerBuilder,
 };
+use seismic_attestation::{AttestationType, NetworkId, SeismicMeasurementPolicy};
 use seismic_enclave::{
-    AttestationGetEvidenceResponse, GetPurposeKeysResponse, ShareRootKeyResponse,
-    TdxQuoteRpcClient as _, api::TdxQuoteRpcServer,
+    AttestationGetEvidenceResponse, GetPurposeKeysResponse, TdxQuoteRpcClient as _,
+    api::TdxQuoteRpcServer,
 };
 use std::{net::SocketAddr, time::Duration};
 use tracing::{info, warn};
 
+/// Attestation type this build mints and verifies evidence for. Azure TDX +
+/// vTPM is the only supported surface today (see `attestation::AttestationAgent`).
+const ATTESTATION_TYPE: AttestationType = AttestationType::AzureTdx;
+
+/// Epoch used for the standalone `getAttestationEvidence` tx_io binding.
+const TX_IO_BINDING_EPOCH: u64 = 0;
+
 pub struct TdxQuoteServer {
     attestation_agent: AttestationAgent,
     key_manager: KeyManager,
+    /// This node's network identity: `H(network-manifest.json)`. Every
+    /// attestation binding this server mints or verifies is scoped to it.
+    network_id: NetworkId,
 }
 
 impl TdxQuoteServer {
-    pub fn new(attestation_agent: AttestationAgent, key_manager: KeyManager) -> Self {
+    pub fn new(
+        attestation_agent: AttestationAgent,
+        key_manager: KeyManager,
+        network_id: NetworkId,
+    ) -> Self {
         Self {
             attestation_agent,
             key_manager,
+            network_id,
         }
     }
 }
@@ -46,10 +70,22 @@ impl TdxQuoteRpcServer for TdxQuoteServer {
         })
     }
 
-    /// Generates attestation evidence from the attestation authority
+    /// Generates attestation evidence bound to this node's tx_io public key.
+    ///
+    /// The quote commits to `tx_io_binding(network_id, tx_io_pk, epoch)`, so a
+    /// verifier learns the attested node holds this tx_io key on this network.
     async fn get_attestation_evidence(&self) -> RpcResult<AttestationGetEvidenceResponse> {
+        let tx_io_pk = self
+            .key_manager
+            .get_tx_io_pk(TX_IO_BINDING_EPOCH)
+            .serialize();
+        let binding = seismic_attestation::bindings::tx_io_binding(
+            &self.network_id,
+            &tx_io_pk,
+            TX_IO_BINDING_EPOCH,
+        );
         self.attestation_agent
-            .get_attestation_evidence()
+            .get_attestation_evidence(binding)
             .map_err(anyhow_to_rpc_error)
     }
 
@@ -66,24 +102,37 @@ impl TdxQuoteRpcServer for TdxQuoteServer {
             .map_err(anyhow_to_rpc_error)
     }
 
-    /// Shares the root key with an existing node
-    async fn boot_share_root_key(&self, quote: Vec<u8>) -> RpcResult<ShareRootKeyResponse> {
-        let quote = QuoteV4::from_bytes(&quote); // todo(dalton): This will panic if invalid quote bytes are sent find a way to catch or alternative
+    /// Get the network root key for a booting peer, AEAD-wrapped.
+    ///
+    /// Verifies the requester's attestation, ECDHs to its attested ephemeral
+    /// key, and returns the root key sealed under the derived key plus our own
+    /// quote over the response transcript. See [`crate::bootstrap`].
+    async fn get_wrapped_root_key(&self, request: Vec<u8>) -> RpcResult<Vec<u8>> {
+        let request: RootKeyRequest =
+            serde_json::from_slice(&request).map_err(|e| anyhow_to_rpc_error(e.into()))?;
 
-        self.attestation_agent
-            .verify_attestation_report(quote)
-            .await
-            .map_err(anyhow_to_rpc_error)?;
+        let response = answer_root_key_request(
+            &request,
+            &self.network_id,
+            &self.key_manager.get_root_key(),
+            bootstrap_measurement_policy(),
+            ATTESTATION_TYPE,
+        )
+        .await
+        .map_err(anyhow_to_rpc_error)?;
 
-        // quote is good send key
-        // Todo figure out encryption. We either force https or we handle encryption here
-        let root_key = self.key_manager.get_root_key();
-        Ok(ShareRootKeyResponse { root_key })
+        serde_json::to_vec(&response).map_err(|e| anyhow_to_rpc_error(e.into()))
     }
 }
 
 pub async fn start_server(addr: SocketAddr, args: Args) -> anyhow::Result<()> {
     let attestation_agent = AttestationAgent::new().unwrap();
+
+    // Derive this node's network identity from the manifest tdx-init dropped on
+    // tmpfs. Fatal if absent/malformed: without it every attestation binding is
+    // unscoped, so we refuse to serve rather than fall back to an unbound quote.
+    let network_id = load_network_id(NETWORK_MANIFEST_PATH)?;
+    info!("Derived network_id {network_id} from {NETWORK_MANIFEST_PATH}");
 
     let key_manager = if args.genesis_node {
         info!("Starting as genesis node; generating fresh network root key");
@@ -104,7 +153,7 @@ pub async fn start_server(addr: SocketAddr, args: Args) -> anyhow::Result<()> {
             "Starting as peer node; fetching root key from {} peer(s)",
             args.peers.len()
         );
-        fetch_root_key_from_peers(args.peers, &attestation_agent).await
+        fetch_root_key_from_peers(args.peers, &network_id).await
     };
 
     // Hand off the LUKS storage + header-MAC keys to setup-persistent-luks
@@ -115,7 +164,8 @@ pub async fn start_server(addr: SocketAddr, args: Args) -> anyhow::Result<()> {
 
     let server = ServerBuilder::default().build(addr).await?;
 
-    let handle = server.start(TdxQuoteServer::new(attestation_agent, key_manager).into_rpc());
+    let handle =
+        server.start(TdxQuoteServer::new(attestation_agent, key_manager, network_id).into_rpc());
 
     info!("TDX Quote JSON-RPC Server started at {}", addr);
 
@@ -124,27 +174,21 @@ pub async fn start_server(addr: SocketAddr, args: Args) -> anyhow::Result<()> {
     Ok(())
 }
 
-pub async fn fetch_root_key_from_peers(
-    peers: Vec<String>,
-    attestation_agent: &AttestationAgent,
-) -> KeyManager {
+/// Run the requester side of the v2 bootstrap against each peer until one
+/// returns a root key we can verify and unwrap.
+///
+/// Per attempt: build a fresh attested request (new ephemeral key + nonce),
+/// POST it, then verify the peer's response quote and AEAD-open the wrapped
+/// key. A fresh ephemeral key per attempt means a failed exchange leaks nothing
+/// reusable.
+pub async fn fetch_root_key_from_peers(peers: Vec<String>, network_id: &NetworkId) -> KeyManager {
     info!("Starting root key fetching from peers");
     loop {
-        let evidence = attestation_agent
-            .get_attestation_evidence()
-            .expect("Unable to get our own quote data");
-
         for peer in &peers {
-            let Ok(client) = HttpClientBuilder::default().build(peer) else {
-                warn!("Unable to make a connection with peer: {peer}. Trying next peer...");
-                continue;
-            };
-
-            match client.boot_share_root_key(evidence.quote.clone()).await {
-                Ok(res) => {
-                    // We got the key
-                    info!("Key received. Starting Key manager");
-                    return KeyManager::new(res.root_key);
+            match try_fetch_root_key_from_peer(peer, network_id).await {
+                Ok(root_key) => {
+                    info!("Key received from {peer}. Starting Key manager");
+                    return KeyManager::new(root_key);
                 }
                 Err(e) => {
                     warn!(
@@ -155,9 +199,48 @@ pub async fn fetch_root_key_from_peers(
             }
         }
 
-        tracing::warn!(
+        warn!(
             "Cycled through all provided peers and did not receive root_key. Sleeping for 30 seconds and trying again"
         );
         tokio::time::sleep(Duration::from_secs(30)).await;
     }
+}
+
+/// One requester-side handshake against a single peer.
+async fn try_fetch_root_key_from_peer(
+    peer: &str,
+    network_id: &NetworkId,
+) -> anyhow::Result<[u8; 32]> {
+    let (request, eph_sk_b) = build_root_key_request(network_id, ATTESTATION_TYPE)?;
+
+    let client = HttpClientBuilder::default().build(peer)?;
+    let request_bytes = serde_json::to_vec(&request)?;
+    let response_bytes = client.get_wrapped_root_key(request_bytes).await?;
+    let response: RootKeyResponse = serde_json::from_slice(&response_bytes)?;
+
+    unwrap_root_key_from_response(
+        &response,
+        &request,
+        &eph_sk_b,
+        network_id,
+        bootstrap_measurement_policy(),
+    )
+    .await
+}
+
+/// Measurement policy for verifying the *other* side of the bootstrap handshake.
+///
+/// TODO(bootstrap): load the policy pinned by the manifest's
+/// `measurements.bootstrap_policy_hash` (the seismic-images
+/// `build/measurements.json` artifact) once it is delivered to the node, and
+/// check the artifact bytes against that hash. Until that artifact is wired in,
+/// this accepts any measurements after the backend's cryptographic quote
+/// verification succeeds — adequate for bringing the encrypted transcript up,
+/// NOT a production allowlist.
+fn bootstrap_measurement_policy() -> SeismicMeasurementPolicy {
+    warn!(
+        "bootstrap: using dangerously-permissive measurement policy; \
+         peer image measurements are NOT being checked against an allowlist"
+    );
+    SeismicMeasurementPolicy::dangerously_accept_any_for_testing(ATTESTATION_TYPE)
 }

--- a/crates/enclave-server/tests/integration/integration.rs
+++ b/crates/enclave-server/tests/integration/integration.rs
@@ -9,11 +9,11 @@ use seismic_enclave_server::utils::{init_tracing, is_sudo};
 // This can be set up by running the test_multisig_upgrade_operator_workflow test in the enclave-contract crate
 #[serial_test::serial(attestation_agent)]
 #[tokio::test]
-async fn test_boot_share_root_key() {
+async fn test_get_wrapped_root_key_bootstrap() {
     init_tracing();
     // Check the starting conditions are as expected
     if !is_sudo() {
-        panic!("test_boot_share_root_key: skipped (requires sudo privileges)");
+        panic!("test_get_wrapped_root_key_bootstrap: skipped (requires sudo privileges)");
     }
 
     // Start first enclave as genesis node

--- a/crates/enclave/src/api.rs
+++ b/crates/enclave/src/api.rs
@@ -20,9 +20,21 @@ pub trait TdxQuoteRpc {
     async fn eval_attestation_evidence(&self, hcl_report: Vec<u8>, quote: Vec<u8>)
     -> RpcResult<()>;
 
-    /// Shares the root key with an existing node
-    #[method(name = "boot.share_root_key")]
-    async fn boot_share_root_key(&self, quote: Vec<u8>) -> RpcResult<ShareRootKeyResponse>;
+    /// Get the network root key from an existing node, wrapped to this caller.
+    ///
+    /// Called by a booting/joining node on a peer that already holds the
+    /// network root key. `request` is a serialized [`RootKeyRequest`] carrying
+    /// the caller's attested ephemeral key + nonce, and the reply is a
+    /// serialized [`RootKeyResponse`] carrying the root key AEAD-wrapped under
+    /// an ECDH key bound into the attested transcript.
+    ///
+    /// The wire body is opaque bytes here so this crate need not depend on the
+    /// attestation stack.
+    ///
+    /// [`RootKeyRequest`]: ../../enclave-server/src/bootstrap.rs
+    /// [`RootKeyResponse`]: ../../enclave-server/src/bootstrap.rs
+    #[method(name = "getWrappedRootKey")]
+    async fn get_wrapped_root_key(&self, request: Vec<u8>) -> RpcResult<Vec<u8>>;
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -37,9 +49,4 @@ pub struct GetPurposeKeysResponse {
 pub struct AttestationGetEvidenceResponse {
     pub hcl_report: Vec<u8>,
     pub quote: Vec<u8>,
-}
-
-#[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct ShareRootKeyResponse {
-    pub root_key: [u8; 32],
 }

--- a/crates/enclave/src/mock.rs
+++ b/crates/enclave/src/mock.rs
@@ -6,9 +6,7 @@ use jsonrpsee::core::{RpcResult, async_trait};
 use jsonrpsee::server::ServerBuilder;
 use tracing::info;
 
-use crate::api::{
-    AttestationGetEvidenceResponse, GetPurposeKeysResponse, ShareRootKeyResponse, TdxQuoteRpcServer,
-};
+use crate::api::{AttestationGetEvidenceResponse, GetPurposeKeysResponse, TdxQuoteRpcServer};
 use crate::{
     get_unsecure_sample_schnorrkel_keypair, get_unsecure_sample_secp256k1_pk,
     get_unsecure_sample_secp256k1_sk,
@@ -54,9 +52,11 @@ impl TdxQuoteRpcServer for MockServer {
         unimplemented!("eval_attestation_evidence not implemented for mock server")
     }
 
-    async fn boot_share_root_key(&self, _quote: Vec<u8>) -> RpcResult<ShareRootKeyResponse> {
-        Ok(ShareRootKeyResponse {
-            root_key: *get_unsecure_sample_secp256k1_sk().as_ref(),
-        })
+    async fn get_wrapped_root_key(&self, _request: Vec<u8>) -> RpcResult<Vec<u8>> {
+        // The v2 wrapped bootstrap needs the attestation stack (quote
+        // generation + verification) the mock deliberately omits. Dev/`sanvil`
+        // nodes start with `genesis_node=true` and never fetch a peer root key,
+        // so this path is unreachable in mock deployments.
+        unimplemented!("get_wrapped_root_key not implemented for mock server")
     }
 }

--- a/crates/seismic-attestation/src/manifest.rs
+++ b/crates/seismic-attestation/src/manifest.rs
@@ -135,7 +135,7 @@ pub struct SummitManifest {
 #[serde(deny_unknown_fields)]
 pub struct MeasurementsManifest {
     /// SHA-256 of the measurement-policy artifact bytes, eg:
-    /// https://github.com/flashbots/attested-tls/blob/f3b47739d17650a9489c8707cd94d0e80751ec40/crates/attestation/test-assets/measurements.json
+    /// <https://github.com/flashbots/attested-tls/blob/f3b47739d17650a9489c8707cd94d0e80751ec40/crates/attestation/test-assets/measurements.json>
     /// Produced by seismic-images' `make measure`, and lands under `build/measurements.json`.
     /// [`crate::SeismicMeasurementPolicy`] parses this file.
     ///

--- a/crates/tdx-init/src/config.rs
+++ b/crates/tdx-init/src/config.rs
@@ -48,7 +48,7 @@ pub struct EnclaveConfig {
 
     /// Peer enclave URLs (e.g. `http://10.0.0.1:7878`). When
     /// `genesis_node` is false, the enclave fetches `root_key` from one
-    /// of these peers via the `boot_share_root_key` RPC. Required for
+    /// of these peers via the `getWrappedRootKey` RPC. Required for
     /// non-genesis nodes; the enclave fails fast at startup if this
     /// list is empty and `genesis_node` is false.
     #[serde(default)]

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -7,7 +7,7 @@ This directory contains scripts for running integration tests for the Seismic en
 The `run_integration_tests.sh` script runs three integration tests in the correct order:
 
 1. **test_multisig_upgrade_operator_workflow** - Sets up the upgrade operator contract and multisig workflow
-2. **test_boot_share_root_key** - Tests the boot process for sharing root keys (requires setup from test 1)
+2. **test_get_wrapped_root_key_bootstrap** - Tests the boot process for fetching the wrapped root key (requires setup from test 1)
 3. **test_snapshot_integration_handlers** - Tests snapshot creation and restoration functionality
 
 ## Prerequisites
@@ -25,9 +25,9 @@ The integration tests require:
 - **Purpose**: Tests the complete multisig workflow for controlling the UpgradeOperator contract
 - **Dependencies**: Reth service running via supervisor
 
-### test_boot_share_root_key
-- **Location**: `crates/enclave-server/tests/integration/booter.rs`
-- **Purpose**: Tests the boot process for sharing root keys between enclave instances
+### test_get_wrapped_root_key_bootstrap
+- **Location**: `crates/enclave-server/tests/integration/integration.rs`
+- **Purpose**: Tests the boot process for fetching the wrapped root key between enclave instances
 - **Dependencies**: 
   - Reth service running via supervisor
   - Enclave-server service NOT running

--- a/scripts/run_integration_tests.sh
+++ b/scripts/run_integration_tests.sh
@@ -5,7 +5,7 @@
 # The assertion-bearing multisig coverage now lives in the hosted `check_and_test`
 # job (test_multisig_upgrade_operator_workflow against a throwaway anvil). Here we
 # only need the multisig flow as on-chain SETUP: it writes the booter's measurement
-# into the UpgradeOperator on the reth devnet, which test_boot_share_root_key reads
+# into the UpgradeOperator on the reth devnet, which test_get_wrapped_root_key_bootstrap reads
 # at boot (enclave-server queries reth at :8545 for the allowlist — see
 # crates/enclave-server/src/attestation/upgrade_contract.rs).
 #
@@ -15,10 +15,10 @@
 # point reth's RPC had dropped — that ConnectionRefused was the original failure.)
 #
 # 1. multisig setup           -> seed the UpgradeOperator allowlist on reth
-# 2. test_boot_share_root_key -> needs enclave-server stopped (TPM) + the setup above
+# 2. test_get_wrapped_root_key_bootstrap -> needs enclave-server stopped (TPM) + the setup above
 #
 # KNOWN RESIDUAL (out of scope for this script, tracked separately):
-# test_boot_share_root_key can still fail for two infra reasons unrelated to this
+# test_get_wrapped_root_key_bootstrap can still fail for two infra reasons unrelated to this
 # script's structure:
 #   (i)  enclave-server exiting at startup — it now requires a network manifest at
 #        /run/seismic/conf/network-manifest.json; supervisor reports "Exited too
@@ -92,8 +92,8 @@ echo "✅ UpgradeOperator allowlist setup complete"
 sudo supervisorctl stop enclave-server || true
 sleep 2
 
-# Test: Run boot share root key test
-echo "🧪 Running test_boot_share_root_key..."
+# Test: run wrapped root-key bootstrap test
+echo "🧪 Running test_get_wrapped_root_key_bootstrap..."
 cd ../enclave-server
 ls -la Cargo.toml 2>/dev/null || echo "❌ Cargo.toml not found in $(pwd)"
 
@@ -109,13 +109,13 @@ echo "Found binaries: ${binaries[*]}"
 # Run the first binary with the specific test
 sleep 2
 
-echo "🚀 Executing: sudo ${binaries[0]} test_boot_share_root_key"
-if ! sudo "${binaries[0]}" test_boot_share_root_key; then
-    echo "❌ test_boot_share_root_key failed with exit code $?"
+echo "🚀 Executing: sudo ${binaries[0]} test_get_wrapped_root_key_bootstrap"
+if ! sudo "${binaries[0]}" test_get_wrapped_root_key_bootstrap; then
+    echo "❌ test_get_wrapped_root_key_bootstrap failed with exit code $?"
     echo "🔍 Last 20 lines of system log:"
     sudo journalctl -n 20 --no-pager 2>/dev/null || echo "Could not access journalctl"
     exit 1
 fi
-echo "✅ test_boot_share_root_key passed"
+echo "✅ test_get_wrapped_root_key_bootstrap passed"
 
 echo "🎉 All integration tests passed!" 


### PR DESCRIPTION
Joining nodes now fetch the network root key through an attested ECDH/AES-GCM wrapping flow. The getWrappedRootKey RPC takes an opaque serialized RootKeyRequest and returns an opaque serialized RootKeyResponse.

A requester sends a fresh nonce, an ephemeral secp256k1 ECDH public key, and attestation evidence over root_key_request_binding(network_id, nonce, eph_pk). The responder verifies that evidence, wraps root_key to the requester's attested ephemeral key, and returns its own ephemeral public key, the wrapped root key, and evidence over root_key_response_binding(network_id, nonce, responder_eph_pk, wrapped).

Also derive network_id at enclave-server startup from the exact bytes of /run/seismic/conf/network-manifest.json and thread it through tx_io and root-key bootstrap bindings. The server fails fast if the manifest is missing or malformed.

Other changes:
- bind getAttestationEvidence to tx_io_binding(network_id, tx_io_pk, epoch 0)
- rename boot.share_root_key to getWrappedRootKey
- keep seismic-enclave free of seismic-attestation by using opaque Vec<u8> bodies for bootstrap RPC payloads
- add bootstrap/network unit tests
- update mock/server docs, tdx-init comments, and integration-test naming

Known follow-ups:
- replace the temporary permissive bootstrap measurement policy with a real allowlist/admission check
- add an attestation evidence v2 RPC returning AttestationExchangeMessage and route that endpoint through seismic-attestation
- split today's seismic-enclave common crate into narrower RPC/crypto/mock/ bootstrap-protocol/custodian-IPC crates