### PR TITLE
refactor: extract root-key custody into a seismic-key-custodian crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5168,7 +5168,6 @@ dependencies = [
 name = "seismic-enclave-server"
 version = "0.1.0"
 dependencies = [
- "aes-gcm",
  "alloy",
  "anyhow",
  "az-tdx-vtpm",
@@ -5177,26 +5176,38 @@ dependencies = [
  "dcap-rs",
  "enclave-contract",
  "hex",
- "hkdf",
  "jsonrpsee",
  "libc",
  "openssl",
  "rand 0.9.2",
  "reqwest 0.11.27",
- "schnorrkel",
  "secp256k1",
  "seismic-attestation",
  "seismic-enclave",
+ "seismic-key-custodian",
  "serde",
  "serde_json",
  "serial_test",
- "sha2",
  "tempfile",
  "tokio",
  "tracing",
  "tracing-subscriber",
  "urlencoding",
  "x509-parser 0.15.1",
+]
+
+[[package]]
+name = "seismic-key-custodian"
+version = "0.1.0"
+dependencies = [
+ "aes-gcm",
+ "anyhow",
+ "hkdf",
+ "rand 0.9.2",
+ "schnorrkel",
+ "secp256k1",
+ "seismic-enclave-crypto",
+ "sha2",
  "zeroize",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "crates/enclave-server",
     "crates/enclave-contract", "crates/enclave",
     "crates/enclave-crypto",
+    "crates/key-custodian",
     "crates/network-manifest",
     "crates/seismic-attestation",
     "crates/tdx-init",
@@ -24,6 +25,7 @@ enclave-contract = { path = "crates/enclave-contract" }
 seismic-attestation = { path = "crates/seismic-attestation" }
 seismic-enclave = {path = "crates/enclave" }
 seismic-enclave-crypto = { path = "crates/enclave-crypto" }
+seismic-key-custodian = { path = "crates/key-custodian" }
 seismic-network-manifest = { path = "crates/network-manifest" }
 
 # Other deps

--- a/crates/enclave-server/Cargo.toml
+++ b/crates/enclave-server/Cargo.toml
@@ -20,32 +20,28 @@ path = "src/main.rs"
 [dependencies]
 seismic-enclave.workspace = true
 seismic-attestation.workspace = true
+seismic-key-custodian.workspace = true
 enclave-contract.workspace = true
 
 alloy.workspace = true
 openssl.workspace = true
 chrono = "0.4.40"
 hex.workspace = true
-hkdf.workspace = true
 jsonrpsee.workspace = true
 tokio.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 anyhow.workspace = true
 secp256k1.workspace = true
-schnorrkel.workspace = true
 dcap-rs.workspace = true
 libc.workspace = true
 x509-parser.workspace = true
 reqwest.workspace = true
 urlencoding.workspace = true
 clap.workspace = true
-aes-gcm.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 rand.workspace = true
-zeroize.workspace = true
-sha2.workspace = true
 
 # az-tdx-vtpm pulls in tss-esapi-sys, which links against the Linux tpm2-tss
 # user-space stack and only ships prebuilt bindings for Linux tuples (plus

--- a/crates/enclave-server/src/bootstrap.rs
+++ b/crates/enclave-server/src/bootstrap.rs
@@ -39,56 +39,22 @@
 //! - `wrapped` (in the response binding) and the request binding (as AEAD AAD)
 //!   — bind the ciphertext to the handshake it belongs to.
 //!
-//! The root key itself only ever crosses the wire AEAD-sealed under the
+//! The root key itself only ever crosses the wire AEAD-wrapped under the
 //! ECDH-derived key; the AEAD tag plus the responder quote let the requester
 //! reject anything not produced by a genuine peer enclave for this request.
 
-use anyhow::{Context, Result, anyhow};
+use anyhow::{Context, Result};
 use rand::{TryRngCore as _, rngs::OsRng};
+use secp256k1::{PublicKey, SecretKey};
 use seismic_attestation::{
     AttestationExchangeMessage, AttestationType, NetworkId, SeismicMeasurementPolicy,
     bindings::{binding64_from_digest32, root_key_request_binding, root_key_response_binding},
     generate_evidence, verify_evidence,
 };
-use seismic_enclave::{
-    AESGCM_NONCE_SIZE, Nonce, aes_decrypt_aead, aes_encrypt_aead, derive_aes_key,
-    secp256k1::{PublicKey, Secp256k1, SecretKey, ecdh::SharedSecret},
+use seismic_key_custodian::{
+    Custodian, EphemeralKeypair, VerifiedPeerAuthorization, unwrap_root_key,
 };
 use serde::{Deserialize, Serialize};
-
-/// A freshly minted ephemeral secp256k1 ECDH keypair for one handshake.
-///
-/// Held only for the lifetime of a single exchange and dropped after; never
-/// derived from or mixed with the root key, so a leak reveals nothing about it.
-struct EphemeralKeypair {
-    sk: SecretKey,
-    pk: PublicKey,
-}
-
-impl EphemeralKeypair {
-    /// Draw the scalar from the OS CSPRNG (like `KeyManager::new_as_genesis`),
-    /// retrying on the negligible chance of an out-of-range scalar. We seed from
-    /// bytes rather than secp256k1's own `generate_keypair` because that helper
-    /// wants a `rand` 0.8 RNG, while this workspace is on `rand` 0.9.
-    fn generate() -> Self {
-        let secp = Secp256k1::new();
-        loop {
-            let mut bytes = [0u8; 32];
-            OsRng
-                .try_fill_bytes(&mut bytes)
-                .expect("OS RNG must produce ephemeral key material");
-            if let Ok(sk) = SecretKey::from_byte_array(&bytes) {
-                let pk = PublicKey::from_secret_key(&secp, &sk);
-                return Self { sk, pk };
-            }
-        }
-    }
-
-    /// Compressed 33-byte SEC1 encoding, the form the binding helpers hash.
-    fn pk_compressed(&self) -> [u8; 33] {
-        self.pk.serialize()
-    }
-}
 
 /// The requester's half of the handshake: a fresh nonce + ephemeral pubkey,
 /// attested by `evidence` over [`root_key_request_binding`].
@@ -112,7 +78,8 @@ pub struct RootKeyRequest {
 pub struct RootKeyResponse {
     /// Responder ephemeral ECDH pubkey.
     pub eph_pk_a: PublicKey,
-    /// `nonce(12) || AES-256-GCM(root_key)`; see [`wrap_root_key_for_peer`].
+    /// `nonce(12) || AES-256-GCM(root_key)`; see
+    /// [`Custodian::wrap_root_key_for_peer`].
     pub wrapped: Vec<u8>,
     /// Responder attestation over `root_key_response_binding(network_id,
     /// nonce_b, eph_pk_a, wrapped)`.
@@ -146,18 +113,19 @@ pub fn build_root_key_request(
     Ok((request, eph.sk))
 }
 
-/// Responder step: verify the requester's evidence, then return the root key
-/// AEAD-wrapped under a fresh ECDH key and the responder's own attestation.
+/// Responder step: verify the requester's evidence, have the custodian wrap
+/// the root key for it, and attest the response.
 ///
-/// `root_key` is consumed only to seal it; it never leaves this function in the
-/// clear. `policy` is the responder's measurement allowlist (the requester must
-/// be running an admitted image). `network_id` is the responder's own —
-/// verification recomputes the requester's binding from it, so a quote for a
-/// different network fails the binding check.
+/// The root key itself never appears here: only the custodian touches it, and
+/// only to wrap it once the requester's evidence has verified. `policy` is the
+/// responder's measurement allowlist (the requester must be running an
+/// admitted image). `network_id` is the responder's own — verification
+/// recomputes the requester's binding from it, so a quote for a different
+/// network fails the binding check.
 pub async fn answer_root_key_request(
     request: &RootKeyRequest,
     network_id: &NetworkId,
-    root_key: &[u8; 32],
+    custodian: &Custodian,
     policy: SeismicMeasurementPolicy,
     attestation_type: AttestationType,
 ) -> Result<RootKeyResponse> {
@@ -173,24 +141,29 @@ pub async fn answer_root_key_request(
     .await
     .context("verifying requester attestation evidence")?;
 
-    // 2. Wrap the root key for the requester's attested ephemeral key.
-    let eph_a = EphemeralKeypair::generate();
-    let wrapped =
-        wrap_root_key_for_peer(&eph_a.sk, &request.eph_pk_b, root_key, network_id, request)?;
+    // 2. Verification succeeded: authorize the custodian to wrap the root key
+    //    to the requester's attested ephemeral key, with the verified request
+    //    binding as the AEAD AAD.
+    let auth = VerifiedPeerAuthorization {
+        root_key_request_binding: expected,
+    };
+    let wrap = custodian
+        .wrap_root_key_for_peer(&auth, &request.eph_pk_b)
+        .context("wrapping root key for peer")?;
 
     // 3. Attest over the response transcript, committing to the ciphertext.
     let binding = root_key_response_binding(
         network_id,
         &request.nonce_b,
-        &eph_a.pk_compressed(),
-        &wrapped,
+        &wrap.responder_eph_pk.serialize(),
+        &wrap.wrapped,
     );
     let evidence = generate_evidence(attestation_type, binding64_from_digest32(binding))
         .context("generating responder attestation evidence")?;
 
     Ok(RootKeyResponse {
-        eph_pk_a: eph_a.pk,
-        wrapped,
+        eph_pk_a: wrap.responder_eph_pk,
+        wrapped: wrap.wrapped,
         evidence,
     })
 }
@@ -226,173 +199,14 @@ pub async fn unwrap_root_key_from_response(
     .await
     .context("verifying responder attestation evidence")?;
 
-    // 2. ECDH to the responder's ephemeral key, then AEAD-open.
+    // 2. ECDH to the responder's ephemeral key, then AEAD-open, with the
+    //    request-binding AAD recomputed from our own copies of the fields.
+    let request_binding =
+        root_key_request_binding(network_id, &request.nonce_b, &request.eph_pk_b.serialize());
     unwrap_root_key(
         eph_sk_b,
         &response.eph_pk_a,
         &response.wrapped,
-        network_id,
-        request,
+        &request_binding,
     )
-}
-
-/// AEAD-seal `root_key` for a peer's ephemeral ECDH key.
-///
-/// Output layout: `nonce(12 bytes) || AES-256-GCM ciphertext+tag`. The AEAD AAD
-/// is the [`root_key_request_binding`] digest, so the sealed key is
-/// cryptographically tied to this exact request transcript (network_id,
-/// nonce_b, eph_pk_b) — a wrapped blob can't be lifted onto a different
-/// handshake even before the responder quote is checked.
-fn wrap_root_key_for_peer(
-    eph_sk_a: &SecretKey,
-    eph_pk_b: &PublicKey,
-    root_key: &[u8; 32],
-    network_id: &NetworkId,
-    request: &RootKeyRequest,
-) -> Result<Vec<u8>> {
-    let aes_key = derive_handshake_key(eph_sk_a, eph_pk_b)?;
-    let aad = root_key_request_binding(network_id, &request.nonce_b, &request.eph_pk_b.serialize());
-
-    let nonce = Nonce::new_rand();
-    let ciphertext = aes_encrypt_aead(&aes_key, root_key, nonce.clone(), &aad)
-        .context("sealing root key for peer")?;
-
-    let mut wrapped = Vec::with_capacity(AESGCM_NONCE_SIZE + ciphertext.len());
-    wrapped.extend_from_slice(&nonce.0);
-    wrapped.extend_from_slice(&ciphertext);
-    Ok(wrapped)
-}
-
-/// Inverse of [`wrap_root_key_for_peer`]: ECDH + AEAD-open, with the same
-/// request-binding AAD recomputed from the requester's own copies.
-fn unwrap_root_key(
-    eph_sk_b: &SecretKey,
-    eph_pk_a: &PublicKey,
-    wrapped: &[u8],
-    network_id: &NetworkId,
-    request: &RootKeyRequest,
-) -> Result<[u8; 32]> {
-    if wrapped.len() < AESGCM_NONCE_SIZE {
-        return Err(anyhow!("wrapped root key too short to contain a nonce"));
-    }
-    let (nonce_bytes, ciphertext) = wrapped.split_at(AESGCM_NONCE_SIZE);
-    let nonce: [u8; AESGCM_NONCE_SIZE] = nonce_bytes.try_into().expect("checked length above");
-
-    let aes_key = derive_handshake_key(eph_sk_b, eph_pk_a)?;
-    let aad = root_key_request_binding(network_id, &request.nonce_b, &request.eph_pk_b.serialize());
-
-    let plaintext = aes_decrypt_aead(&aes_key, ciphertext, nonce, &aad)
-        .context("opening wrapped root key (AEAD tag mismatch)")?;
-    plaintext
-        .try_into()
-        .map_err(|_| anyhow!("unwrapped root key is not 32 bytes"))
-}
-
-/// Derive the symmetric handshake key from an ECDH shared secret.
-///
-/// Reuses [`derive_aes_key`] so wrap and unwrap stay in lockstep with the rest
-/// of the enclave's ECDH-AES key schedule.
-fn derive_handshake_key(
-    sk: &SecretKey,
-    pk: &PublicKey,
-) -> Result<aes_gcm::Key<aes_gcm::Aes256Gcm>> {
-    let shared = SharedSecret::new(pk, sk);
-    derive_aes_key(&shared).map_err(|e| anyhow!("deriving handshake AES key: {e}"))
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    // End-to-end wrap/unwrap with matching transcripts recovers the key; this
-    // exercises the ECDH + AEAD path without needing real attestation evidence.
-    #[test]
-    fn wrap_then_unwrap_roundtrips() {
-        let network_id = NetworkId::from_bytes([0x11; 32]);
-        let root_key = [0x42u8; 32];
-
-        let requester = EphemeralKeypair::generate();
-        let request = RootKeyRequest {
-            nonce_b: [0x33; 32],
-            eph_pk_b: requester.pk,
-            evidence: AttestationExchangeMessage::without_attestation(),
-        };
-
-        let responder = EphemeralKeypair::generate();
-        let wrapped = wrap_root_key_for_peer(
-            &responder.sk,
-            &requester.pk,
-            &root_key,
-            &network_id,
-            &request,
-        )
-        .unwrap();
-
-        let recovered = unwrap_root_key(
-            &requester.sk,
-            &responder.pk,
-            &wrapped,
-            &network_id,
-            &request,
-        )
-        .unwrap();
-        assert_eq!(recovered, root_key);
-    }
-
-    // A wrapped blob is bound to its request transcript via the AEAD AAD: open
-    // it under a different nonce_b and the tag check must fail.
-    #[test]
-    fn unwrap_rejects_foreign_request_binding() {
-        let network_id = NetworkId::from_bytes([0x11; 32]);
-        let root_key = [0x42u8; 32];
-
-        let requester = EphemeralKeypair::generate();
-        let request = RootKeyRequest {
-            nonce_b: [0x33; 32],
-            eph_pk_b: requester.pk,
-            evidence: AttestationExchangeMessage::without_attestation(),
-        };
-        let responder = EphemeralKeypair::generate();
-        let wrapped = wrap_root_key_for_peer(
-            &responder.sk,
-            &requester.pk,
-            &root_key,
-            &network_id,
-            &request,
-        )
-        .unwrap();
-
-        let mut tampered = request.clone();
-        tampered.nonce_b = [0xFF; 32];
-        let err = unwrap_root_key(
-            &requester.sk,
-            &responder.pk,
-            &wrapped,
-            &network_id,
-            &tampered,
-        )
-        .unwrap_err();
-        assert!(err.to_string().contains("AEAD tag mismatch"));
-    }
-
-    // Wrong network_id changes the AAD just like a wrong nonce does.
-    #[test]
-    fn unwrap_rejects_foreign_network() {
-        let net_a = NetworkId::from_bytes([0x11; 32]);
-        let net_b = NetworkId::from_bytes([0x22; 32]);
-        let root_key = [0x42u8; 32];
-
-        let requester = EphemeralKeypair::generate();
-        let request = RootKeyRequest {
-            nonce_b: [0x33; 32],
-            eph_pk_b: requester.pk,
-            evidence: AttestationExchangeMessage::without_attestation(),
-        };
-        let responder = EphemeralKeypair::generate();
-        let wrapped =
-            wrap_root_key_for_peer(&responder.sk, &requester.pk, &root_key, &net_a, &request)
-                .unwrap();
-
-        assert!(unwrap_root_key(&requester.sk, &responder.pk, &wrapped, &net_b, &request).is_err());
-    }
 }

--- a/crates/enclave-server/src/lib.rs
+++ b/crates/enclave-server/src/lib.rs
@@ -1,6 +1,5 @@
 mod attestation;
 mod bootstrap;
-mod key_manager;
 mod luks_keys;
 mod luks_status;
 mod network;

--- a/crates/enclave-server/src/luks_keys.rs
+++ b/crates/enclave-server/src/luks_keys.rs
@@ -1,16 +1,15 @@
 //! Hand off LUKS-related derived keys to `setup-persistent-luks` at startup. See
 //! https://github.com/SeismicSystems/seismic-images/blob/29bb1f4e39/modules/seismic/mkosi.extra/usr/bin/setup-persistent-luks
 //!
-//! Writes 64 raw bytes — `storage_key (32B) || header_mac_key (32B)` —
-//! to a tmpfs file owned by the enclave user. The LUKS-setup script
+//! The custodian writes 64 raw bytes — `storage_key (32B) || header_mac_key
+//! (32B)` — to a tmpfs file owned by the enclave user. The LUKS-setup script
 //! reads the file, uses both keys, and `shred -u`s the file after
-//! `cryptsetup open` succeeds. The directory itself is created by
-//! systemd's `RuntimeDirectory=` in enclave.service before this
-//! process starts.
+//! `cryptsetup open` succeeds. The directory itself is created by systemd's
+//! `RuntimeDirectory=` in enclave.service before this process starts.
 
-use crate::key_manager::{KeyManager, KeyPurpose};
-use anyhow::{Context as _, Result};
-use std::{fs, fs::OpenOptions, io::Write as _, os::unix::fs::OpenOptionsExt as _, path::Path};
+use anyhow::Result;
+use seismic_key_custodian::Custodian;
+use std::path::Path;
 use tracing::info;
 
 /// Drop-zone for the LUKS keys. Hardcoded to match the `RuntimeDirectory=`
@@ -18,40 +17,11 @@ use tracing::info;
 /// systemd before this process starts.
 const LUKS_KEYS_PATH: &str = "/run/seismic/enclave/luks-keys";
 
-/// Storage and header-MAC keys are pinned at epoch 0; they are never rotated.
-const KEYS_EPOCH_0: u64 = 0;
-
-/// Derive `storage_key` + `header_mac_key` from the current root_key
-/// and write them to a tmpfs file for setup-persistent-luks to read.
+/// Have the custodian write the LUKS keyfile to the agreed drop-zone.
 /// Errors are fatal: without these keys reaching the LUKS-setup script,
 /// `/persistent` won't mount and the node can't proceed.
-pub fn write_keys_for_luks_setup(km: &KeyManager) -> Result<()> {
-    let storage_key = km.derive_purpose_key(KeyPurpose::Storage, KEYS_EPOCH_0)?;
-    let header_mac_key = km.derive_purpose_key(KeyPurpose::LuksHeaderMac, KEYS_EPOCH_0)?;
-
-    let mut buf = [0u8; 64];
-    buf[..32].copy_from_slice(storage_key.as_ref());
-    buf[32..].copy_from_slice(header_mac_key.as_ref());
-
-    // Write to a tmp file and rename into place: the consumer script `setup-persistent-luks`
-    // polls for this exact path, so it must never observe a partially-written file.
-    let path = Path::new(LUKS_KEYS_PATH);
-    let tmp = path.with_extension("tmp");
-    // delete in case a previous run left a tmp file (crashed before deleting it)
-    let _ = fs::remove_file(&tmp);
-    let mut f = OpenOptions::new()
-        .write(true)
-        .create_new(true)
-        .mode(0o400)
-        .open(&tmp)
-        .with_context(|| format!("creating {}", tmp.display()))?;
-    f.write_all(&buf)?;
-    f.sync_all()?;
-    drop(f);
-    fs::rename(&tmp, path).with_context(|| format!("renaming {} into place", tmp.display()))?;
-    info!(
-        "wrote LUKS keys for setup-persistent-luks at {}",
-        path.display()
-    );
+pub fn write_keys_for_luks_setup(custodian: &Custodian) -> Result<()> {
+    custodian.write_luks_keyfile(Path::new(LUKS_KEYS_PATH))?;
+    info!("wrote LUKS keys for setup-persistent-luks at {LUKS_KEYS_PATH}");
     Ok(())
 }

--- a/crates/enclave-server/src/server.rs
+++ b/crates/enclave-server/src/server.rs
@@ -5,7 +5,6 @@ use crate::{
         RootKeyRequest, RootKeyResponse, answer_root_key_request, build_root_key_request,
         unwrap_root_key_from_response,
     },
-    key_manager::KeyManager,
     luks_keys,
     network::{NETWORK_MANIFEST_PATH, load_network_id},
     utils::anyhow_to_rpc_error,
@@ -21,6 +20,7 @@ use seismic_enclave::{
     AttestationGetEvidenceResponse, GetPurposeKeysResponse, LuksProvisioningStatus,
     TdxQuoteRpcClient as _, api::TdxQuoteRpcServer,
 };
+use seismic_key_custodian::Custodian;
 use std::{net::SocketAddr, time::Duration};
 use tracing::{info, warn};
 
@@ -33,7 +33,7 @@ const TX_IO_BINDING_EPOCH: u64 = 0;
 
 pub struct TdxQuoteServer {
     attestation_agent: AttestationAgent,
-    key_manager: KeyManager,
+    custodian: Custodian,
     /// This node's network identity: `H(network-manifest.json)`. Every
     /// attestation binding this server mints or verifies is scoped to it.
     network_id: NetworkId,
@@ -42,12 +42,12 @@ pub struct TdxQuoteServer {
 impl TdxQuoteServer {
     pub fn new(
         attestation_agent: AttestationAgent,
-        key_manager: KeyManager,
+        custodian: Custodian,
         network_id: NetworkId,
     ) -> Self {
         Self {
             attestation_agent,
-            key_manager,
+            custodian,
             network_id,
         }
     }
@@ -63,10 +63,10 @@ impl TdxQuoteRpcServer for TdxQuoteServer {
     /// Get the secp256k1 public key
     async fn get_purpose_keys(&self, epoch: u64) -> RpcResult<GetPurposeKeysResponse> {
         Ok(GetPurposeKeysResponse {
-            tx_io_sk: self.key_manager.get_tx_io_sk(epoch),
-            tx_io_pk: self.key_manager.get_tx_io_pk(epoch),
-            snapshot_key_bytes: self.key_manager.get_snapshot_key(epoch).into(),
-            rng_keypair: self.key_manager.get_rng_keypair(epoch),
+            tx_io_sk: self.custodian.get_tx_io_sk(epoch),
+            tx_io_pk: self.custodian.get_tx_io_pk(epoch),
+            snapshot_key_bytes: self.custodian.get_snapshot_key(epoch).into(),
+            rng_keypair: self.custodian.get_rng_keypair(epoch),
         })
     }
 
@@ -75,10 +75,7 @@ impl TdxQuoteRpcServer for TdxQuoteServer {
     /// The quote commits to `tx_io_binding(network_id, tx_io_pk, epoch)`, so a
     /// verifier learns the attested node holds this tx_io key on this network.
     async fn get_attestation_evidence(&self) -> RpcResult<AttestationGetEvidenceResponse> {
-        let tx_io_pk = self
-            .key_manager
-            .get_tx_io_pk(TX_IO_BINDING_EPOCH)
-            .serialize();
+        let tx_io_pk = self.custodian.get_tx_io_pk(TX_IO_BINDING_EPOCH).serialize();
         let binding = seismic_attestation::bindings::tx_io_binding(
             &self.network_id,
             &tx_io_pk,
@@ -114,7 +111,7 @@ impl TdxQuoteRpcServer for TdxQuoteServer {
         let response = answer_root_key_request(
             &request,
             &self.network_id,
-            &self.key_manager.get_root_key(),
+            &self.custodian,
             bootstrap_measurement_policy(),
             ATTESTATION_TYPE,
         )
@@ -141,9 +138,9 @@ pub async fn start_server(addr: SocketAddr, args: Args) -> anyhow::Result<()> {
     let network_id = load_network_id(NETWORK_MANIFEST_PATH)?;
     info!("Derived network_id {network_id} from {NETWORK_MANIFEST_PATH}");
 
-    let key_manager = if args.genesis_node {
+    let custodian = if args.genesis_node {
         info!("Starting as genesis node; generating fresh network root key");
-        KeyManager::new_as_genesis()?
+        Custodian::new_as_genesis()?
     } else {
         if args.peers.is_empty() {
             anyhow::bail!(
@@ -167,12 +164,12 @@ pub async fn start_server(addr: SocketAddr, args: Args) -> anyhow::Result<()> {
     // (seismic-images script) via a tmpfs file. Fatal on failure — without
     // these keys reaching the LUKS-setup script, /persistent can't
     // mount and the node can't proceed past this boot.
-    luks_keys::write_keys_for_luks_setup(&key_manager)?;
+    luks_keys::write_keys_for_luks_setup(&custodian)?;
 
     let server = ServerBuilder::default().build(addr).await?;
 
     let handle =
-        server.start(TdxQuoteServer::new(attestation_agent, key_manager, network_id).into_rpc());
+        server.start(TdxQuoteServer::new(attestation_agent, custodian, network_id).into_rpc());
 
     info!("TDX Quote JSON-RPC Server started at {}", addr);
 
@@ -188,14 +185,14 @@ pub async fn start_server(addr: SocketAddr, args: Args) -> anyhow::Result<()> {
 /// POST it, then verify the peer's response quote and AEAD-open the wrapped
 /// key. A fresh ephemeral key per attempt means a failed exchange leaks nothing
 /// reusable.
-pub async fn fetch_root_key_from_peers(peers: Vec<String>, network_id: &NetworkId) -> KeyManager {
+pub async fn fetch_root_key_from_peers(peers: Vec<String>, network_id: &NetworkId) -> Custodian {
     info!("Starting root key fetching from peers");
     loop {
         for peer in &peers {
             match try_fetch_root_key_from_peer(peer, network_id).await {
                 Ok(root_key) => {
-                    info!("Key received from {peer}. Starting Key manager");
-                    return KeyManager::new(root_key);
+                    info!("Key received from {peer}. Starting key custodian");
+                    return Custodian::new(root_key);
                 }
                 Err(e) => {
                     warn!(

--- a/crates/key-custodian/Cargo.toml
+++ b/crates/key-custodian/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "seismic-key-custodian"
+edition.workspace = true
+version.workspace = true
+repository.workspace = true
+homepage.workspace = true
+authors.workspace = true
+license.workspace = true
+readme.workspace = true
+description = "RAM-only custodian of the Seismic network root key"
+
+[dependencies]
+seismic-enclave-crypto.workspace = true
+
+aes-gcm.workspace = true
+anyhow.workspace = true
+hkdf.workspace = true
+rand.workspace = true
+schnorrkel.workspace = true
+secp256k1.workspace = true
+sha2.workspace = true
+zeroize.workspace = true

--- a/crates/key-custodian/src/custodian.rs
+++ b/crates/key-custodian/src/custodian.rs
@@ -18,9 +18,11 @@ impl AsRef<[u8]> for Key {
     }
 }
 
-#[derive(Clone)]
-pub struct KeyManager {
-    root_key: Key,
+/// Holder of the network root key; every other secret is derived from it on
+/// demand. Deliberately not `Clone`: exactly one copy per process, dropped
+/// (and zeroized) with the custodian itself.
+pub struct Custodian {
+    pub(crate) root_key: Key,
 }
 
 /// Enum representing the intended usage ("purpose") of a derived key.
@@ -32,7 +34,7 @@ pub enum KeyPurpose {
     /// LUKS volume unlock key.
     Storage,
     /// HMAC key for verifying the LUKS2 header against tampering:
-    /// https://blog.trailofbits.com/2025/10/30/vulnerabilities-in-luks2-disk-encryption-for-confidential-vms/
+    /// <https://blog.trailofbits.com/2025/10/30/vulnerabilities-in-luks2-disk-encryption-for-confidential-vms/>
     /// Used by setup-persistent-luks to MAC `segments + keyslots + digests`
     /// and store the result as a custom LUKS2 token; verified on every subsequent boot
     /// before `cryptsetup open`.
@@ -57,19 +59,22 @@ impl KeyPurpose {
     }
 }
 
-impl KeyManager {
+impl Custodian {
+    /// Install an already-obtained root key (the joining-node path: the caller
+    /// ran the attested bootstrap handshake and unwrapped the peer's response).
     pub fn new(root_key: [u8; 32]) -> Self {
         Self {
             root_key: Key(root_key),
         }
     }
 
+    /// Generate a fresh root key from the OS CSPRNG (the genesis-node path).
     pub fn new_as_genesis() -> Result<Self> {
         let mut rng = OsRng;
         let mut rng_bytes = [0u8; 32];
         rng.try_fill_bytes(&mut rng_bytes)?;
 
-        let km = KeyManager::new(rng_bytes);
+        let km = Custodian::new(rng_bytes);
         Ok(km)
     }
 
@@ -93,7 +98,7 @@ impl KeyManager {
     pub fn get_tx_io_sk(&self, epoch: u64) -> secp256k1::SecretKey {
         let key = self
             .derive_purpose_key(KeyPurpose::TxIo, epoch)
-            .expect("KeyManager should always have a snapshot key");
+            .expect("purpose key derivation must succeed");
         secp256k1::SecretKey::from_slice(key.as_ref())
             .expect("retrieved secp256k1 secret key should be valid")
     }
@@ -102,7 +107,7 @@ impl KeyManager {
     pub fn get_tx_io_pk(&self, epoch: u64) -> secp256k1::PublicKey {
         let key = self
             .derive_purpose_key(KeyPurpose::TxIo, epoch)
-            .expect("KeyManager should always have a snapshot key");
+            .expect("purpose key derivation must succeed");
         let sk = secp256k1::SecretKey::from_slice(key.as_ref())
             .expect("retrieved secp256k1 secret key should be valid");
 
@@ -113,7 +118,7 @@ impl KeyManager {
     pub fn get_rng_keypair(&self, epoch: u64) -> schnorrkel::keys::Keypair {
         let mini_key = self
             .derive_purpose_key(KeyPurpose::RngPrecompile, epoch)
-            .expect("KeyManager should always have a snapshot key");
+            .expect("purpose key derivation must succeed");
         let mini_key_bytes = mini_key.as_ref();
         let mini_secret_key = schnorrkel::MiniSecretKey::from_bytes(mini_key_bytes)
             .expect("mini_secret_key should be valid");
@@ -126,14 +131,8 @@ impl KeyManager {
     pub fn get_snapshot_key(&self, epoch: u64) -> aes_gcm::Key<aes_gcm::Aes256Gcm> {
         let key = self
             .derive_purpose_key(KeyPurpose::Snapshot, epoch)
-            .expect("KeyManager should always have a snapshot key");
+            .expect("purpose key derivation must succeed");
         let bytes: [u8; 32] = key.as_ref().try_into().expect("Key should be 32 bytes");
         bytes.into()
-    }
-    /// Retrieves a copy of the root secp256k1 secret key used for key management.
-    pub fn get_root_key(&self) -> [u8; 32] {
-        let root_guard = self.root_key.0;
-        let bytes: [u8; 32] = root_guard.as_ref().try_into().unwrap();
-        bytes
     }
 }

--- a/crates/key-custodian/src/lib.rs
+++ b/crates/key-custodian/src/lib.rs
@@ -1,0 +1,26 @@
+//! The Seismic network root-key custodian.
+//!
+//! [`Custodian`] owns `root_key`, the network-wide master secret from which
+//! every purpose key is derived (tx-io, snapshot, RNG, LUKS storage +
+//! header-MAC). The key is RAM-only: generated fresh on the genesis node or
+//! received from a peer via the attested wrap protocol, never written to disk
+//! in any form. At-rest confidentiality comes from the LUKS volume, whose
+//! unlock key is itself derived from `root_key`.
+//!
+//! Boundary rule: this crate never sees remote attestation evidence, let
+//! alone parses it. Releasing `root_key` to a peer requires a
+//! [`VerifiedPeerAuthorization`], produced by a caller that has already
+//! verified the peer's evidence against admission policy. Keeping the
+//! CVE-prone evidence parsers (DCAP, vTPM, X.509) and every network listener
+//! out of this crate is what lets the process holding `root_key` shrink to a
+//! minimal, auditable surface.
+
+// One module per way key material can leave the process:
+mod custodian; // it doesn't — RAM-only derivation of root_key + purpose keys
+mod luks_keyfile; // ephemeral tmpfs keyfile, handed off to setup-persistent-luks
+mod root_key_wrap; // over the network, AEAD-wrapped to an attested peer
+
+pub use custodian::{Custodian, Key, KeyPurpose};
+pub use root_key_wrap::{
+    EphemeralKeypair, VerifiedPeerAuthorization, WrappedRootKey, unwrap_root_key,
+};

--- a/crates/key-custodian/src/luks_keyfile.rs
+++ b/crates/key-custodian/src/luks_keyfile.rs
@@ -1,0 +1,41 @@
+//! Export of the LUKS keyfile consumed by the persistent-disk setup path.
+
+use crate::custodian::{Custodian, KeyPurpose};
+use anyhow::{Context as _, Result};
+use std::{fs, fs::OpenOptions, io::Write as _, os::unix::fs::OpenOptionsExt as _, path::Path};
+
+/// Storage and header-MAC keys are pinned at epoch 0; they are never rotated.
+const KEYS_EPOCH_0: u64 = 0;
+
+impl Custodian {
+    /// Derive the LUKS keys and write them to `path` as 64 raw bytes —
+    /// `storage_key (32B) || header_mac_key (32B)` — mode 0400.
+    ///
+    /// Writes to a sibling tmp file and renames into place: consumers poll
+    /// for the exact path, so they must never observe a partially-written
+    /// file. Where the file goes, and who reads and shreds it, is the
+    /// caller's deployment contract.
+    pub fn write_luks_keyfile(&self, path: &Path) -> Result<()> {
+        let storage_key = self.derive_purpose_key(KeyPurpose::Storage, KEYS_EPOCH_0)?;
+        let header_mac_key = self.derive_purpose_key(KeyPurpose::LuksHeaderMac, KEYS_EPOCH_0)?;
+
+        let mut buf = [0u8; 64];
+        buf[..32].copy_from_slice(storage_key.as_ref());
+        buf[32..].copy_from_slice(header_mac_key.as_ref());
+
+        let tmp = path.with_extension("tmp");
+        // delete in case a previous run left a tmp file (crashed before deleting it)
+        let _ = fs::remove_file(&tmp);
+        let mut f = OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .mode(0o400)
+            .open(&tmp)
+            .with_context(|| format!("creating {}", tmp.display()))?;
+        f.write_all(&buf)?;
+        f.sync_all()?;
+        drop(f);
+        fs::rename(&tmp, path).with_context(|| format!("renaming {} into place", tmp.display()))?;
+        Ok(())
+    }
+}

--- a/crates/key-custodian/src/root_key_wrap.rs
+++ b/crates/key-custodian/src/root_key_wrap.rs
@@ -1,0 +1,207 @@
+//! Wrapping `root_key` to an authorized peer's ephemeral ECDH key.
+//!
+//! This is the custody half of the root-key bootstrap handshake: the caller
+//! (today `seismic-enclave-server`) runs the attested protocol — verifying
+//! the requester's quote and minting the responder's — while this module only
+//! turns "authorized peer + its ephemeral key" into an AEAD-wrapped root key.
+//! The transcript digest the caller verified rides along as the AEAD AAD, so
+//! a wrapped key cannot be lifted onto a different handshake.
+
+use crate::custodian::Custodian;
+use anyhow::{Context, Result, anyhow};
+use rand::{TryRngCore as _, rngs::OsRng};
+use secp256k1::{PublicKey, Secp256k1, SecretKey, ecdh::SharedSecret};
+use seismic_enclave_crypto::{
+    AESGCM_NONCE_SIZE, Nonce, aes_decrypt_aead, aes_encrypt_aead, derive_aes_key,
+};
+
+/// A freshly minted ephemeral secp256k1 ECDH keypair for one handshake.
+///
+/// Held only for the lifetime of a single exchange and dropped after; never
+/// derived from or mixed with the root key, so a leak reveals nothing about it.
+pub struct EphemeralKeypair {
+    pub sk: SecretKey,
+    pub pk: PublicKey,
+}
+
+impl EphemeralKeypair {
+    /// Draw the scalar from the OS CSPRNG (like [`Custodian::new_as_genesis`]),
+    /// retrying on the negligible chance of an out-of-range scalar. We seed from
+    /// bytes rather than secp256k1's own `generate_keypair` because that helper
+    /// wants a `rand` 0.8 RNG, while this workspace is on `rand` 0.9.
+    pub fn generate() -> Self {
+        let secp = Secp256k1::new();
+        loop {
+            let mut bytes = [0u8; 32];
+            OsRng
+                .try_fill_bytes(&mut bytes)
+                .expect("OS RNG must produce ephemeral key material");
+            if let Ok(sk) = SecretKey::from_byte_array(&bytes) {
+                let pk = PublicKey::from_secret_key(&secp, &sk);
+                return Self { sk, pk };
+            }
+        }
+    }
+
+    /// Compressed 33-byte SEC1 encoding, the form the binding helpers hash.
+    pub fn pk_compressed(&self) -> [u8; 33] {
+        self.pk.serialize()
+    }
+}
+
+/// Attestation-verified permission to release `root_key` to one peer.
+///
+/// Constructing one asserts that the peer's evidence for exactly this
+/// handshake transcript has been verified against admission policy. The
+/// custodian trusts it blindly — by design it cannot re-check — so build one
+/// only at the point where verification just succeeded. Who verifies, and
+/// against what policy, is the caller's affair; that is what keeps this crate
+/// free of the attestation stack.
+pub struct VerifiedPeerAuthorization {
+    /// Digest of the verified request transcript (network id, request nonce,
+    /// peer ephemeral key), as defined by
+    /// `seismic_attestation::bindings::root_key_request_binding`. The wire
+    /// protocol pins that choice: the digest becomes the AEAD AAD, and the
+    /// requester independently recomputes it to unwrap, tying the wrapped
+    /// root key to the transcript that was actually verified. The custodian
+    /// never computes or checks the digest — it carries opaque bytes into the
+    /// AAD, which is what keeps this crate free of the attestation stack.
+    pub root_key_request_binding: [u8; 32],
+}
+
+/// One wrap operation's output: the wrapped root key plus the custodian-side
+/// ephemeral pubkey the peer needs for ECDH. The matching ephemeral secret
+/// never leaves the custodian.
+pub struct WrappedRootKey {
+    /// Custodian-side ephemeral ECDH pubkey for this handshake.
+    pub responder_eph_pk: PublicKey,
+    /// `nonce(12) || AES-256-GCM ciphertext+tag` over `root_key`.
+    pub wrapped: Vec<u8>,
+}
+
+impl Custodian {
+    /// AEAD-wrap `root_key` for an authorized peer's ephemeral ECDH key.
+    ///
+    /// Output layout: `nonce(12 bytes) || AES-256-GCM ciphertext+tag`, with
+    /// the authorization's request-transcript digest as AAD — the wrapped
+    /// blob can't be replayed onto a different handshake even before the peer
+    /// checks the responder's quote.
+    pub fn wrap_root_key_for_peer(
+        &self,
+        auth: &VerifiedPeerAuthorization,
+        peer_eph_pk: &PublicKey,
+    ) -> Result<WrappedRootKey> {
+        let eph = EphemeralKeypair::generate();
+        let aes_key = derive_handshake_key(&eph.sk, peer_eph_pk)?;
+
+        let nonce = Nonce::new_rand();
+        let ciphertext = aes_encrypt_aead(
+            &aes_key,
+            self.root_key.as_ref(),
+            nonce.clone(),
+            &auth.root_key_request_binding,
+        )
+        .context("AEAD-wrapping root key")?;
+
+        let mut wrapped = Vec::with_capacity(AESGCM_NONCE_SIZE + ciphertext.len());
+        wrapped.extend_from_slice(&nonce.0);
+        wrapped.extend_from_slice(&ciphertext);
+        Ok(WrappedRootKey {
+            responder_eph_pk: eph.pk,
+            wrapped,
+        })
+    }
+}
+
+/// Inverse of [`Custodian::wrap_root_key_for_peer`], run by the requester side
+/// of the handshake once it has verified the responder's evidence: ECDH the
+/// requester's ephemeral secret against the responder's ephemeral pubkey, then
+/// AEAD-open with the request-binding AAD recomputed from the requester's own
+/// copies of the transcript fields.
+pub fn unwrap_root_key(
+    eph_sk: &SecretKey,
+    responder_eph_pk: &PublicKey,
+    wrapped: &[u8],
+    root_key_request_binding: &[u8; 32],
+) -> Result<[u8; 32]> {
+    if wrapped.len() < AESGCM_NONCE_SIZE {
+        return Err(anyhow!("wrapped root key too short to contain a nonce"));
+    }
+    let (nonce_bytes, ciphertext) = wrapped.split_at(AESGCM_NONCE_SIZE);
+    let nonce: [u8; AESGCM_NONCE_SIZE] = nonce_bytes.try_into().expect("checked length above");
+
+    let aes_key = derive_handshake_key(eph_sk, responder_eph_pk)?;
+    let plaintext = aes_decrypt_aead(&aes_key, ciphertext, nonce, root_key_request_binding)
+        .context("opening wrapped root key (AEAD tag mismatch)")?;
+    plaintext
+        .try_into()
+        .map_err(|_| anyhow!("unwrapped root key is not 32 bytes"))
+}
+
+/// Derive the symmetric handshake key from an ECDH shared secret.
+///
+/// Reuses [`derive_aes_key`] so wrap and unwrap stay in lockstep with the rest
+/// of the enclave's ECDH-AES key schedule.
+fn derive_handshake_key(
+    sk: &SecretKey,
+    pk: &PublicKey,
+) -> Result<aes_gcm::Key<aes_gcm::Aes256Gcm>> {
+    let shared = SharedSecret::new(pk, sk);
+    derive_aes_key(&shared).map_err(|e| anyhow!("deriving handshake AES key: {e}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // End-to-end wrap/unwrap with matching transcripts recovers the key; this
+    // exercises the ECDH + AEAD path without needing real attestation evidence.
+    #[test]
+    fn wrap_then_unwrap_roundtrips() {
+        let root_key = [0x42u8; 32];
+        let custodian = Custodian::new(root_key);
+        let auth = VerifiedPeerAuthorization {
+            root_key_request_binding: [0x33; 32],
+        };
+
+        let requester = EphemeralKeypair::generate();
+        let response = custodian
+            .wrap_root_key_for_peer(&auth, &requester.pk)
+            .unwrap();
+
+        let recovered = unwrap_root_key(
+            &requester.sk,
+            &response.responder_eph_pk,
+            &response.wrapped,
+            &auth.root_key_request_binding,
+        )
+        .unwrap();
+        assert_eq!(recovered, root_key);
+    }
+
+    // The wrapped key is bound to the verified transcript via the AEAD AAD:
+    // open it under any other binding digest (a different nonce, network, or
+    // ephemeral key upstream) and the tag check must fail.
+    #[test]
+    fn unwrap_rejects_foreign_request_binding() {
+        let root_key = [0x42u8; 32];
+        let custodian = Custodian::new(root_key);
+        let auth = VerifiedPeerAuthorization {
+            root_key_request_binding: [0x33; 32],
+        };
+
+        let requester = EphemeralKeypair::generate();
+        let response = custodian
+            .wrap_root_key_for_peer(&auth, &requester.pk)
+            .unwrap();
+
+        let err = unwrap_root_key(
+            &requester.sk,
+            &response.responder_eph_pk,
+            &response.wrapped,
+            &[0xFF; 32],
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("AEAD tag mismatch"));
+    }
+}


### PR DESCRIPTION
Move KeyManager out of enclave-server into a new seismic-key-custodian crate (renamed Custodian) that owns root_key and everything derived from it. The crate never sees remote attestation evidence, JSON-RPC, or any network input: releasing root_key to a peer requires a VerifiedPeerAuthorization, built by the caller at the point where it has just verified the peer's evidence. The verified transcript digest (root_key_request_binding) rides along and becomes the AEAD AAD, so a wrapped key cannot be lifted onto a different handshake. enclave-server keeps the untrusted-input surface (evidence verification, RPC) and calls into the custodian through this typed API.

Beyond the code motion, the custody boundary is now enforced by the API:

- KeyManager::get_root_key() is gone. Raw root-key bytes are unreachable outside the crate; root_key only leaves AEAD-wrapped via wrap_root_key_for_peer.
- The Clone derive is gone: exactly one Custodian per process, zeroized on drop.
- The responder-side ephemeral ECDH keypair is now generated inside wrap_root_key_for_peer, so its secret also never exists outside the custodian.
- answer_root_key_request takes &Custodian instead of &[u8; 32]: bootstrap.rs orchestrates verify -> authorize -> attest without ever holding key material.

The crate's modules are organized by how key material can leave the process: custodian.rs (it doesn't — RAM-only derivation of root_key and purpose keys), luks_keyfile.rs (ephemeral tmpfs handoff to setup-persistent-luks), root_key_wrap.rs (over the network, AEAD-wrapped to an attested peer).

No behavior change: the wire format (nonce || ciphertext+tag, request-binding AAD), HKDF derivations (salts, domain separators), and epoch handling are byte-identical to before.

This is groundwork for splitting enclave-server into a network-facing attestation service and a minimal key-custodian process with no network listener.