### PR TITLE
feat: serve custodian key ops over a Unix socket

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,11 @@ jobs:
         uses: foundry-rs/foundry-toolchain@v1
       - name: cargo check warnings
         run: RUSTFLAGS="-D warnings" cargo check
+      # The workspace pass builds seismic-custodian-ipc with default features
+      # only, which compiles out the `server` module (and its ACL tests) and
+      # skips the `cli` binary entirely (required-features). Cover them here.
+      - name: Run seismic-custodian-ipc tests (all features)
+        run: cargo test -p seismic-custodian-ipc --all-features
       # Default test coverage for every workspace crate, so new crates get
       # tested without anyone remembering to add a job. Exclusions, each for
       # its own reason:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1581,6 +1581,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
 name = "cipher"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2751,6 +2778,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3036,7 +3074,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.0",
  "tokio",
  "tower-service",
  "tracing",
@@ -4383,7 +4421,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.0",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -4420,7 +4458,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.0",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -5138,6 +5176,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "seismic-custodian-ipc"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "ciborium",
+ "clap",
+ "hex",
+ "libc",
+ "serde",
+ "serde_bytes",
+ "sha2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "zeroize",
+]
+
+[[package]]
 name = "seismic-enclave"
 version = "0.1.0"
 dependencies = [
@@ -5183,6 +5239,7 @@ dependencies = [
  "reqwest 0.11.27",
  "secp256k1",
  "seismic-attestation",
+ "seismic-custodian-ipc",
  "seismic-enclave",
  "seismic-key-custodian",
  "serde",
@@ -6546,7 +6603,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 resolver = "2"
 members = [
+    "crates/custodian-ipc",
     "crates/enclave-server",
     "crates/enclave-contract", "crates/enclave",
     "crates/enclave-crypto",
@@ -23,6 +24,7 @@ readme = "README.md"
 # workspace libs
 enclave-contract = { path = "crates/enclave-contract" }
 seismic-attestation = { path = "crates/seismic-attestation" }
+seismic-custodian-ipc = { path = "crates/custodian-ipc" }
 seismic-enclave = {path = "crates/enclave" }
 seismic-enclave-crypto = { path = "crates/enclave-crypto" }
 seismic-key-custodian = { path = "crates/key-custodian" }
@@ -36,6 +38,7 @@ attestation = { git = "https://github.com/flashbots/attested-tls", rev = "05a79a
 az-cvm-vtpm = { version = "0.7.4", default-features = false }
 az-tdx-vtpm = "0.7.4"
 bincode = "1.3.3"
+ciborium = "0.2"
 clap = { version = "4.5.51", features = ["derive", "env"] }
 dcap-rs = "0.1.0"
 base64-url = "3.0.0"
@@ -50,6 +53,7 @@ reqwest = { version = "0.11", features = ["json"] }
 schnorrkel = { version = "0.11.2", features = ["serde"] }
 secp256k1 = { version = "0.30", features = ["rand", "recovery", "std", "serde"] }
 serde = { version = "1.0", features = ["derive"] }
+serde_bytes = "0.11"
 serde_json = "1.0"
 sha2 = "0.10.9"
 tokio = { version = "1.44", features = ["full"] }

--- a/crates/custodian-ipc/Cargo.toml
+++ b/crates/custodian-ipc/Cargo.toml
@@ -1,0 +1,53 @@
+[package]
+name = "seismic-custodian-ipc"
+edition.workspace = true
+version.workspace = true
+repository.workspace = true
+homepage.workspace = true
+authors.workspace = true
+license.workspace = true
+readme.workspace = true
+description = "Wire protocol, client, and server for the Seismic key-custodian Unix socket"
+
+[dependencies]
+# Core (wire protocol + blocking framing): kept minimal on purpose — this is
+# the dependency floor for any process that links the crate.
+ciborium.workspace = true
+serde.workspace = true
+serde_bytes.workspace = true
+thiserror.workspace = true
+zeroize = { workspace = true, features = ["derive"] }
+
+# `client` feature: async client for tokio hosts (reth, enclave-server).
+tokio = { workspace = true, optional = true }
+
+# `server` feature: synchronous socket server (peer creds via libc).
+libc = { workspace = true, optional = true }
+tracing = { workspace = true, optional = true }
+
+# `cli` feature: debug binary.
+anyhow = { workspace = true, optional = true }
+clap = { workspace = true, optional = true }
+hex = { workspace = true, optional = true }
+sha2 = { workspace = true, optional = true }
+
+[features]
+# Default-on client keeps async consumers frictionless; the custodian binary
+# opts out with default-features = false, features = ["server"] and links no
+# tokio at all.
+#
+# CAUTION — feature unification: that no-tokio guarantee only holds when the
+# server-only consumer is built in its own cargo invocation. Building it
+# together with a `client` consumer (--workspace, or one `cargo build` with
+# multiple --bin targets) unifies features on this crate and silently pulls
+# tokio back into the server consumer's build. Keep the key-holding binary's
+# build standalone; if that convention ever proves too fragile, split this
+# crate into core/client/server crates so the boundary is structural.
+default = ["client"]
+client = ["dep:tokio"]
+server = ["dep:libc", "dep:tracing"]
+cli = ["client", "dep:anyhow", "dep:clap", "dep:hex", "dep:sha2"]
+
+[[bin]]
+name = "custodian-ipc-cli"
+required-features = ["cli"]

--- a/crates/custodian-ipc/src/bin/custodian-ipc-cli.rs
+++ b/crates/custodian-ipc/src/bin/custodian-ipc-cli.rs
@@ -1,0 +1,74 @@
+//! Debug client for the custodian socket — the `socat` stand-in for a binary
+//! wire format, and the reference consumer of [`CustodianClient`].
+//!
+//! Prints public material and SHA-256 fingerprints only, never raw secrets:
+//! good enough to check "is the custodian up and deriving the keys every
+//! other node derives" without turning a debug tool into a key-exfil path.
+
+use anyhow::Result;
+use clap::{Parser, Subcommand};
+use seismic_custodian_ipc::{CUSTODIAN_SOCKET_PATH, CustodianClient};
+use sha2::{Digest as _, Sha256};
+
+#[derive(Parser)]
+#[command(about = "Debug client for the Seismic key-custodian Unix socket")]
+struct Cli {
+    /// Path to the custodian socket.
+    #[arg(long, default_value = CUSTODIAN_SOCKET_PATH)]
+    socket: std::path::PathBuf,
+
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Subcommand)]
+enum Command {
+    /// Liveness probe.
+    Ping,
+    /// Fetch every purpose key this UID is allowed; prints the tx_io public
+    /// key, SHA-256 fingerprints of the secret material, and per-purpose
+    /// denials.
+    PurposeKeys {
+        #[arg(long, default_value_t = 0)]
+        epoch: u64,
+    },
+}
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> Result<()> {
+    let cli = Cli::parse();
+    let mut client = CustodianClient::connect(&cli.socket).await?;
+    match cli.command {
+        Command::Ping => {
+            client.ping().await?;
+            println!("OK");
+        }
+        Command::PurposeKeys { epoch } => {
+            println!("epoch:               {epoch}");
+            match client.get_tx_io_keypair(epoch).await {
+                Ok(keys) => {
+                    println!("tx_io pk:            {}", hex::encode(keys.pk));
+                    println!("tx_io sk sha256:     {}", fingerprint(&keys.sk));
+                }
+                Err(e) => println!("tx_io:               {e}"),
+            }
+            match client.get_rng_keypair(epoch).await {
+                Ok(keys) => {
+                    println!("rng_keypair sha256:  {}", fingerprint(&keys.keypair));
+                }
+                Err(e) => println!("rng_keypair:         {e}"),
+            }
+            match client.get_snapshot_key(epoch).await {
+                Ok(key) => {
+                    println!("snapshot_key sha256: {}", fingerprint(&key.key));
+                }
+                Err(e) => println!("snapshot_key:        {e}"),
+            }
+        }
+    }
+    Ok(())
+}
+
+fn fingerprint(bytes: &[u8]) -> String {
+    hex::encode(Sha256::digest(bytes))
+}

--- a/crates/custodian-ipc/src/client.rs
+++ b/crates/custodian-ipc/src/client.rs
@@ -1,0 +1,96 @@
+//! Request/response client for the custodian socket.
+//!
+//! One in-flight request per connection — send a frame, read a frame — which
+//! is why methods take `&mut self`. Callers needing concurrency open more
+//! connections; the expected callers (reth at startup, attestation-service
+//! per bootstrap) never need to.
+
+use crate::error::IpcError;
+use crate::framing::{read_frame, write_frame};
+use crate::messages::{
+    Request, Response, RngKeypairBytes, SnapshotKeyBytes, TxIoKeypairBytes, WrappedRootKeyBytes,
+};
+use std::path::Path;
+use tokio::net::UnixStream;
+
+pub struct CustodianClient {
+    stream: UnixStream,
+}
+
+impl CustodianClient {
+    pub async fn connect(path: impl AsRef<Path>) -> Result<Self, IpcError> {
+        Ok(Self {
+            stream: UnixStream::connect(path).await?,
+        })
+    }
+
+    /// One request/response exchange. The server's failure variants become
+    /// typed errors: [`Response::Denied`] → [`IpcError::Denied`],
+    /// [`Response::Error`] → [`IpcError::Custodian`].
+    pub async fn call(&mut self, request: &Request) -> Result<Response, IpcError> {
+        write_frame(&mut self.stream, request).await?;
+        match read_frame(&mut self.stream).await? {
+            Some(Response::Denied { message }) => Err(IpcError::Denied(message)),
+            Some(Response::Error { message }) => Err(IpcError::Custodian(message)),
+            Some(response) => Ok(response),
+            None => Err(std::io::Error::new(
+                std::io::ErrorKind::UnexpectedEof,
+                "custodian closed the connection",
+            )
+            .into()),
+        }
+    }
+
+    pub async fn ping(&mut self) -> Result<(), IpcError> {
+        match self.call(&Request::Ping).await? {
+            Response::Pong => Ok(()),
+            _ => Err(IpcError::UnexpectedResponse { method: "ping" }),
+        }
+    }
+
+    pub async fn get_tx_io_keypair(&mut self, epoch: u64) -> Result<TxIoKeypairBytes, IpcError> {
+        match self.call(&Request::GetTxIoKeypair { epoch }).await? {
+            Response::TxIoKeypair(keys) => Ok(keys),
+            _ => Err(IpcError::UnexpectedResponse {
+                method: "get_tx_io_keypair",
+            }),
+        }
+    }
+
+    pub async fn get_rng_keypair(&mut self, epoch: u64) -> Result<RngKeypairBytes, IpcError> {
+        match self.call(&Request::GetRngKeypair { epoch }).await? {
+            Response::RngKeypair(keys) => Ok(keys),
+            _ => Err(IpcError::UnexpectedResponse {
+                method: "get_rng_keypair",
+            }),
+        }
+    }
+
+    pub async fn get_snapshot_key(&mut self, epoch: u64) -> Result<SnapshotKeyBytes, IpcError> {
+        match self.call(&Request::GetSnapshotKey { epoch }).await? {
+            Response::SnapshotKey(key) => Ok(key),
+            _ => Err(IpcError::UnexpectedResponse {
+                method: "get_snapshot_key",
+            }),
+        }
+    }
+
+    pub async fn wrap_root_key(
+        &mut self,
+        root_key_request_binding: [u8; 32],
+        peer_eph_pk: [u8; 33],
+    ) -> Result<WrappedRootKeyBytes, IpcError> {
+        match self
+            .call(&Request::WrapRootKey {
+                root_key_request_binding,
+                peer_eph_pk,
+            })
+            .await?
+        {
+            Response::WrappedRootKey(wrapped) => Ok(wrapped),
+            _ => Err(IpcError::UnexpectedResponse {
+                method: "wrap_root_key",
+            }),
+        }
+    }
+}

--- a/crates/custodian-ipc/src/error.rs
+++ b/crates/custodian-ipc/src/error.rs
@@ -1,0 +1,25 @@
+use crate::framing::MAX_FRAME_BODY_LEN;
+
+#[derive(Debug, thiserror::Error)]
+pub enum IpcError {
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+    #[error("frame body length {len} exceeds maximum {MAX_FRAME_BODY_LEN}")]
+    FrameTooLarge { len: usize },
+    #[error("CBOR encode: {0}")]
+    Encode(String),
+    #[error("CBOR decode: {0}")]
+    Decode(String),
+    /// The transport's ACL refused this method ([`crate::Response::Denied`]);
+    /// retrying cannot succeed until the node's ACL changes.
+    #[error("custodian denied: {0}")]
+    Denied(String),
+    /// The custodian accepted the request but the operation failed
+    /// ([`crate::Response::Error`]).
+    #[error("custodian: {0}")]
+    Custodian(String),
+    /// The custodian answered, but with a variant that doesn't match the
+    /// request — a protocol bug on one side or the other.
+    #[error("unexpected response variant to {method}")]
+    UnexpectedResponse { method: &'static str },
+}

--- a/crates/custodian-ipc/src/framing.rs
+++ b/crates/custodian-ipc/src/framing.rs
@@ -1,0 +1,268 @@
+//! Length-prefixed CBOR framing: every message is a 4-byte big-endian length
+//! followed by exactly that many bytes of CBOR. The reader knows the frame
+//! boundary before parsing any content and enforces [`MAX_FRAME_BODY_LEN`] before
+//! allocating.
+//!
+//! The wire logic lives in crate-private pure functions (`encode_frame`,
+//! `decode_header`, `decode_body`); the public API is the frame I/O
+//! functions. Two sets of thin I/O wrappers share the pure core: blocking
+//! ones over `std::io` for the synchronous server, and — behind the `client`
+//! feature — async ones over tokio for async consumers.
+
+use crate::error::IpcError;
+use serde::{Serialize, de::DeserializeOwned};
+use std::io::{Read, Write};
+use zeroize::Zeroize as _;
+
+/// Size of the frame header (big-endian u32 body length).
+pub(crate) const FRAME_HEADER_LEN: usize = 4;
+
+/// Upper bound on a frame body, enforced on both sides. Generous: the largest
+/// legitimate message (a wrapped-root-key response) is well under 1 KiB.
+pub const MAX_FRAME_BODY_LEN: usize = 64 * 1024;
+
+/// Blocking read of one frame. `Ok(None)` means the peer closed the stream
+/// before starting a frame (normal end of connection); EOF *inside* a frame
+/// is an error.
+pub fn read_frame_blocking<R, T>(reader: &mut R) -> Result<Option<T>, IpcError>
+where
+    R: Read,
+    T: DeserializeOwned,
+{
+    let mut header = [0u8; FRAME_HEADER_LEN];
+    match reader.read_exact(&mut header) {
+        Ok(_) => {}
+        Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => return Ok(None),
+        Err(e) => return Err(e.into()),
+    }
+    let mut body = vec![0u8; decode_header(header)?];
+    reader.read_exact(&mut body)?;
+    let decoded = decode_body(&body);
+    // Frames can carry key material; scrub the transport copy either way.
+    body.zeroize();
+    decoded.map(Some)
+}
+
+/// Blocking write of one frame (length prefix + CBOR body) and flush.
+pub fn write_frame_blocking<W, T>(writer: &mut W, message: &T) -> Result<(), IpcError>
+where
+    W: Write,
+    T: Serialize,
+{
+    let mut frame = encode_frame(message)?;
+    let result = writer.write_all(&frame).and_then(|()| writer.flush());
+    frame.zeroize();
+    result.map_err(IpcError::Io)
+}
+
+/// Async read of one frame; same semantics as [`read_frame_blocking`].
+#[cfg(feature = "client")]
+pub async fn read_frame<R, T>(reader: &mut R) -> Result<Option<T>, IpcError>
+where
+    R: tokio::io::AsyncRead + Unpin,
+    T: DeserializeOwned,
+{
+    use tokio::io::AsyncReadExt as _;
+
+    let mut header = [0u8; FRAME_HEADER_LEN];
+    match reader.read_exact(&mut header).await {
+        Ok(_) => {}
+        Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => return Ok(None),
+        Err(e) => return Err(e.into()),
+    }
+    let mut body = vec![0u8; decode_header(header)?];
+    reader.read_exact(&mut body).await?;
+    let decoded = decode_body(&body);
+    body.zeroize();
+    decoded.map(Some)
+}
+
+/// Async write of one frame; same semantics as [`write_frame_blocking`].
+#[cfg(feature = "client")]
+pub async fn write_frame<W, T>(writer: &mut W, message: &T) -> Result<(), IpcError>
+where
+    W: tokio::io::AsyncWrite + Unpin,
+    T: Serialize,
+{
+    use tokio::io::AsyncWriteExt as _;
+
+    let mut frame = encode_frame(message)?;
+    let result = async {
+        writer.write_all(&frame).await?;
+        writer.flush().await
+    }
+    .await;
+    frame.zeroize();
+    result.map_err(IpcError::Io)
+}
+
+/// Encode one message into a complete wire frame (header + CBOR body).
+///
+/// The returned buffer may carry key material; callers must zeroize it after
+/// writing, as the write helpers do.
+pub(crate) fn encode_frame<T: Serialize>(message: &T) -> Result<Vec<u8>, IpcError> {
+    // Reserve the whole frame bound up front and serialize straight after the
+    // header, so any in-bounds message is one allocation and the secret bytes
+    // exist in one place — a realloc would strand an unzeroized copy in freed
+    // memory. The calls are rare enough (single-digit per process lifetime)
+    // that always reserving MAX_FRAME_BODY_LEN costs nothing.
+    let mut frame = Vec::with_capacity(FRAME_HEADER_LEN + MAX_FRAME_BODY_LEN);
+    frame.resize(FRAME_HEADER_LEN, 0);
+    if let Err(e) = ciborium::ser::into_writer(message, &mut frame) {
+        frame.zeroize();
+        return Err(IpcError::Encode(format!("{e}")));
+    }
+    let body_len = frame.len() - FRAME_HEADER_LEN;
+    if body_len > MAX_FRAME_BODY_LEN {
+        frame.zeroize();
+        return Err(IpcError::FrameTooLarge { len: body_len });
+    }
+    frame[..FRAME_HEADER_LEN].copy_from_slice(&(body_len as u32).to_be_bytes());
+    Ok(frame)
+}
+
+/// Parse a frame header into the body length, enforcing [`MAX_FRAME_BODY_LEN`]
+/// so the caller rejects an oversize frame before allocating for it.
+pub(crate) fn decode_header(header: [u8; FRAME_HEADER_LEN]) -> Result<usize, IpcError> {
+    let len = u32::from_be_bytes(header) as usize;
+    if len > MAX_FRAME_BODY_LEN {
+        return Err(IpcError::FrameTooLarge { len });
+    }
+    Ok(len)
+}
+
+/// Decode one frame body. The buffer may carry key material; callers must
+/// zeroize it afterwards, as the read helpers do.
+pub(crate) fn decode_body<T: DeserializeOwned>(body: &[u8]) -> Result<T, IpcError> {
+    ciborium::de::from_reader(body).map_err(|e| IpcError::Decode(format!("{e}")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::messages::{Request, Response};
+
+    // The sync path a std-only host would use: pure functions, no I/O.
+    #[test]
+    fn pure_encode_decode_roundtrips_without_io() {
+        let frame = encode_frame(&Request::GetTxIoKeypair { epoch: 9 }).expect("encode");
+        let header: [u8; FRAME_HEADER_LEN] = frame[..FRAME_HEADER_LEN].try_into().expect("header");
+        let body_len = decode_header(header).expect("header length");
+        assert_eq!(body_len, frame.len() - FRAME_HEADER_LEN);
+        let decoded: Request = decode_body(&frame[FRAME_HEADER_LEN..]).expect("decode");
+        let Request::GetTxIoKeypair { epoch } = decoded else {
+            panic!("wrong variant");
+        };
+        assert_eq!(epoch, 9);
+    }
+
+    #[test]
+    fn blocking_roundtrip_over_in_memory_stream() {
+        let mut wire = Vec::new();
+        write_frame_blocking(&mut wire, &Request::Ping).expect("write");
+        write_frame_blocking(&mut wire, &Response::Pong).expect("write");
+
+        let mut reader = wire.as_slice();
+        let first: Request = read_frame_blocking(&mut reader)
+            .expect("read")
+            .expect("some");
+        assert!(matches!(first, Request::Ping));
+        let second: Response = read_frame_blocking(&mut reader)
+            .expect("read")
+            .expect("some");
+        assert!(matches!(second, Response::Pong));
+        // Clean EOF after the last frame.
+        let end: Option<Request> = read_frame_blocking(&mut reader).expect("read");
+        assert!(end.is_none());
+    }
+
+    #[test]
+    fn blocking_oversize_header_is_rejected() {
+        let wire = ((MAX_FRAME_BODY_LEN as u32) + 1).to_be_bytes().to_vec();
+        let result: Result<Option<Request>, _> = read_frame_blocking(&mut wire.as_slice());
+        assert!(matches!(result, Err(IpcError::FrameTooLarge { .. })));
+    }
+
+    #[test]
+    fn blocking_truncated_body_is_an_error_not_eof() {
+        let mut wire = 100u32.to_be_bytes().to_vec();
+        wire.extend_from_slice(&[0u8; 10]);
+        let result: Result<Option<Request>, _> = read_frame_blocking(&mut wire.as_slice());
+        assert!(matches!(result, Err(IpcError::Io(_))));
+    }
+
+    #[test]
+    fn blocking_unknown_variant_is_a_decode_error() {
+        // A well-formed CBOR map that is not any Request variant.
+        let bogus = ciborium::Value::Map(vec![(
+            ciborium::Value::Text("NoSuchMethod".into()),
+            ciborium::Value::Integer(1.into()),
+        )]);
+        let mut wire = Vec::new();
+        write_frame_blocking(&mut wire, &bogus).expect("write");
+        let result: Result<Option<Request>, _> = read_frame_blocking(&mut wire.as_slice());
+        assert!(matches!(result, Err(IpcError::Decode(_))));
+    }
+
+    #[test]
+    fn oversize_write_is_rejected() {
+        let blob = serde_bytes::ByteBuf::from(vec![0u8; MAX_FRAME_BODY_LEN + 1]);
+        let result = write_frame_blocking(&mut Vec::new(), &blob);
+        assert!(matches!(result, Err(IpcError::FrameTooLarge { .. })));
+    }
+
+    // The async wrappers must be byte-identical to the blocking ones: write
+    // async, read blocking (and vice versa).
+    #[cfg(feature = "client")]
+    mod async_wrappers {
+        use super::*;
+        use tokio::io::AsyncWriteExt as _;
+
+        #[tokio::test]
+        async fn async_and_blocking_interoperate() {
+            let (mut client, mut server) = tokio::io::duplex(1024);
+            write_frame(&mut client, &Request::GetTxIoKeypair { epoch: 3 })
+                .await
+                .expect("write");
+            let decoded: Request = read_frame(&mut server).await.expect("read").expect("some");
+            let frame = encode_frame(&decoded).expect("encode");
+            let roundtrip: Request = read_frame_blocking(&mut frame.as_slice())
+                .expect("read")
+                .expect("some");
+            let Request::GetTxIoKeypair { epoch } = roundtrip else {
+                panic!("wrong variant");
+            };
+            assert_eq!(epoch, 3);
+        }
+
+        #[tokio::test]
+        async fn clean_eof_reads_as_none() {
+            let (client, mut server) = tokio::io::duplex(1024);
+            drop(client);
+            let decoded: Option<Request> = read_frame(&mut server).await.expect("read");
+            assert!(decoded.is_none());
+        }
+
+        #[tokio::test]
+        async fn oversize_header_is_rejected_before_reading_body() {
+            let (mut client, mut server) = tokio::io::duplex(1024);
+            let len = (MAX_FRAME_BODY_LEN as u32) + 1;
+            client.write_all(&len.to_be_bytes()).await.expect("write");
+            let result: Result<Option<Request>, _> = read_frame(&mut server).await;
+            assert!(matches!(result, Err(IpcError::FrameTooLarge { .. })));
+        }
+
+        #[tokio::test]
+        async fn truncated_body_is_an_error_not_eof() {
+            let (mut client, mut server) = tokio::io::duplex(1024);
+            client
+                .write_all(&100u32.to_be_bytes())
+                .await
+                .expect("write");
+            client.write_all(&[0u8; 10]).await.expect("write");
+            drop(client);
+            let result: Result<Option<Request>, _> = read_frame(&mut server).await;
+            assert!(matches!(result, Err(IpcError::Io(_))));
+        }
+    }
+}

--- a/crates/custodian-ipc/src/lib.rs
+++ b/crates/custodian-ipc/src/lib.rs
@@ -1,0 +1,46 @@
+//! Wire protocol, client, and server for the key-custodian Unix socket.
+//!
+//! Framing is a 4-byte big-endian length prefix followed by a CBOR body
+//! ([`framing`]); messages are the byte-oriented [`Request`]/[`Response`]
+//! serde enums.
+//! This crate is both ends of the custodian wire surface, feature-gated by
+//! what each host needs:
+//!
+//! - core (always): wire types + pure/blocking framing — serde, ciborium,
+//!   zeroize only
+//! - `client` (default): async [`CustodianClient`] for tokio hosts (reth,
+//!   the attestation service)
+//! - `server`: the synchronous socket server in [`server`] — no async
+//!   runtime, for the process that holds the keys
+//!
+//! Boundary rule: this crate stays a leaf — no custodian, attestation, or
+//! crypto-stack dependencies. Key material crosses the wire as raw bytes and
+//! callers convert to typed keys on their side; the server takes dispatch as
+//! an injected closure rather than knowing the custodian. Linking any part
+//! of this crate never drags the enclave stack into a consumer.
+
+#[cfg(feature = "client")]
+mod client;
+mod error;
+pub mod framing;
+mod messages;
+#[cfg(feature = "server")]
+pub mod server;
+
+#[cfg(feature = "client")]
+pub use client::CustodianClient;
+pub use error::IpcError;
+// The pure encode/decode internals stay crate-private; consumers frame
+// messages through these I/O functions (or the client/server above them).
+// Re-exporting more later is additive, so start minimal — this crate's API
+// gets pinned by consumers at the process split.
+pub use framing::{MAX_FRAME_BODY_LEN, read_frame_blocking, write_frame_blocking};
+#[cfg(feature = "client")]
+pub use framing::{read_frame, write_frame};
+pub use messages::{
+    Request, Response, RngKeypairBytes, SnapshotKeyBytes, TxIoKeypairBytes, WrappedRootKeyBytes,
+};
+
+/// Where enclave-server hosts the custodian socket on a node. `/run/seismic`
+/// is tmpfs, created by tdx-init before enclave-server starts.
+pub const CUSTODIAN_SOCKET_PATH: &str = "/run/seismic/custodian.sock";

--- a/crates/custodian-ipc/src/messages.rs
+++ b/crates/custodian-ipc/src/messages.rs
@@ -1,0 +1,249 @@
+//! Message types for the custodian socket.
+//!
+//! Everything crosses the wire as raw bytes — fixed-size arrays for keys and
+//! digests, `Vec<u8>` for variable-length blobs — tagged `serde_bytes` so CBOR
+//! encodes them as native byte strings. Callers convert to typed keys
+//! (`secp256k1`, `schnorrkel`, `aes-gcm`) at their own boundary; see the
+//! crate-level boundary rule.
+//!
+//! Key-fetch methods are deliberately one-per-purpose, never bundled: the
+//! method is the unit an ACL grant covers, so each caller can be given
+//! exactly the purposes it needs (see `server::MethodAcl` for who gets
+//! what), and each purpose keeps an independent epoch so one key can be
+//! rotated without touching the others.
+
+use serde::{Deserialize, Serialize};
+use std::fmt;
+use zeroize::{Zeroize, ZeroizeOnDrop};
+
+/// One request over the custodian socket.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum Request {
+    /// Liveness probe; carries no key material in either direction.
+    Ping,
+    /// Derive this epoch's tx-io ECDH keypair (TxSeismic calldata
+    /// encryption). Epochs are fixed at 0 until a consensus-driven manual
+    /// rotation exists; same for the other purposes below.
+    GetTxIoKeypair { epoch: u64 },
+    /// Derive this epoch's RNG-precompile keypair.
+    GetRngKeypair { epoch: u64 },
+    /// Derive this epoch's snapshot encryption key.
+    GetSnapshotKey { epoch: u64 },
+    /// AEAD-wrap the root key for an attestation-verified peer.
+    ///
+    /// `root_key_request_binding` is the digest of the request transcript the
+    /// *caller* already verified (it becomes the AEAD AAD; the custodian
+    /// carries it opaquely). Sending this request asserts that verification
+    /// succeeded — the ACL must confine it to the attestation-service.
+    WrapRootKey {
+        #[serde(with = "serde_bytes")]
+        root_key_request_binding: [u8; 32],
+        /// Peer's ephemeral ECDH public key, 33-byte compressed SEC1.
+        #[serde(with = "serde_bytes")]
+        peer_eph_pk: [u8; 33],
+    },
+}
+
+impl Request {
+    /// Stable method label for ACL decisions and log lines.
+    pub fn method(&self) -> &'static str {
+        match self {
+            Request::Ping => "ping",
+            Request::GetTxIoKeypair { .. } => "get_tx_io_keypair",
+            Request::GetRngKeypair { .. } => "get_rng_keypair",
+            Request::GetSnapshotKey { .. } => "get_snapshot_key",
+            Request::WrapRootKey { .. } => "wrap_root_key",
+        }
+    }
+}
+
+/// One response; variants mirror [`Request`] plus two failure variants,
+/// split by which layer failed the request: [`Response::Denied`] is minted
+/// only by the transport's ACL loop, [`Response::Error`] only by the host's
+/// dispatch handler.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum Response {
+    Pong,
+    TxIoKeypair(TxIoKeypairBytes),
+    RngKeypair(RngKeypairBytes),
+    SnapshotKey(SnapshotKeyBytes),
+    WrappedRootKey(WrappedRootKeyBytes),
+    /// The ACL refused this peer the method; the handler never saw the
+    /// request. Retrying cannot succeed until the node's ACL changes.
+    Denied {
+        message: String,
+    },
+    /// The handler accepted the request but the operation failed (bad
+    /// argument or internal error); no partial output is returned.
+    Error {
+        message: String,
+    },
+}
+
+/// secp256k1 tx-io keypair as raw bytes. Zeroized on drop: `sk` is a secret.
+#[derive(Clone, Serialize, Deserialize, Zeroize, ZeroizeOnDrop)]
+pub struct TxIoKeypairBytes {
+    #[serde(with = "serde_bytes")]
+    pub sk: [u8; 32],
+    /// 33-byte compressed SEC1 public key.
+    #[serde(with = "serde_bytes")]
+    pub pk: [u8; 33],
+}
+
+// Manual Debug so a stray `{:?}` on a response can't log the secret half.
+impl fmt::Debug for TxIoKeypairBytes {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("TxIoKeypairBytes")
+            .field("sk", &"<redacted>")
+            .field("pk", &self.pk)
+            .finish()
+    }
+}
+
+/// schnorrkel RNG keypair as raw bytes (`Keypair::to_bytes()`, 96 bytes,
+/// secret half included). Zeroized on drop.
+#[derive(Clone, Serialize, Deserialize, Zeroize, ZeroizeOnDrop)]
+pub struct RngKeypairBytes {
+    #[serde(with = "serde_bytes")]
+    pub keypair: Vec<u8>,
+}
+
+impl fmt::Debug for RngKeypairBytes {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("RngKeypairBytes")
+            .field("keypair", &"<redacted>")
+            .finish()
+    }
+}
+
+/// AES-256-GCM snapshot key as raw bytes. Zeroized on drop.
+#[derive(Clone, Serialize, Deserialize, Zeroize, ZeroizeOnDrop)]
+pub struct SnapshotKeyBytes {
+    #[serde(with = "serde_bytes")]
+    pub key: [u8; 32],
+}
+
+impl fmt::Debug for SnapshotKeyBytes {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SnapshotKeyBytes")
+            .field("key", &"<redacted>")
+            .finish()
+    }
+}
+
+/// One wrap operation's output — `WrappedRootKey` from seismic-key-custodian
+/// as raw bytes. Not secret: the payload is AEAD-sealed to the peer's
+/// ephemeral key and the pubkey is public by definition.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WrappedRootKeyBytes {
+    /// Custodian-side ephemeral ECDH public key, 33-byte compressed SEC1.
+    #[serde(with = "serde_bytes")]
+    pub responder_eph_pk: [u8; 33],
+    /// `nonce(12) || AES-256-GCM ciphertext+tag` over the root key.
+    #[serde(with = "serde_bytes")]
+    pub wrapped: Vec<u8>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn to_cbor<T: Serialize>(value: &T) -> Vec<u8> {
+        let mut buf = Vec::new();
+        ciborium::ser::into_writer(value, &mut buf).expect("serialize");
+        buf
+    }
+
+    fn from_cbor<T: serde::de::DeserializeOwned>(bytes: &[u8]) -> T {
+        ciborium::de::from_reader(bytes).expect("deserialize")
+    }
+
+    #[test]
+    fn request_roundtrips() {
+        let requests = [
+            Request::Ping,
+            Request::GetTxIoKeypair { epoch: 7 },
+            Request::GetRngKeypair { epoch: 8 },
+            Request::GetSnapshotKey { epoch: 9 },
+            Request::WrapRootKey {
+                root_key_request_binding: [0xAB; 32],
+                peer_eph_pk: [0xCD; 33],
+            },
+        ];
+        for request in requests {
+            let decoded: Request = from_cbor(&to_cbor(&request));
+            assert_eq!(format!("{request:?}"), format!("{decoded:?}"));
+        }
+    }
+
+    #[test]
+    fn response_roundtrips() {
+        let response = Response::TxIoKeypair(TxIoKeypairBytes {
+            sk: [1; 32],
+            pk: [2; 33],
+        });
+        let Response::TxIoKeypair(keys) = from_cbor(&to_cbor(&response)) else {
+            panic!("wrong variant");
+        };
+        assert_eq!(keys.sk, [1; 32]);
+        assert_eq!(keys.pk, [2; 33]);
+
+        let response = Response::SnapshotKey(SnapshotKeyBytes { key: [3; 32] });
+        let Response::SnapshotKey(snapshot) = from_cbor(&to_cbor(&response)) else {
+            panic!("wrong variant");
+        };
+        assert_eq!(snapshot.key, [3; 32]);
+
+        let response = Response::RngKeypair(RngKeypairBytes {
+            keypair: vec![4; 96],
+        });
+        let Response::RngKeypair(rng) = from_cbor(&to_cbor(&response)) else {
+            panic!("wrong variant");
+        };
+        assert_eq!(rng.keypair, vec![4; 96]);
+
+        // The two failure variants must stay distinct across the wire.
+        let response = Response::Denied {
+            message: "not authorized".into(),
+        };
+        let Response::Denied { message } = from_cbor(&to_cbor(&response)) else {
+            panic!("wrong variant");
+        };
+        assert_eq!(message, "not authorized");
+    }
+
+    // The reason this crate exists over plain JSON: key material must encode
+    // as CBOR byte strings (major type 2), not arrays of integers. 0x58 0x20
+    // is "byte string, length 32".
+    #[test]
+    fn byte_fields_encode_as_cbor_byte_strings() {
+        let encoded = to_cbor(&Request::WrapRootKey {
+            root_key_request_binding: [0xAB; 32],
+            peer_eph_pk: [0xCD; 33],
+        });
+        let marker = [0x58, 0x20, 0xAB, 0xAB];
+        assert!(
+            encoded.windows(marker.len()).any(|w| w == marker),
+            "expected 32-byte byte-string header in {encoded:02x?}"
+        );
+    }
+
+    #[test]
+    fn secret_payload_debug_redacts_secrets() {
+        let tx_io = TxIoKeypairBytes {
+            sk: [1; 32],
+            pk: [2; 33],
+        };
+        let debug = format!("{tx_io:?}");
+        assert!(debug.contains("<redacted>"));
+        assert!(!debug.contains("1, 1"), "sk leaked: {debug}");
+
+        let rng = RngKeypairBytes {
+            keypair: vec![4; 96],
+        };
+        assert!(format!("{rng:?}").contains("<redacted>"));
+
+        let snapshot = SnapshotKeyBytes { key: [3; 32] };
+        assert!(format!("{snapshot:?}").contains("<redacted>"));
+    }
+}

