### PR TITLE
feat(tdx-init)!: require [network] manifest in InitConfig

### DIFF
--- a/crates/tdx-init/src/config.rs
+++ b/crates/tdx-init/src/config.rs
@@ -9,14 +9,12 @@ pub struct InitConfig {
     pub domain: DomainConfig,
     #[serde(default)]
     pub enclave: EnclaveConfig,
-    /// TODO: drop the `Option` (make `[network]` required) once both hold:
-    /// (1) enclave-server reads `network-manifest.json` for its attestation
-    /// `network_id` bindings — the consumer that breaks at boot when the
-    /// file is missing; (2) deploy flows embed the section in every
-    /// node.toml by default. Until then a missing section must stay
-    /// tolerated: nothing consumes the file yet, and existing node.tomls
-    /// don't carry it.
-    pub network: Option<NetworkConfig>,
+    /// Required: enclave-server reads `network-manifest.json` at startup to
+    /// derive `network_id` and bind every attestation to it, and is fatal
+    /// without it. A POST that omits `[network]` therefore 400s here rather
+    /// than booting a node that crash-loops on the missing file. The deploy
+    /// CLI merges the network-wide manifest into the per-node config at POST time.
+    pub network: NetworkConfig,
 }
 
 /// DNS name + contact email for the Let's Encrypt cert that fronts this
@@ -84,13 +82,19 @@ email = "ops@example.com"
 [enclave]
 genesis_node = true
 peers = ["http://10.0.0.1:7878", "http://10.0.0.2:7878"]
+
+[network]
+manifest_base64 = "eyJtYW5pZmVzdF92ZXJzaW9uIjogMX0K"
 "#;
         let cfg: InitConfig = toml::from_str(toml_input).unwrap();
         assert_eq!(cfg.domain.name, "node1.example.com");
         assert_eq!(cfg.domain.email, "ops@example.com");
         assert!(cfg.enclave.genesis_node);
         assert_eq!(cfg.enclave.peers.len(), 2);
-        assert!(cfg.network.is_none());
+        assert_eq!(
+            cfg.network.manifest_base64,
+            "eyJtYW5pZmVzdF92ZXJzaW9uIjogMX0K"
+        );
     }
 
     #[test]
@@ -105,7 +109,7 @@ manifest_base64 = "eyJtYW5pZmVzdF92ZXJzaW9uIjogMX0K"
 "#;
         let cfg: InitConfig = toml::from_str(toml_input).unwrap();
         assert_eq!(
-            cfg.network.unwrap().manifest_base64,
+            cfg.network.manifest_base64,
             "eyJtYW5pZmVzdF92ZXJzaW9uIjogMX0K"
         );
     }
@@ -131,10 +135,27 @@ network_id = "0xabcd"
 [domain]
 name = "node1.example.com"
 email = "ops@example.com"
+
+[network]
+manifest_base64 = "eyJtYW5pZmVzdF92ZXJzaW9uIjogMX0K"
 "#;
         let cfg: InitConfig = toml::from_str(toml_input).unwrap();
         assert!(!cfg.enclave.genesis_node);
         assert!(cfg.enclave.peers.is_empty());
+    }
+
+    #[test]
+    fn requires_network_section() {
+        let toml_input = r#"
+[domain]
+name = "node1.example.com"
+email = "ops@example.com"
+
+[enclave]
+genesis_node = true
+"#;
+        let err = toml::from_str::<InitConfig>(toml_input).unwrap_err();
+        assert!(err.to_string().contains("network"));
     }
 
     #[test]
@@ -143,6 +164,9 @@ email = "ops@example.com"
 [domain]
 name = "node1.example.com"
 email = "ops@example.com"
+
+[network]
+manifest_base64 = "eyJ9"
 
 [bogus]
 field = "value"
@@ -161,6 +185,9 @@ email = "ops@example.com"
 [enclave]
 genesis_node = false
 log_level = "trace"
+
+[network]
+manifest_base64 = "eyJ9"
 "#;
         let err = toml::from_str::<InitConfig>(toml_input).unwrap_err();
         assert!(err.to_string().to_lowercase().contains("unknown"));
@@ -171,6 +198,9 @@ log_level = "trace"
         let toml_input = r#"
 [enclave]
 genesis_node = true
+
+[network]
+manifest_base64 = "eyJ9"
 "#;
         let err = toml::from_str::<InitConfig>(toml_input).unwrap_err();
         assert!(err.to_string().contains("domain"));

