### PR TITLE
feat(tdx-init)!: require reth genesis in InitConfig

### DIFF
--- a/crates/tdx-init/README.md
+++ b/crates/tdx-init/README.md
@@ -40,8 +40,9 @@ email = "<contact@example.com>"     # ACME registration / renewal email
 genesis_node = false                # true on exactly one VM per network
 peers = ["http://10.0.0.1:7878"]    # required when genesis_node = false
 
-[network]                           # optional during rollout
+[network]
 manifest_base64 = "eyJib290c3RyYXBfbWVhc3VyZW1lbn..."
+reth_genesis_base64 = "eyJjb25maWciOnsiY2hhaW5JZCI..."
 ```
 
 `manifest_base64` carries the network's `network-manifest.json` as opaque
@@ -54,6 +55,15 @@ authoritative parser is the sibling
 [`seismic-attestation`](../seismic-attestation) crate, kept in lockstep
 with this crate via its shared fixture.
 
+`reth_genesis_base64` carries the reth genesis JSON (chain spec) every
+node's reth boots from. It is network-wide like the manifest, whose
+`eth.genesis_hash` pins its genesis *block* (header and, via the state
+root, the alloc) but not the file's `config` section (fork schedule) —
+so POST-time validation is structural: valid JSON whose `config.chainId`
+matches the manifest's `eth.chain_id`. The block-hash commitment is
+enforced deploy-side and at ceremony time; see `src/reth_genesis.rs`.
+Written verbatim to `reth-genesis.json`.
+
 ## Per-service outputs
 
 After validation, tdx-init writes:
@@ -62,7 +72,8 @@ After validation, tdx-init writes:
 |---|---|---|
 | `/run/seismic/conf/domain.env` | `DOMAIN_NAME=...`, `DOMAIN_EMAIL=...` | `setup-nginx-ssl` (seismic-images) — `source`'d before invoking certbot for Let's Encrypt cert issuance and renewal |
 | `/run/seismic/conf/enclave.env` | `SEISMIC_ENCLAVE_GENESIS_NODE=...`, `SEISMIC_ENCLAVE_PEERS=...` | `enclave.service` (seismic-images) — loaded via `EnvironmentFile=`, then consumed by [`seismic-enclave-server`](../enclave-server) through clap `env=` attributes |
-| `/run/seismic/conf/network-manifest.json` | verbatim manifest bytes (only when `[network]` present) | [`seismic-enclave-server`](../enclave-server) — hashes the file itself to derive `network_id` for attestation bindings |
+| `/run/seismic/conf/network-manifest.json` | verbatim manifest bytes | [`seismic-enclave-server`](../enclave-server) — hashes the file itself to derive `network_id` for attestation bindings |
+| `/run/seismic/conf/reth-genesis.json` | verbatim reth genesis bytes | `reth.service` (seismic-images) — passed to `seismic-reth node --chain` |
 
 Each downstream service reads its own native format (env-var pairs,
 either via systemd `EnvironmentFile=` or shell `source`); tdx-init is

--- a/crates/tdx-init/src/config.rs
+++ b/crates/tdx-init/src/config.rs
@@ -66,6 +66,16 @@ pub struct NetworkConfig {
     /// base64 (standard alphabet) of the network-manifest.json bytes, as
     /// emitted by the deploy tool's manifest assembly step.
     pub manifest_base64: String,
+
+    /// base64 encoding of the reth genesis JSON — the chain spec
+    /// every node's reth boots from (`--chain
+    /// /run/seismic/conf/reth-genesis.json`). Network-wide like the manifest,
+    /// whose `eth.genesis_hash` pins its genesis block; required because a
+    /// node booted without it has no chain spec and reth crash-loops.
+    /// Validated at POST time against the manifest's `eth.chain_id`
+    /// (`src/reth_genesis.rs`) and written verbatim to `reth-genesis.json`
+    /// under [`crate::CONF_DIR`].
+    pub reth_genesis_base64: String,
 }
 
 #[cfg(test)]
@@ -85,6 +95,7 @@ peers = ["http://10.0.0.1:7878", "http://10.0.0.2:7878"]
 
 [network]
 manifest_base64 = "eyJtYW5pZmVzdF92ZXJzaW9uIjogMX0K"