--- a/crates/custodian-ipc/src/server.rs
+++ b/crates/custodian-ipc/src/server.rs
@@ -1,0 +1,366 @@
+//! Synchronous Unix-socket server for the custodian protocol.
+//!
+//! Deliberately not async: the socket serves two or three long-lived local
+//! clients with single-digit requests per process lifetime, so a thread per
+//! connection is the entire concurrency requirement and the key-holding
+//! process links no async runtime. Hosts inject *dispatch* as a closure —
+//! this crate never touches key material or depends on the custodian; it
+//! owns only the transport: bind semantics, peer credentials, ACL
+//! enforcement (structurally before dispatch), and the frame loop.
+//!
+//! Call [`serve`] from a dedicated thread; it blocks forever.
+
+use crate::framing::{read_frame_blocking, write_frame_blocking};
+use crate::messages::{Request, Response};
+use std::collections::HashSet;
+use std::fs;
+use std::io::{Read, Write};
+use std::os::unix::fs::PermissionsExt as _;
+use std::os::unix::net::{UnixListener, UnixStream};
+use std::path::Path;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use tracing::{info, warn};
+
+/// Upper bound on concurrent connections (and thus per-connection threads).
+/// Legitimate callers number in the single digits; the cap only exists so a
+/// misbehaving authorized client can't grow threads without bound.
+const MAX_CONNECTIONS: usize = 64;
+
+/// Which peer UIDs may call which methods, one allowlist per purpose so each
+/// caller is granted exactly the keys it needs. `Ping` is open to anyone who
+/// can connect (it carries no key material); everything else is
+/// deny-by-default — `MethodAcl::default()` denies all.
+#[derive(Default)]
+pub struct MethodAcl {
+    /// UIDs allowed the tx-io keypair (reth: TxSeismic calldata).
+    pub tx_io: HashSet<u32>,
+    /// UIDs allowed the RNG-precompile keypair (reth: EVM randomness).
+    pub rng: HashSet<u32>,
+    /// UIDs allowed the snapshot key (the snapshot service; NOT reth).
+    pub snapshot: HashSet<u32>,
+    /// UIDs allowed to request root-key wraps. A caller here is trusted to
+    /// have verified peer attestation first — confine to attestation-service.
+    pub wrap_root_key: HashSet<u32>,
+}
+
+impl MethodAcl {
+    /// Default until dedicated per-service users exist: only this process's
+    /// own effective UID, on every method. Exercises the socket end-to-end
+    /// while every legitimate caller still lives in the host process.
+    pub fn own_uid_only() -> Self {
+        // SAFETY: geteuid has no failure modes and touches no memory.
+        let uid = unsafe { libc::geteuid() };
+        let own = HashSet::from([uid]);
+        Self {
+            tx_io: own.clone(),
+            rng: own.clone(),
+            snapshot: own.clone(),
+            wrap_root_key: own,
+        }
+    }
+
+    pub fn allows(&self, uid: u32, request: &Request) -> bool {
+        match request {
+            Request::Ping => true,
+            Request::GetTxIoKeypair { .. } => self.tx_io.contains(&uid),
+            Request::GetRngKeypair { .. } => self.rng.contains(&uid),
+            Request::GetSnapshotKey { .. } => self.snapshot.contains(&uid),
+            Request::WrapRootKey { .. } => self.wrap_root_key.contains(&uid),
+        }
+    }
+}
+
+/// Bind the custodian socket. Separate from [`serve`] so hosts can fail hard
+/// at startup if the socket can't exist (and tests can bind a tmpdir path).
+pub fn bind(path: &Path) -> std::io::Result<UnixListener> {
+    // A previous run's socket inode makes bind() fail even though nothing is
+    // listening; remove it. /run is tmpfs so this only matters for restarts.
+    match fs::remove_file(path) {
+        Ok(()) => {}
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+        Err(e) => return Err(e),
+    }
+    let listener = UnixListener::bind(path)?;
+    // 0660: owner + group only. The group decides who may even connect;
+    // MethodAcl decides what a connected UID may call.
+    fs::set_permissions(path, fs::Permissions::from_mode(0o660))?;
+    info!("custodian IPC listening on {}", path.display());
+    Ok(listener)
+}
+
+/// Accept loop: one thread per connection, `handler` invoked only for
+/// requests the ACL allows for the peer's kernel-reported UID. Blocks
+/// forever; per-connection errors are logged and drop only that connection.
+pub fn serve<H>(listener: UnixListener, acl: MethodAcl, handler: H)
+where
+    H: Fn(Request) -> Response + Send + Sync + 'static,
+{
+    let acl = Arc::new(acl);
+    let handler = Arc::new(handler);
+    let active = Arc::new(AtomicUsize::new(0));
+    loop {
+        let (stream, _addr) = match listener.accept() {
+            Ok(conn) => conn,
+            Err(e) => {
+                warn!("custodian IPC: accept failed: {e}");
+                continue;
+            }
+        };
+        let uid = match peer_uid(&stream) {
+            Ok(uid) => uid,
+            Err(e) => {
+                // No credentials means no ACL decision; never serve blind.
+                warn!("custodian IPC: dropping connection without peer creds: {e}");
+                continue;
+            }
+        };
+        if active.load(Ordering::Acquire) >= MAX_CONNECTIONS {
+            warn!(uid, "custodian IPC: connection limit reached, dropping");
+            continue;
+        }
+        active.fetch_add(1, Ordering::AcqRel);
+        let (acl, handler, active) = (acl.clone(), handler.clone(), active.clone());
+        std::thread::spawn(move || {
+            // Decrement via a drop guard so a panicking handler can't leak
+            // the slot — 64 leaked slots would stop the socket serving keys.
+            struct SlotGuard(Arc<AtomicUsize>);
+            impl Drop for SlotGuard {
+                fn drop(&mut self) {
+                    self.0.fetch_sub(1, Ordering::AcqRel);
+                }
+            }
+            let _slot = SlotGuard(active);
+            handle_connection(stream, uid, &acl, &*handler);
+        });
+    }
+}
+
+/// Serve one connection whose peer the kernel identified as `uid`. Generic
+/// over the stream so the request/ACL/dispatch path is testable over
+/// in-memory buffers; only [`serve`] touches real sockets and peer creds.
+fn handle_connection<S, H>(mut stream: S, uid: u32, acl: &MethodAcl, handler: &H)
+where
+    S: Read + Write,
+    H: Fn(Request) -> Response + ?Sized,
+{
+    loop {
+        let request: Request = match read_frame_blocking(&mut stream) {
+            Ok(Some(request)) => request,
+            Ok(None) => return, // peer closed
+            Err(e) => {
+                warn!(uid, "custodian IPC: dropping connection: {e}");
+                return;
+            }
+        };
+        let response = if acl.allows(uid, &request) {
+            handler(request)
+        } else {
+            warn!(
+                uid,
+                method = request.method(),
+                "custodian IPC: denied by ACL"
+            );
+            Response::Denied {
+                message: format!("uid {uid} is not authorized for {}", request.method()),
+            }
+        };
+        if let Err(e) = write_frame_blocking(&mut stream, &response) {
+            warn!(uid, "custodian IPC: write failed: {e}");
+            return;
+        }
+    }
+}
+
+/// Kernel-reported UID of the connected peer. std's `peer_cred()` is
+/// unstable, so ask libc directly.
+#[cfg(target_os = "linux")]
+fn peer_uid(stream: &UnixStream) -> std::io::Result<u32> {
+    use std::os::fd::AsRawFd as _;
+    let mut cred = libc::ucred {
+        pid: 0,
+        uid: 0,
+        gid: 0,
+    };
+    let mut len = size_of::<libc::ucred>() as libc::socklen_t;
+    // SAFETY: fd is a live socket owned by `stream`; the kernel writes at
+    // most `len` bytes into `cred`, which is sized for exactly that.
+    let rc = unsafe {
+        libc::getsockopt(
+            stream.as_raw_fd(),
+            libc::SOL_SOCKET,
+            libc::SO_PEERCRED,
+            (&raw mut cred).cast(),
+            &raw mut len,
+        )
+    };
+    if rc != 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok(cred.uid)
+}
+
+/// macOS analogue of `SO_PEERCRED`, for dev machines; production is Linux.
+#[cfg(target_os = "macos")]
+fn peer_uid(stream: &UnixStream) -> std::io::Result<u32> {
+    use std::os::fd::AsRawFd as _;
+    let mut uid: libc::uid_t = 0;
+    let mut gid: libc::gid_t = 0;
+    // SAFETY: fd is a live socket owned by `stream`; getpeereid writes one
+    // uid_t and one gid_t through the provided pointers.
+    let rc = unsafe { libc::getpeereid(stream.as_raw_fd(), &raw mut uid, &raw mut gid) };
+    if rc != 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok(uid)
+}
+
+// Fail loudly on an unsupported target instead of compiling a server that
+// cannot authenticate its peers.
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+compile_error!("custodian IPC server requires SO_PEERCRED or getpeereid");
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::framing::encode_frame;
+    use std::io::Cursor;
+
+    const UID: u32 = 1000;
+
+    /// In-memory stand-in for a connection: reads scripted request frames,
+    /// captures response frames.
+    struct ScriptedStream {
+        input: Cursor<Vec<u8>>,
+        output: Vec<u8>,
+    }
+
+    impl Read for ScriptedStream {
+        fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+            self.input.read(buf)
+        }
+    }
+
+    impl Write for ScriptedStream {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.output.write(buf)
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    /// Run one connection to completion and return the responses.
+    fn run_connection<H>(
+        requests: &[Request],
+        uid: u32,
+        acl: &MethodAcl,
+        handler: H,
+    ) -> Vec<Response>
+    where
+        H: Fn(Request) -> Response,
+    {
+        let mut wire = Vec::new();
+        for request in requests {
+            wire.extend(encode_frame(request).expect("encode"));
+        }
+        let mut stream = ScriptedStream {
+            input: Cursor::new(wire),
+            output: Vec::new(),
+        };
+        handle_connection(&mut stream, uid, acl, &handler);
+        let mut reader = stream.output.as_slice();
+        let mut responses = Vec::new();
+        while let Some(response) = read_frame_blocking(&mut reader).expect("read response") {
+            responses.push(response);
+        }
+        responses
+    }
+
+    fn allow_all_for(uid: u32) -> MethodAcl {
+        let own = HashSet::from([uid]);
+        MethodAcl {
+            tx_io: own.clone(),
+            rng: own.clone(),
+            snapshot: own.clone(),
+            wrap_root_key: own,
+        }
+    }
+
+    #[test]
+    fn handler_sees_allowed_requests() {
+        let responses = run_connection(
+            &[Request::Ping, Request::GetTxIoKeypair { epoch: 4 }],
+            UID,
+            &allow_all_for(UID),
+            |request| match request {
+                Request::Ping => Response::Pong,
+                Request::GetTxIoKeypair { epoch } => Response::Error {
+                    message: format!("handler saw epoch {epoch}"),
+                },
+                _ => unreachable!(),
+            },
+        );
+        assert!(matches!(responses[0], Response::Pong));
+        let Response::Error { message } = &responses[1] else {
+            panic!("expected handler response");
+        };
+        assert_eq!(message, "handler saw epoch 4");
+    }
+
+    #[test]
+    fn denied_request_never_reaches_handler_but_ping_does() {
+        let responses = run_connection(
+            &[
+                Request::GetTxIoKeypair { epoch: 0 },
+                Request::Ping, // a denial answers the request; it doesn't poison the connection
+            ],
+            UID,
+            &MethodAcl::default(), // deny-all
+            |request| match request {
+                Request::Ping => Response::Pong,
+                _ => panic!("handler must not see denied requests"),
+            },
+        );
+        let Response::Denied { message } = &responses[0] else {
+            panic!("expected denial");
+        };
+        assert!(message.contains("not authorized"), "{message}");
+        assert!(matches!(responses[1], Response::Pong));
+    }
+
+    // The point of per-purpose methods: a grant for one key purpose implies
+    // nothing about any other.
+    #[test]
+    fn purpose_grants_are_independent() {
+        let reth_like = MethodAcl {
+            tx_io: HashSet::from([UID]),
+            rng: HashSet::from([UID]),
+            ..MethodAcl::default()
+        };
+        assert!(reth_like.allows(UID, &Request::GetTxIoKeypair { epoch: 0 }));
+        assert!(reth_like.allows(UID, &Request::GetRngKeypair { epoch: 0 }));
+        assert!(!reth_like.allows(UID, &Request::GetSnapshotKey { epoch: 0 }));
+        assert!(!reth_like.allows(
+            UID,
+            &Request::WrapRootKey {
+                root_key_request_binding: [0; 32],
+                peer_eph_pk: [0; 33],
+            }
+        ));
+        assert!(!reth_like.allows(UID + 1, &Request::GetTxIoKeypair { epoch: 0 }));
+    }
+
+    #[test]
+    fn oversize_frame_drops_connection_without_reply() {
+        let mut stream = ScriptedStream {
+            input: Cursor::new(u32::MAX.to_be_bytes().to_vec()),
+            output: Vec::new(),
+        };
+        handle_connection(&mut stream, UID, &allow_all_for(UID), &|_| Response::Pong);
+        assert!(
+            stream.output.is_empty(),
+            "server must close on an oversize frame, not answer"
+        );
+    }
+}

