### PR TITLE
fix(enclave): write the LUKS keyfile atomically (tmp + rename)

### DIFF
--- a/crates/enclave-server/src/luks_keys.rs
+++ b/crates/enclave-server/src/luks_keys.rs
@@ -48,8 +48,7 @@ pub fn write_keys_for_luks_setup(km: &KeyManager) -> Result<()> {
     f.write_all(&buf)?;
     f.sync_all()?;
     drop(f);
-    fs::rename(&tmp, path)
-        .with_context(|| format!("renaming {} into place", tmp.display()))?;
+    fs::rename(&tmp, path).with_context(|| format!("renaming {} into place", tmp.display()))?;
     info!(
         "wrote LUKS keys for setup-persistent-luks at {}",
         path.display()

--- a/crates/enclave-server/src/luks_keys.rs
+++ b/crates/enclave-server/src/luks_keys.rs
@@ -1,5 +1,5 @@
-//! Hand off LUKS-related derived keys to `setup-persistent-luks`
-//! (seismic-images) at startup.
+//! Hand off LUKS-related derived keys to `setup-persistent-luks` at startup. See
+//! https://github.com/SeismicSystems/seismic-images/blob/29bb1f4e39/modules/seismic/mkosi.extra/usr/bin/setup-persistent-luks
 //!
 //! Writes 64 raw bytes — `storage_key (32B) || header_mac_key (32B)` —
 //! to a tmpfs file owned by the enclave user. The LUKS-setup script
@@ -10,7 +10,7 @@
 
 use crate::key_manager::{KeyManager, KeyPurpose};
 use anyhow::{Context as _, Result};
-use std::{fs::OpenOptions, io::Write as _, os::unix::fs::OpenOptionsExt as _, path::Path};
+use std::{fs, fs::OpenOptions, io::Write as _, os::unix::fs::OpenOptionsExt as _, path::Path};
 use tracing::info;
 
 /// Drop-zone for the LUKS keys. Hardcoded to match the `RuntimeDirectory=`
@@ -33,16 +33,23 @@ pub fn write_keys_for_luks_setup(km: &KeyManager) -> Result<()> {
     buf[..32].copy_from_slice(storage_key.as_ref());
     buf[32..].copy_from_slice(header_mac_key.as_ref());
 
+    // Write to a tmp file and rename into place: the consumer script `setup-persistent-luks`
+    // polls for this exact path, so it must never observe a partially-written file.
     let path = Path::new(LUKS_KEYS_PATH);
+    let tmp = path.with_extension("tmp");
+    // delete in case a previous run left a tmp file (crashed before deleting it)
+    let _ = fs::remove_file(&tmp);
     let mut f = OpenOptions::new()
         .write(true)
-        .create(true)
-        .truncate(true)
+        .create_new(true)
         .mode(0o400)
-        .open(path)
-        .with_context(|| format!("creating {}", path.display()))?;
+        .open(&tmp)
+        .with_context(|| format!("creating {}", tmp.display()))?;
     f.write_all(&buf)?;
     f.sync_all()?;
+    drop(f);
+    fs::rename(&tmp, path)
+        .with_context(|| format!("renaming {} into place", tmp.display()))?;
     info!(
         "wrote LUKS keys for setup-persistent-luks at {}",
         path.display()


### PR DESCRIPTION
setup-persistent-luks (seismic-images) polls for this exact path at 1Hz, but create+truncate+write makes the file visible at open(), an instant before its 64 bytes land — a poller waking inside that window reads a short keyfile. Write to luks-keys.tmp and rename into place so existence implies fully written; the script-side wait now relies on exactly that.

rename also fixes a pre-existing restart wrinkle: the keyfile is mode 0400, so reopening it with truncate(true) is EACCES even for the owner — an enclave-server restart before the script consumed the previous keyfile would have failed here. rename replaces the stale file without opening it. The stale .tmp from a crashed earlier run is removed up front, since create_new would refuse it for the same permission reason (and it holds key material worth scrubbing).