+reth_genesis_base64 = "eyJjb25maWciOnt9fQ=="
 "#;
         let cfg: InitConfig = toml::from_str(toml_input).unwrap();
         assert_eq!(cfg.domain.name, "node1.example.com");
@@ -106,6 +117,7 @@ email = "ops@example.com"
 
 [network]
 manifest_base64 = "eyJtYW5pZmVzdF92ZXJzaW9uIjogMX0K"
+reth_genesis_base64 = "eyJjb25maWciOnt9fQ=="
 "#;
         let cfg: InitConfig = toml::from_str(toml_input).unwrap();
         assert_eq!(
@@ -123,6 +135,7 @@ email = "ops@example.com"
 
 [network]
 manifest_base64 = "eyJ9"
+reth_genesis_base64 = "eyJjb25maWciOnt9fQ=="
 network_id = "0xabcd"
 "#;
         let err = toml::from_str::<InitConfig>(toml_input).unwrap_err();
@@ -138,10 +151,27 @@ email = "ops@example.com"
 
 [network]
 manifest_base64 = "eyJtYW5pZmVzdF92ZXJzaW9uIjogMX0K"
+reth_genesis_base64 = "eyJjb25maWciOnt9fQ=="
 "#;
         let cfg: InitConfig = toml::from_str(toml_input).unwrap();
         assert!(!cfg.enclave.genesis_node);
         assert!(cfg.enclave.peers.is_empty());
+    }
+
+    #[test]
+    fn requires_reth_genesis_field() {
+        // An older deploy CLI that doesn't send the genesis must get a clean
+        // 400 here, not a node whose reth has no chain spec.
+        let toml_input = r#"
+[domain]
+name = "node1.example.com"
+email = "ops@example.com"
+
+[network]
+manifest_base64 = "eyJtYW5pZmVzdF92ZXJzaW9uIjogMX0K"
+"#;
+        let err = toml::from_str::<InitConfig>(toml_input).unwrap_err();
+        assert!(err.to_string().contains("reth_genesis_base64"));
     }
 
     #[test]
@@ -167,6 +197,7 @@ email = "ops@example.com"
 
 [network]
 manifest_base64 = "eyJ9"
+reth_genesis_base64 = "eyJjb25maWciOnt9fQ=="
 
 [bogus]
 field = "value"
@@ -188,6 +219,7 @@ log_level = "trace"
 
 [network]
 manifest_base64 = "eyJ9"
+reth_genesis_base64 = "eyJjb25maWciOnt9fQ=="
 "#;
         let err = toml::from_str::<InitConfig>(toml_input).unwrap_err();
         assert!(err.to_string().to_lowercase().contains("unknown"));
@@ -201,6 +233,7 @@ genesis_node = true
 
 [network]
 manifest_base64 = "eyJ9"
+reth_genesis_base64 = "eyJjb25maWciOnt9fQ=="
 "#;
         let err = toml::from_str::<InitConfig>(toml_input).unwrap_err();
         assert!(err.to_string().contains("domain"));

--- a/crates/tdx-init/src/error.rs
+++ b/crates/tdx-init/src/error.rs
@@ -12,6 +12,9 @@ pub enum TdxInitError {
     #[error("invalid network manifest: {0}")]
     InvalidManifest(String),
 
+    #[error("invalid reth genesis: {0}")]
+    InvalidRethGenesis(String),
+
     #[error("Server error: {0}")]
     ServerError(String),
 }