--- a/crates/tdx-init/src/server.rs
+++ b/crates/tdx-init/src/server.rs
@@ -57,11 +57,10 @@ pub async fn run_initialization_server() -> Result<InitConfig> {
 async fn handle_config(State(state): State<AppState>, body: String) -> Result<Response> {
     let config: InitConfig = toml::from_str(&body)?;
 
-    // Validate the manifest embed while the operator's POST is still waiting
-    // on a response: a bad manifest must 400 the deploy, not fail at boot.
-    if let Some(network) = &config.network {
-        crate::manifest::decode_and_validate(&network.manifest_base64)?;
-    }
+    // Validate the manifest while the operator's POST is still waiting on a
+    // response: a bad (or absent) manifest must 400 the deploy, not fail at boot
+    // when enclave-server tries to use it.
+    crate::manifest::decode_and_validate(&config.network.manifest_base64)?;
 
     let mut sender_guard = state.config_sender.lock().await;
     match sender_guard.take() {

--- a/crates/tdx-init/src/writer.rs
+++ b/crates/tdx-init/src/writer.rs
@@ -22,9 +22,7 @@ pub async fn write_service_configs(conf_dir: &Path, config: &InitConfig) -> Resu
     fs::create_dir_all(conf_dir).await?;
     write_domain_env(conf_dir, config).await?;
     write_enclave_env(conf_dir, config).await?;
-    if let Some(network) = &config.network {
-        write_network_manifest(conf_dir, network).await?;
-    }
+    write_network_manifest(conf_dir, &config.network).await?;
     Ok(())
 }
 
@@ -80,7 +78,8 @@ async fn write_with_mode(path: &Path, content: impl AsRef<[u8]>, mode: u32) -> R
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::{DomainConfig, EnclaveConfig};
+    use crate::config::{DomainConfig, EnclaveConfig, NetworkConfig};
+    use base64::Engine as _;
     use tempfile::TempDir;
 
     fn sample_config(genesis_node: bool, peers: Vec<&str>) -> InitConfig {
@@ -93,7 +92,12 @@ mod tests {
                 genesis_node,
                 peers: peers.into_iter().map(String::from).collect(),
             },
-            network: None,
+            network: NetworkConfig {
+                // A valid manifest (the shared seismic-attestation fixture);
+                manifest_base64: base64::engine::general_purpose::STANDARD.encode(include_bytes!(
+                    "../../seismic-attestation/fixtures/network-manifest-v1.json"
+                )),
+            },
         }
     }
 
@@ -134,8 +138,6 @@ mod tests {
 
     #[tokio::test]
     async fn writes_network_manifest_verbatim() {
-        use base64::Engine as _;
-
         let tmp = TempDir::new().unwrap();
         let mut cfg = sample_config(false, vec![]);
         // A valid manifest with a non-canonical byte (trailing newline): the
@@ -146,24 +148,14 @@ mod tests {
             b"\n",
         ]
         .concat();
-        cfg.network = Some(crate::config::NetworkConfig {
+        cfg.network = NetworkConfig {
             manifest_base64: base64::engine::general_purpose::STANDARD.encode(&raw),
-        });
+        };
 
         write_service_configs(tmp.path(), &cfg).await.unwrap();
 
         let written = std::fs::read(tmp.path().join("network-manifest.json")).unwrap();
         assert_eq!(written, raw);
-    }
-
-    #[tokio::test]
-    async fn skips_network_manifest_when_section_absent() {
-        let tmp = TempDir::new().unwrap();
-        let cfg = sample_config(false, vec![]);
-
-        write_service_configs(tmp.path(), &cfg).await.unwrap();
-
-        assert!(!tmp.path().join("network-manifest.json").exists());
     }
 
     #[tokio::test]


### PR DESCRIPTION
`network` was Option<NetworkConfig>, so a POST without [network] was accepted (200) — but enclave-server hard-requires network-manifest.json at startup (it derives network_id and binds every attestation to it) and is fatal without it. The node then crash-looped at boot, with the cause visible only in journalctl.

Make `network` required so toml::from_str rejects a manifest-less POST with 400 at deploy time — loud and actionable — instead of a silent boot-time crash-loop. server and writer drop their `if let Some(..)` guards and validate/write the manifest unconditionally.

The deploy CLI (seismic-tee configure) merges the network-wide manifest into the per-node config at POST time, so [network] is always present on the wire.