### PR TITLE
feat(enclave): add getLuksProvisioningStatus RPC for first-boot wipe progress

### DIFF
--- a/crates/enclave-server/src/lib.rs
+++ b/crates/enclave-server/src/lib.rs
@@ -2,6 +2,7 @@ mod attestation;
 mod bootstrap;
 mod key_manager;
 mod luks_keys;
+mod luks_status;
 mod network;
 mod server;
 pub mod utils;

--- a/crates/enclave-server/src/luks_status.rs
+++ b/crates/enclave-server/src/luks_status.rs
@@ -1,0 +1,117 @@
+//! Reader for the first-boot LUKS-wipe progress that the `setup-persistent-luks`
+//! script publishes. See
+//! <https://github.com/SeismicSystems/seismic-images/blob/seismic/modules/seismic/mkosi.extra/usr/bin/setup-persistent-luks>
+//!
+//! First boot wipes the whole persistent disk to seed dm-integrity tags — an
+//! hour-plus, otherwise-silent operation. The script writes progress to a
+//! tmpfs file (atomically) and removes it when done; enclave-server is the
+//! only node service alive for the entire wipe, so it serves the latest
+//! snapshot via the `getLuksProvisioningStatus` RPC for the operator's CLI
+//! progress bar.
+//!
+//! Strictly read-only and decoupled: we read the file on demand and never
+//! write it, so a status read can never affect the wipe (and vice versa).
+
+use seismic_enclave::LuksProvisioningStatus;
+
+/// tmpfs file the wipe producer writes (and removes on completion). Absent
+/// whenever no first-boot provisioning is in flight.
+const LUKS_STATUS_FILE: &str = "/run/seismic/status/luks.json";
+
+/// Current wipe status. Returns [`LuksProvisioningStatus::Idle`] when the file
+/// is absent (no wipe in flight — done or never started), and
+/// [`LuksProvisioningStatus::Unknown`] when it exists but can't be read or
+/// parsed (a broken status pipeline, which is distinct from "done"). Best-effort
+/// telemetry: a polling CLI must never get a hard error, so this is infallible.
+pub fn read() -> LuksProvisioningStatus {
+    read_from(LUKS_STATUS_FILE)
+}
+
+fn read_from(path: &str) -> LuksProvisioningStatus {
+    // A tiny tmpfs read; synchronous is fine inside the async RPC handler.
+    match std::fs::read(path) {
+        // Present but unparseable → the pipeline is broken, not "done".
+        Ok(bytes) => serde_json::from_slice(&bytes).unwrap_or(LuksProvisioningStatus::Unknown),
+        // Absent is the normal "no wipe in flight" case (done or never started).
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => LuksProvisioningStatus::Idle,
+        // Exists but unreadable (perms/IO): surface as Unknown, never as Idle.
+        Err(_) => LuksProvisioningStatus::Unknown,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    fn write_temp(contents: &str) -> tempfile::NamedTempFile {
+        let mut f = tempfile::NamedTempFile::new().unwrap();
+        f.write_all(contents.as_bytes()).unwrap();
+        f
+    }
+
+    #[test]
+    fn absent_file_is_idle() {
+        assert_eq!(
+            read_from("/no/such/path/luks.json"),
+            LuksProvisioningStatus::Idle
+        );
+    }
+
+    #[test]
+    fn absent_is_idle_but_garbage_is_unknown() {
+        // A present-but-unparseable file must NOT look like "done" (Idle);
+        // it signals a broken status pipeline.
+        let f = write_temp("not json{");
+        assert_eq!(
+            read_from(f.path().to_str().unwrap()),
+            LuksProvisioningStatus::Unknown
+        );
+    }
+
+    /// Pins the wire contract the bash producer hand-writes. If this changes,
+    /// `setup-persistent-luks`'s `write_progress_status` must change too.
+    #[test]
+    fn parses_provisioning_with_eta() {
+        let f = write_temp(
+            r#"{"state":"provisioning","bytes_done":104857600,"bytes_total":1099511627776,"eta_seconds":5400}"#,
+        );
+        assert_eq!(
+            read_from(f.path().to_str().unwrap()),
+            LuksProvisioningStatus::Provisioning {
+                bytes_done: 104857600,
+                bytes_total: 1099511627776,
+                eta_seconds: Some(5400),
+            }
+        );
+    }
+
+    #[test]
+    fn parses_provisioning_without_eta() {
+        let f = write_temp(r#"{"state":"provisioning","bytes_done":0,"bytes_total":0}"#);
+        assert_eq!(
+            read_from(f.path().to_str().unwrap()),
+            LuksProvisioningStatus::Provisioning {
+                bytes_done: 0,
+                bytes_total: 0,
+                eta_seconds: None,
+            }
+        );
+    }
+
+    #[test]
+    fn parses_idle_and_error() {
+        let idle = write_temp(r#"{"state":"idle"}"#);
+        assert_eq!(
+            read_from(idle.path().to_str().unwrap()),
+            LuksProvisioningStatus::Idle
+        );
+        let err = write_temp(r#"{"state":"error","error":"boom"}"#);
+        assert_eq!(
+            read_from(err.path().to_str().unwrap()),
+            LuksProvisioningStatus::Error {
+                error: "boom".to_string()
+            }
+        );
+    }
+}

--- a/crates/enclave-server/src/server.rs
+++ b/crates/enclave-server/src/server.rs
@@ -18,8 +18,8 @@ use jsonrpsee::{
 };
 use seismic_attestation::{AttestationType, NetworkId, SeismicMeasurementPolicy};
 use seismic_enclave::{
-    AttestationGetEvidenceResponse, GetPurposeKeysResponse, TdxQuoteRpcClient as _,
-    api::TdxQuoteRpcServer,
+    AttestationGetEvidenceResponse, GetPurposeKeysResponse, LuksProvisioningStatus,
+    TdxQuoteRpcClient as _, api::TdxQuoteRpcServer,
 };
 use std::{net::SocketAddr, time::Duration};
 use tracing::{info, warn};
@@ -122,6 +122,13 @@ impl TdxQuoteRpcServer for TdxQuoteServer {
         .map_err(anyhow_to_rpc_error)?;
 
         serde_json::to_vec(&response).map_err(|e| anyhow_to_rpc_error(e.into()))
+    }
+
+    /// Serve the first-boot LUKS-wipe progress the setup-persistent-luks
+    /// script publishes (read-only; `Idle` when no wipe is in flight). See
+    /// [`crate::luks_status`].
+    async fn get_luks_provisioning_status(&self) -> RpcResult<LuksProvisioningStatus> {
+        Ok(crate::luks_status::read())
     }
 }
 

--- a/crates/enclave/src/api.rs
+++ b/crates/enclave/src/api.rs
@@ -35,6 +35,17 @@ pub trait TdxQuoteRpc {
     /// [`RootKeyResponse`]: ../../enclave-server/src/bootstrap.rs
     #[method(name = "getWrappedRootKey")]
     async fn get_wrapped_root_key(&self, request: Vec<u8>) -> RpcResult<Vec<u8>>;
+
+    /// Report first-boot LUKS provisioning progress.
+    ///
+    /// First boot wipes the entire persistent disk to seed dm-integrity tags,
+    /// which can take 1h+ and is otherwise opaque to the operator. The deploy
+    /// CLI polls this to render a progress bar; it returns
+    /// [`LuksProvisioningStatus::Idle`] whenever no wipe is in flight (not
+    /// started, or already finished). enclave-server is the only node service
+    /// alive for the whole wipe, which is why it hosts this.
+    #[method(name = "getLuksProvisioningStatus")]
+    async fn get_luks_provisioning_status(&self) -> RpcResult<LuksProvisioningStatus>;
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -49,4 +60,43 @@ pub struct GetPurposeKeysResponse {
 pub struct AttestationGetEvidenceResponse {
     pub hcl_report: Vec<u8>,
     pub quote: Vec<u8>,
+}
+
+// TODO: this is intentionally scoped to just the first-boot LUKS wipe — the one
+// long, opaque phase the operator CLI needs a progress bar for. If we later want
+// a full node boot-status surface, this would grow into a richer enum covering
+// all states: distinguishing wipe-done from never-started, plus the other boot
+// phases (root_key fetch / LUKS unlock / summit keygen / ready). Kept minimal
+// for now; revisit if the CLI needs more than "is the disk still being wiped?".
+/// First-boot LUKS-wipe progress, published by the `setup-persistent-luks`
+/// script to a tmpfs file and served by enclave-server.
+/// <https://github.com/SeismicSystems/seismic-images/blob/seismic/modules/seismic/mkosi.extra/usr/bin/setup-persistent-luks>
+///
+/// Internally tagged by `state` so the JSON matches what the script
+/// hand-writes (e.g. `{"state":"provisioning","bytes_done":..,"bytes_total":..}`).
+/// Only `provisioning`/`error` are ever written to the file; `Idle`/`Unknown`
+/// are synthesized by the reader (and still serialized to the CLI).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "state", rename_all = "snake_case")]
+pub enum LuksProvisioningStatus {
+    /// No wipe in flight: the status file is absent. Deliberately conflates
+    /// "finished" (the script removes the file when done) with "never started"
+    /// (a later boot that takes the fast unlock path) — the consumer reacts to
+    /// both the same way: no bar, poll the node's real endpoints for readiness.
+    Idle,
+    /// The wipe is running. `bytes_done`/`bytes_total` drive the progress bar;
+    /// a `bytes_total` of 0 means "just started, no measurement yet"
+    /// (the CLI should show an indeterminate state until the first real tick).
+    Provisioning {
+        bytes_done: u64,
+        bytes_total: u64,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        eta_seconds: Option<u64>,
+    },
+    /// The wipe failed; systemd is retrying `persistent-luks-setup.service`.
+    Error { error: String },
+    /// The status file exists but couldn't be read or parsed — a producer bug
+    /// or a perms/IO issue, NOT evidence the wipe finished. The consumer should
+    /// surface a warning and keep polling, never treat this as "done".
+    Unknown,
 }

--- a/crates/enclave/src/mock.rs
+++ b/crates/enclave/src/mock.rs
@@ -6,7 +6,10 @@ use jsonrpsee::core::{RpcResult, async_trait};
 use jsonrpsee::server::ServerBuilder;
 use tracing::info;
 
-use crate::api::{AttestationGetEvidenceResponse, GetPurposeKeysResponse, TdxQuoteRpcServer};
+use crate::api::{
+    AttestationGetEvidenceResponse, GetPurposeKeysResponse, LuksProvisioningStatus,
+    TdxQuoteRpcServer,
+};
 use crate::{
     get_unsecure_sample_schnorrkel_keypair, get_unsecure_sample_secp256k1_pk,
     get_unsecure_sample_secp256k1_sk,
@@ -58,5 +61,10 @@ impl TdxQuoteRpcServer for MockServer {
         // nodes start with `genesis_node=true` and never fetch a peer root key,
         // so this path is unreachable in mock deployments.
         unimplemented!("get_wrapped_root_key not implemented for mock server")
+    }
+
+    async fn get_luks_provisioning_status(&self) -> RpcResult<LuksProvisioningStatus> {
+        // The mock has no real persistent disk, so nothing is ever provisioning.
+        Ok(LuksProvisioningStatus::Idle)
     }
 }


### PR DESCRIPTION
First boot wipes the entire persistent disk to seed dm-integrity tags, which can take 1h+ and is otherwise an opaque, silent wait. Add a read-only RPC so the operator CLI can poll it and render a progress bar.
- api.rs: LuksProvisioningStatus type (internally tagged by `state`: idle / provisioning{bytes_done,bytes_total,eta_seconds?} / error / unknown) + getLuksProvisioningStatus on the TdxQuoteRpc trait.
- enclave-server: luks_status.rs reads /run/seismic/status/luks.json (written by seismic-images' setup-persistent-luks) and serves the latest snapshot. Absent file -> Idle; present-but-unreadable -> Unknown, so a broken status pipeline never masquerades as "done". Hosted here because enclave-server is the only node service alive for the whole wipe.
- mock: returns Idle (no real disk).

For now this is scoped deliberately to the wipe; not a general boot-status surface. Might eventually expand to a full status/liveness check.