--- a/crates/enclave-server/Cargo.toml
+++ b/crates/enclave-server/Cargo.toml
@@ -20,6 +20,7 @@ path = "src/main.rs"
 [dependencies]
 seismic-enclave.workspace = true
 seismic-attestation.workspace = true
+seismic-custodian-ipc = { workspace = true, features = ["server"] }
 seismic-key-custodian.workspace = true
 enclave-contract.workspace = true
 

--- a/crates/enclave-server/src/ipc.rs
+++ b/crates/enclave-server/src/ipc.rs
@@ -1,0 +1,204 @@
+//! Dispatch for the custodian Unix socket: the shim between the wire
+//! protocol and [`Custodian`].
+//!
+//! The transport — bind semantics, peer credentials, ACL-before-dispatch,
+//! the frame loop — lives in `seismic_custodian_ipc::server` and is shared
+//! with any future host. This module is only the part that must live next to
+//! the key: mapping authorized [`Request`]s onto custodian operations.
+
+use anyhow::Context as _;
+use seismic_custodian_ipc::{
+    Request, Response, RngKeypairBytes, SnapshotKeyBytes, TxIoKeypairBytes, WrappedRootKeyBytes,
+};
+use seismic_key_custodian::{Custodian, VerifiedPeerAuthorization};
+
+/// Map one ACL-authorized socket request onto the custodian.
+///
+/// No production caller connects to the socket yet — reth still fetches keys
+/// over HTTP `getPurposeKeys`, and the bootstrap responder calls `Custodian`
+/// directly in-process — so today only tests and the debug CLI land here.
+/// See the wiring note in `server::start_server`.
+pub fn dispatch(custodian: &Custodian, request: Request) -> Response {
+    match request {
+        Request::Ping => Response::Pong,
+        Request::GetTxIoKeypair { epoch } => Response::TxIoKeypair(TxIoKeypairBytes {
+            sk: custodian.get_tx_io_sk(epoch).secret_bytes(),
+            pk: custodian.get_tx_io_pk(epoch).serialize(),
+        }),
+        Request::GetRngKeypair { epoch } => Response::RngKeypair(RngKeypairBytes {
+            keypair: custodian.get_rng_keypair(epoch).to_bytes().to_vec(),
+        }),
+        Request::GetSnapshotKey { epoch } => Response::SnapshotKey(SnapshotKeyBytes {
+            key: custodian.get_snapshot_key(epoch).into(),
+        }),
+        Request::WrapRootKey {
+            root_key_request_binding,
+            peer_eph_pk,
+        } => match wrap_root_key(custodian, root_key_request_binding, &peer_eph_pk) {
+            Ok(wrapped) => Response::WrappedRootKey(wrapped),
+            Err(e) => Response::Error {
+                message: format!("wrap_root_key: {e:#}"),
+            },
+        },
+    }
+}
+
+fn wrap_root_key(
+    custodian: &Custodian,
+    root_key_request_binding: [u8; 32],
+    peer_eph_pk: &[u8; 33],
+) -> anyhow::Result<WrappedRootKeyBytes> {
+    let peer_pk = secp256k1::PublicKey::from_slice(peer_eph_pk)
+        .context("peer_eph_pk is not a valid compressed secp256k1 point")?;
+    let auth = VerifiedPeerAuthorization {
+        root_key_request_binding,
+    };
+    let wrapped = custodian.wrap_root_key_for_peer(&auth, &peer_pk)?;
+    Ok(WrappedRootKeyBytes {
+        responder_eph_pk: wrapped.responder_eph_pk.serialize(),
+        wrapped: wrapped.wrapped,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use seismic_key_custodian::{EphemeralKeypair, unwrap_root_key};
+
+    const ROOT_KEY: [u8; 32] = [7u8; 32];
+
+    #[test]
+    fn ping_pong() {
+        let custodian = Custodian::new(ROOT_KEY);
+        assert!(matches!(
+            dispatch(&custodian, Request::Ping),
+            Response::Pong
+        ));
+    }
+
+    #[test]
+    fn purpose_keys_match_direct_derivation() {
+        let custodian = Custodian::new(ROOT_KEY);
+
+        // Parity with the JSON-RPC get_purpose_keys handler: both surfaces
+        // serve the same Custodian getters.
+        let Response::TxIoKeypair(tx_io) =
+            dispatch(&custodian, Request::GetTxIoKeypair { epoch: 0 })
+        else {
+            panic!("expected tx-io keypair");
+        };
+        assert_eq!(tx_io.sk, custodian.get_tx_io_sk(0).secret_bytes());
+        assert_eq!(tx_io.pk, custodian.get_tx_io_pk(0).serialize());
+
+        let Response::RngKeypair(rng) = dispatch(&custodian, Request::GetRngKeypair { epoch: 0 })
+        else {
+            panic!("expected rng keypair");
+        };
+        assert_eq!(
+            rng.keypair,
+            custodian.get_rng_keypair(0).to_bytes().to_vec()
+        );
+
+        let Response::SnapshotKey(snapshot) =
+            dispatch(&custodian, Request::GetSnapshotKey { epoch: 0 })
+        else {
+            panic!("expected snapshot key");
+        };
+        let expected: [u8; 32] = custodian.get_snapshot_key(0).into();
+        assert_eq!(snapshot.key, expected);
+
+        let Response::TxIoKeypair(tx_io_epoch1) =
+            dispatch(&custodian, Request::GetTxIoKeypair { epoch: 1 })
+        else {
+            panic!("expected tx-io keypair");
+        };
+        assert_ne!(tx_io.sk, tx_io_epoch1.sk, "epochs must differ");
+    }
+
+    #[test]
+    fn wrap_root_key_roundtrips_through_unwrap() {
+        let custodian = Custodian::new(ROOT_KEY);
+        let eph = EphemeralKeypair::generate();
+        let binding = [0x33u8; 32];
+        let Response::WrappedRootKey(wrapped) = dispatch(
+            &custodian,
+            Request::WrapRootKey {
+                root_key_request_binding: binding,
+                peer_eph_pk: eph.pk_compressed(),
+            },
+        ) else {
+            panic!("expected wrapped root key");
+        };
+
+        let responder_pk =
+            secp256k1::PublicKey::from_slice(&wrapped.responder_eph_pk).expect("responder pk");
+        let recovered =
+            unwrap_root_key(&eph.sk, &responder_pk, &wrapped.wrapped, &binding).expect("unwrap");
+        assert_eq!(recovered, ROOT_KEY);
+    }
+
+    #[test]
+    fn wrap_root_key_rejects_invalid_peer_point() {
+        let custodian = Custodian::new(ROOT_KEY);
+        let response = dispatch(
+            &custodian,
+            Request::WrapRootKey {
+                root_key_request_binding: [0u8; 32],
+                peer_eph_pk: [0u8; 33],
+            },
+        );
+        assert!(matches!(response, Response::Error { .. }));
+    }
+
+    /// Coverage over a real `UnixListener`: bind semantics, `SO_PEERCRED`
+    /// attribution, and the crate server + async client end-to-end. Needs an
+    /// environment permitting `AF_UNIX` bind (CI, a dev machine); in a
+    /// sandbox that forbids it, skip with `-- --skip real_socket`.
+    mod real_socket {
+        use super::*;
+        use seismic_custodian_ipc::CustodianClient;
+        use seismic_custodian_ipc::server::{MethodAcl, bind, serve};
+        use std::os::unix::fs::PermissionsExt as _;
+        use std::sync::Arc;
+
+        #[test]
+        fn bind_sets_permissions_and_replaces_stale_socket() {
+            let dir = tempfile::tempdir().expect("tempdir");
+            let path = dir.path().join("custodian.sock");
+
+            // Bind, then bind again without unlinking: the stale inode from
+            // the "previous run" must be replaced, not fail the restart.
+            let stale = bind(&path).expect("first bind");
+            drop(stale);
+            let listener = bind(&path).expect("rebind over stale socket");
+            drop(listener);
+
+            let mode = std::fs::metadata(&path)
+                .expect("metadata")
+                .permissions()
+                .mode();
+            assert_eq!(mode & 0o777, 0o660, "socket must be 0660");
+        }
+
+        #[tokio::test]
+        async fn own_uid_is_authorized_via_peer_cred() {
+            let dir = tempfile::tempdir().expect("tempdir");
+            let path = dir.path().join("custodian.sock");
+            let listener = bind(&path).expect("bind");
+            let custodian = Arc::new(Custodian::new(ROOT_KEY));
+            std::thread::spawn(move || {
+                serve(listener, MethodAcl::own_uid_only(), move |request| {
+                    dispatch(&custodian, request)
+                })
+            });
+
+            // The test process connects as itself, so the kernel reports our
+            // own UID and the own-uid-only ACL must authorize key methods.
+            let mut client = CustodianClient::connect(&path).await.expect("connect");
+            client.ping().await.expect("ping");
+            let keys = client.get_tx_io_keypair(0).await.expect("tx-io keypair");
+            let custodian = Custodian::new(ROOT_KEY);
+            assert_eq!(keys.sk, custodian.get_tx_io_sk(0).secret_bytes());
+        }
+    }
+}

--- a/crates/enclave-server/src/lib.rs
+++ b/crates/enclave-server/src/lib.rs
@@ -1,5 +1,6 @@
 mod attestation;
 mod bootstrap;
+pub mod ipc;
 mod luks_keys;
 mod luks_status;
 mod network;

--- a/crates/enclave-server/src/server.rs
+++ b/crates/enclave-server/src/server.rs
@@ -9,6 +9,7 @@ use crate::{
     network::{NETWORK_MANIFEST_PATH, load_network_id},
     utils::anyhow_to_rpc_error,
 };
+use anyhow::Context as _;
 use dcap_rs::types::quotes::version_4::QuoteV4;
 use jsonrpsee::{
     core::{RpcResult, async_trait},
@@ -16,12 +17,13 @@ use jsonrpsee::{
     server::ServerBuilder,
 };
 use seismic_attestation::{AttestationType, NetworkId, SeismicMeasurementPolicy};
+use seismic_custodian_ipc::CUSTODIAN_SOCKET_PATH;
 use seismic_enclave::{
     AttestationGetEvidenceResponse, GetPurposeKeysResponse, LuksProvisioningStatus,
     TdxQuoteRpcClient as _, api::TdxQuoteRpcServer,
 };
 use seismic_key_custodian::Custodian;
-use std::{net::SocketAddr, time::Duration};
+use std::{net::SocketAddr, path::Path, sync::Arc, time::Duration};
 use tracing::{info, warn};
 
 /// Attestation type this build mints and verifies evidence for. Azure TDX +
@@ -33,7 +35,12 @@ const TX_IO_BINDING_EPOCH: u64 = 0;
 
 pub struct TdxQuoteServer {
     attestation_agent: AttestationAgent,
-    custodian: Custodian,
+    /// `Arc` because the one `Custodian` per process (it is deliberately not
+    /// `Clone`) is shared with the IPC socket thread spawned in
+    /// [`start_server`]; every method on it is `&self`, so no lock.
+    /// TODO: once the custodian runs as its own process and this server reaches it
+    /// over the socket, drop the `Arc` with the field.
+    custodian: Arc<Custodian>,
     /// This node's network identity: `H(network-manifest.json)`. Every
     /// attestation binding this server mints or verifies is scoped to it.
     network_id: NetworkId,
@@ -42,7 +49,7 @@ pub struct TdxQuoteServer {
 impl TdxQuoteServer {
     pub fn new(
         attestation_agent: AttestationAgent,
-        custodian: Custodian,
+        custodian: Arc<Custodian>,
         network_id: NetworkId,
     ) -> Self {
         Self {
@@ -165,6 +172,28 @@ pub async fn start_server(addr: SocketAddr, args: Args) -> anyhow::Result<()> {
     // these keys reaching the LUKS-setup script, /persistent can't
     // mount and the node can't proceed past this boot.
     luks_keys::write_keys_for_luks_setup(&custodian)?;
+
+    // The same process also serves local key ops over a Unix socket — the
+    // seam along which the custodian later splits into its own process. The
+    // transport is `seismic_custodian_ipc::server` (synchronous, hence the
+    // dedicated thread); only dispatch (`crate::ipc`) lives here. No
+    // production caller connects yet: in-process users call `Custodian`
+    // directly and reth still fetches keys over HTTP `getPurposeKeys`, so
+    // until the split moves them onto the socket, only the debug CLI (and
+    // tests) exercise it. Bind failure is fatal anyway: a
+    // node that can't serve the socket should fail this boot, not at the
+    // split, and /run/seismic already had to exist for the manifest read.
+    let custodian = Arc::new(custodian);
+    let ipc_listener = seismic_custodian_ipc::server::bind(Path::new(CUSTODIAN_SOCKET_PATH))
+        .with_context(|| format!("binding custodian socket {CUSTODIAN_SOCKET_PATH}"))?;
+    let ipc_custodian = custodian.clone();
+    std::thread::spawn(move || {
+        seismic_custodian_ipc::server::serve(
+            ipc_listener,
+            seismic_custodian_ipc::server::MethodAcl::own_uid_only(),
+            move |request| crate::ipc::dispatch(&ipc_custodian, request),
+        )
+    });
 
     let server = ServerBuilder::default().build(addr).await?;
 


### PR DESCRIPTION
Add seismic-custodian-ipc, a leaf crate carrying both ends of the custodian wire surface, and host its server in enclave-server at /run/seismic/custodian.sock. This is the seam along which the custodian later splits into its own process: at split time the dispatch closure and wiring move to the custodian binary, no transport code moves.

The crate stays a leaf (no custodian/attestation/crypto deps): key material crosses the wire as raw bytes, and the server takes dispatch as an injected closure. Feature-gated by host needs — core (wire types
+ blocking framing: serde/ciborium/zeroize only), `client` (default; async CustodianClient for tokio hosts), `server` (synchronous thread-per-connection listener, peer creds via SO_PEERCRED/getpeereid), `cli` (debug binary; prints fingerprints, never raw secrets) — so the future key-holding binary links no async runtime.

Wire protocol: u32-BE length prefix + CBOR body, MAX_FRAME_BODY_LEN enforced before allocation. Messages are per-purpose key fetches (tx-io, rng, snapshot — each with an independent epoch), WrapRootKey (takes the caller-verified request binding; the custodian never sees evidence), and an ACL-open Ping. Failure variants are split by layer: Denied is minted only by the transport ACL, Error only by dispatch.

Access control is two gates: socket mode 0660 decides who may connect; a deny-by-default per-method UID allowlist (MethodAcl) decides what a connected peer may call. Until per-service users exist, enclave-server runs own-uid-only.

Key-hygiene details: frame buffers are zeroized after I/O and encoding reserves the full frame bound up front so no realloc strands an unscrubbed copy; secret payloads are ZeroizeOnDrop with redacted Debug.

## Note

No production caller connects yet — reth still fetches keys over HTTP getPurposeKeys and the bootstrap responder calls Custodian directly — so the wire format can still change freely while the transport soaks.