@@ -27,6 +30,10 @@ impl IntoResponse for TdxInitError {
             TdxInitError::InvalidManifest(msg) => (
                 StatusCode::BAD_REQUEST,
                 format!("invalid network manifest: {msg}"),
+            ),
+            TdxInitError::InvalidRethGenesis(msg) => (
+                StatusCode::BAD_REQUEST,
+                format!("invalid reth genesis: {msg}"),
             ),
             TdxInitError::Io(_) => (
                 StatusCode::INTERNAL_SERVER_ERROR,

--- a/crates/tdx-init/src/main.rs
+++ b/crates/tdx-init/src/main.rs
@@ -7,6 +7,7 @@ use tracing::info;
 mod config;
 mod error;
 mod manifest;
+mod reth_genesis;
 mod server;
 mod writer;
 

--- a/crates/tdx-init/src/manifest.rs
+++ b/crates/tdx-init/src/manifest.rs
@@ -65,10 +65,17 @@ struct ContractsManifest {
     authority: String,
 }
 
+/// A manifest that passed strict validation: the exact bytes to write (and
+/// hash) — callers must not transform them further — plus the fields other
+/// POST-time checks cross-reference, so they never re-parse the schema.
+#[derive(Debug)]
+pub struct ValidatedManifest {
+    pub bytes: Vec<u8>,
+    pub chain_id: u64,
+}
+
 /// Decode the `[network].manifest_base64` embed and strictly validate it.
-/// Returns the exact manifest bytes to write (and hash) — callers must not
-/// transform them further.
-pub fn decode_and_validate(manifest_base64: &str) -> Result<Vec<u8>> {
+pub fn decode_and_validate(manifest_base64: &str) -> Result<ValidatedManifest> {
     // Be forgiving about transport-layer line wrapping (PEM-style); this
     // changes nothing about the decoded bytes.
     let stripped: String = manifest_base64
@@ -80,8 +87,11 @@ pub fn decode_and_validate(manifest_base64: &str) -> Result<Vec<u8>> {
         .map_err(|e| {
             TdxInitError::InvalidManifest(format!("manifest_base64 is not valid base64: {e}"))
         })?;
-    validate_manifest_bytes(&bytes)?;
-    Ok(bytes)
+    let manifest = validate_manifest_bytes(&bytes)?;
+    Ok(ValidatedManifest {
+        bytes,
+        chain_id: manifest.eth.chain_id,
+    })
 }
 
 /// `network_id` presentation form: lowercase 0x-hex of SHA-256(bytes).
@@ -97,7 +107,7 @@ pub fn network_id_hex(manifest_bytes: &[u8]) -> String {
     out
 }
 
-fn validate_manifest_bytes(bytes: &[u8]) -> Result<()> {
+fn validate_manifest_bytes(bytes: &[u8]) -> Result<NetworkManifestV1> {
     // Probe the version before the strict parse: a future-version manifest
     // carries fields this schema doesn't know, and "unsupported
     // manifest_version 2" is the actionable error, not "unknown field".
@@ -148,7 +158,7 @@ fn validate_manifest_bytes(bytes: &[u8]) -> Result<()> {
         manifest.summit.namespace,
         network_id_hex(bytes),
     );
-    Ok(())
+    Ok(manifest)
 }
 
 fn check_hex(value: &str, nbytes: usize, field: &str) -> Result<()> {
@@ -183,9 +193,10 @@ mod tests {
 
     #[test]
     fn decodes_and_validates_fixture() {
-        let bytes = decode_and_validate(&b64(FIXTURE)).unwrap();
-        assert_eq!(bytes, FIXTURE, "decoded bytes must be verbatim");
-        assert_eq!(network_id_hex(&bytes), FIXTURE_NETWORK_ID);
+        let manifest = decode_and_validate(&b64(FIXTURE)).unwrap();
+        assert_eq!(manifest.bytes, FIXTURE, "decoded bytes must be verbatim");
+        assert_eq!(network_id_hex(&manifest.bytes), FIXTURE_NETWORK_ID);
+        assert_eq!(manifest.chain_id, 5124);
     }
 
     #[test]
@@ -193,8 +204,8 @@ mod tests {
         let mut wrapped = b64(FIXTURE);
         wrapped.insert(10, '\n');
         wrapped.insert(40, ' ');
-        let bytes = decode_and_validate(&wrapped).unwrap();
-        assert_eq!(bytes, FIXTURE);
+        let manifest = decode_and_validate(&wrapped).unwrap();
+        assert_eq!(manifest.bytes, FIXTURE);
     }
 
     // Byte-exactness: a cosmetic edit still parses but is a different network.

--- a/crates/tdx-init/src/reth_genesis.rs
+++ b/crates/tdx-init/src/reth_genesis.rs
@@ -1,0 +1,129 @@
+//! reth-genesis validation at POST time.
+//!
+//! The reth genesis JSON is the chain spec every node's reth boots from
+//! (`--chain /run/seismic/conf/reth-genesis.json`). It is fully
+//! deploy-time-computable (no TEE-born data) and identical on every node of a
+//! network. The manifest's `eth.genesis_hash = keccak(rlp(header))` pins the
+//! file's genesis *block* — the header and, through the state root, the
+//! alloc — but not its `config` section (fork schedule), which lies outside
+//! the header. tdx-init also cannot recompute that hash (it would need
+//! reth's own chain-spec parse path), so POST-time validation here is
+//! structural: valid JSON whose `config.chainId` matches the manifest's
+//! `eth.chain_id`. The block-hash commitment is enforced deploy-side
+//! (`manifest assemble` shells out to `seismic-reth genesis-hash`) and again
+//! at ceremony time (every node's reth must serve the pinned hash as block 0).
+//!
+//! Like the manifest, the file travels base64-encoded and is written
+//! verbatim — reth parses it itself, so tdx-init must not re-render it.
+
+use crate::error::{Result, TdxInitError};
+use base64::Engine;
+use serde::Deserialize;
+use tracing::info;
+
+/// Minimal probe: only the cross-checked field is parsed. The genesis
+/// schema belongs to reth — it is not re-validated here.
+#[derive(Deserialize)]
+struct GenesisProbe {
+    config: GenesisConfigProbe,
+}
+
+#[derive(Deserialize)]
+struct GenesisConfigProbe {
+    #[serde(rename = "chainId")]
+    chain_id: u64,
+}
+
+/// Decode the `[network].reth_genesis_base64` embed and validate it against
+/// the validated manifest's `eth.chain_id`. Returns the exact genesis bytes
+/// to write — callers must not transform them further.
+pub fn decode_and_validate(reth_genesis_base64: &str, manifest_chain_id: u64) -> Result<Vec<u8>> {
+    // Be forgiving about transport-layer line wrapping (PEM-style); this
+    // changes nothing about the decoded bytes.
+    let stripped: String = reth_genesis_base64
+        .chars()
+        .filter(|c| !c.is_ascii_whitespace())
+        .collect();
+    let bytes = base64::engine::general_purpose::STANDARD
+        .decode(stripped)
+        .map_err(|e| {
+            TdxInitError::InvalidRethGenesis(format!(
+                "reth_genesis_base64 is not valid base64: {e}"
+            ))
+        })?;
+
+    let genesis: GenesisProbe = serde_json::from_slice(&bytes).map_err(|e| {
+        TdxInitError::InvalidRethGenesis(format!(
+            "not a genesis JSON object with integer config.chainId: {e}"
+        ))
+    })?;
+    if genesis.config.chain_id != manifest_chain_id {
+        return Err(TdxInitError::InvalidRethGenesis(format!(
+            "config.chainId {} does not match the manifest's eth.chain_id {}",
+            genesis.config.chain_id, manifest_chain_id
+        )));
+    }
+
+    info!(
+        "reth genesis valid: chainId={} ({} bytes)",
+        genesis.config.chain_id,
+        bytes.len(),
+    );
+    Ok(bytes)
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use super::*;
+
+    /// Chain id matching the shared manifest fixture's `eth.chain_id`.
+    pub(crate) const FIXTURE_CHAIN_ID: u64 = 5124;
+
+    pub(crate) fn genesis_json(chain_id: u64) -> Vec<u8> {
+        format!(
+            r#"{{"config":{{"chainId":{chain_id},"mercuryTime":0}},"alloc":{{}},"gasLimit":"0x1c9c380"}}"#
+        )
+        .into_bytes()
+    }
+
+    fn b64(bytes: &[u8]) -> String {
+        base64::engine::general_purpose::STANDARD.encode(bytes)
+    }
+
+    #[test]
+    fn decodes_and_validates_matching_chain_id() {
+        let raw = genesis_json(FIXTURE_CHAIN_ID);
+        let bytes = decode_and_validate(&b64(&raw), FIXTURE_CHAIN_ID).unwrap();
+        assert_eq!(bytes, raw, "decoded bytes must be verbatim");
+    }
+
+    #[test]
+    fn tolerates_wrapped_base64_without_changing_bytes() {
+        let raw = genesis_json(FIXTURE_CHAIN_ID);
+        let mut wrapped = b64(&raw);
+        wrapped.insert(10, '\n');
+        wrapped.insert(20, ' ');
+        let bytes = decode_and_validate(&wrapped, FIXTURE_CHAIN_ID).unwrap();
+        assert_eq!(bytes, raw);
+    }
+
+    #[test]
+    fn rejects_invalid_base64() {
+        let err = decode_and_validate("not-base64!!!", FIXTURE_CHAIN_ID).unwrap_err();
+        assert!(err.to_string().contains("base64"), "{err}");
+    }
+
+    #[test]
+    fn rejects_non_genesis_json() {
+        let err = decode_and_validate(&b64(b"{\"alloc\":{}}"), FIXTURE_CHAIN_ID).unwrap_err();
+        assert!(err.to_string().contains("chainId"), "{err}");
+    }
+
+    #[test]
+    fn rejects_chain_id_mismatch() {
+        let raw = genesis_json(FIXTURE_CHAIN_ID + 1);
+        let err = decode_and_validate(&b64(&raw), FIXTURE_CHAIN_ID).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("5125") && msg.contains("5124"), "{msg}");
+    }
+}

--- a/crates/tdx-init/src/server.rs
+++ b/crates/tdx-init/src/server.rs
@@ -1,7 +1,11 @@
 use crate::config::InitConfig;
 use crate::error::{Result, TdxInitError};
 use axum::{
-    Router, extract::State, http::StatusCode, response::IntoResponse, response::Response,
+    Router,
+    extract::{DefaultBodyLimit, State},
+    http::StatusCode,
+    response::IntoResponse,
+    response::Response,
     routing::post,
 };
 use std::sync::Arc;
@@ -25,6 +29,10 @@ pub async fn run_initialization_server() -> Result<InitConfig> {
 
     let app = Router::new()
         .route("/", post(handle_config))
+        // axum's 2 MiB default is too tight for the config since it embeds
+        // the reth genesis: a mainnet-sized alloc is ~1 MiB of JSON, ~1.4 MiB
+        // as base64, before the rest of the payload.
+        .layer(DefaultBodyLimit::max(16 * 1024 * 1024))
         .with_state(state);
 
     // This listener is unauthenticated and first-POST-wins. An attacker reaching :8080
@@ -57,10 +65,14 @@ pub async fn run_initialization_server() -> Result<InitConfig> {
 async fn handle_config(State(state): State<AppState>, body: String) -> Result<Response> {
     let config: InitConfig = toml::from_str(&body)?;
 
-    // Validate the manifest while the operator's POST is still waiting on a
-    // response: a bad (or absent) manifest must 400 the deploy, not fail at boot
-    // when enclave-server tries to use it.
-    crate::manifest::decode_and_validate(&config.network.manifest_base64)?;
+    // Validate the network artifacts while the operator's POST is still
+    // waiting on a response: a bad (or absent) manifest or reth genesis must
+    // 400 the deploy, not fail at boot when enclave-server/reth try to use them.
+    let manifest = crate::manifest::decode_and_validate(&config.network.manifest_base64)?;
+    crate::reth_genesis::decode_and_validate(
+        &config.network.reth_genesis_base64,
+        manifest.chain_id,
+    )?;
 
     let mut sender_guard = state.config_sender.lock().await;
     match sender_guard.take() {

--- a/crates/tdx-init/src/writer.rs
+++ b/crates/tdx-init/src/writer.rs
@@ -22,25 +22,39 @@ pub async fn write_service_configs(conf_dir: &Path, config: &InitConfig) -> Resu
     fs::create_dir_all(conf_dir).await?;
     write_domain_env(conf_dir, config).await?;
     write_enclave_env(conf_dir, config).await?;
-    write_network_manifest(conf_dir, &config.network).await?;
+    let manifest = crate::manifest::decode_and_validate(&config.network.manifest_base64)?;
+    let genesis = crate::reth_genesis::decode_and_validate(
+        &config.network.reth_genesis_base64,
+        manifest.chain_id,
+    )?;
+    write_network_manifest(conf_dir, &manifest).await?;
+    write_reth_genesis(conf_dir, &genesis).await?;
     Ok(())
 }
 
-/// Write the decoded manifest bytes verbatim (byte-exactness rule):
+/// Write the validated manifest bytes verbatim (byte-exactness rule):
 /// consumers derive `network_id` by hashing this file themselves, so any
 /// re-rendering here would silently change the network's identity.
 async fn write_network_manifest(
     conf_dir: &Path,
-    network: &crate::config::NetworkConfig,
+    manifest: &crate::manifest::ValidatedManifest,
 ) -> Result<()> {
     let path = conf_dir.join("network-manifest.json");
-    let bytes = crate::manifest::decode_and_validate(&network.manifest_base64)?;
-    write_with_mode(&path, &bytes, DEFAULT_FILE_MODE).await?;
+    write_with_mode(&path, &manifest.bytes, DEFAULT_FILE_MODE).await?;
     info!(
         "wrote {} (network_id {})",
         path.display(),
-        crate::manifest::network_id_hex(&bytes),
+        crate::manifest::network_id_hex(&manifest.bytes),
     );
+    Ok(())
+}
+
+/// Write the validated reth genesis bytes verbatim: reth parses the file
+/// itself (`--chain`), so tdx-init never re-renders it.
+async fn write_reth_genesis(conf_dir: &Path, genesis_bytes: &[u8]) -> Result<()> {
+    let path = conf_dir.join("reth-genesis.json");
+    write_with_mode(&path, genesis_bytes, DEFAULT_FILE_MODE).await?;
+    info!("wrote {}", path.display());
     Ok(())
 }
 
@@ -97,6 +111,12 @@ mod tests {
                 manifest_base64: base64::engine::general_purpose::STANDARD.encode(include_bytes!(
                     "../../seismic-attestation/fixtures/network-manifest-v1.json"
                 )),
+                // A genesis whose chainId matches the fixture manifest's.
+                reth_genesis_base64: base64::engine::general_purpose::STANDARD.encode(
+                    crate::reth_genesis::tests::genesis_json(
+                        crate::reth_genesis::tests::FIXTURE_CHAIN_ID,
+                    ),
+                ),
             },
         }
     }
@@ -150,12 +170,26 @@ mod tests {
         .concat();
         cfg.network = NetworkConfig {
             manifest_base64: base64::engine::general_purpose::STANDARD.encode(&raw),
+            ..cfg.network
         };
 
         write_service_configs(tmp.path(), &cfg).await.unwrap();
 
         let written = std::fs::read(tmp.path().join("network-manifest.json")).unwrap();
         assert_eq!(written, raw);
+    }
+
+    #[tokio::test]
+    async fn writes_reth_genesis_verbatim() {
+        let tmp = TempDir::new().unwrap();
+        let cfg = sample_config(false, vec![]);
+
+        write_service_configs(tmp.path(), &cfg).await.unwrap();
+
+        let written = std::fs::read(tmp.path().join("reth-genesis.json")).unwrap();
+        let expected =
+            crate::reth_genesis::tests::genesis_json(crate::reth_genesis::tests::FIXTURE_CHAIN_ID);
+        assert_eq!(written, expected);
     }
 
     #[tokio::test]


### PR DESCRIPTION
The reth chain spec was baked into the node image (mkosi copied seismic-reth's dev.json to /usr/share/seismic-reth/genesis.json), so any network-shape change forced an image rebuild and one measured image could only serve one network. The genesis is fully deploy-time- computable (no TEE-born data) and needed by every node's reth — joiners included — so it rides in the per-boot config POST next to the manifest, not in the image.

[network] gains a required reth_genesis_base64: base64 of the exact reth-genesis.json bytes, written verbatim to
/run/seismic/conf/reth-genesis.json for reth's --chain (the reth.service flip and un-baking land in seismic-images). Required, not optional: a node booted without it has no chain spec and reth crash-loops, so an older deploy CLI's POST now 400s at deploy time instead — same rationale as requiring [network] itself.

POST-time validation is structural: valid JSON whose config.chainId matches the manifest's eth.chain_id. tdx-init can't recompute eth.genesis_hash (that needs reth's own chain-spec parse path — and the hash pins the genesis block, not the file's config section anyway); the block-hash commitment stays deploy-side (manifest assemble) and at ceremony time (the block-0 assert against every node's reth).