### PR TITLE
fix(ci): run every compiled test binary in the sudo jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,11 @@ jobs:
           cd crates/enclave
           OUTPUT=$(cargo test -p seismic-enclave --no-run 2>&1)
           echo "$OUTPUT"
-          mapfile -t binaries < <(echo "$OUTPUT" | grep -o '/[^ ]*seismic_enclave-[a-z0-9]*')
+          # Parse cargo's `Executable ... (path)` lines rather than grepping
+          # for crate-named binaries: name greps silently skip standalone
+          # tests/*.rs targets, whose binaries are named after the test file.
+          mapfile -t binaries < <(echo "$OUTPUT" | sed -nE 's/^[[:space:]]*Executable .*\((.+)\)$/\1/p')
+          [ ${#binaries[@]} -gt 0 ] || { echo "no test binaries found"; exit 1; }
           for binary in "${binaries[@]}"; do
             echo "Running binary: $binary"
             sudo "$binary"
@@ -111,8 +115,24 @@ jobs:
           cd crates/enclave-server
           OUTPUT=$(cargo test -p seismic-enclave-server --no-run 2>&1)
           echo "$OUTPUT"
-          mapfile -t binaries < <(echo "$OUTPUT" | grep -o '/[^ ]*seismic_enclave_server-[a-z0-9]*')
+          # Parse cargo's `Executable ... (path)` lines rather than grepping
+          # for crate-named binaries: name greps silently skip standalone
+          # tests/*.rs targets, whose binaries are named after the test file.
+          mapfile -t binaries < <(echo "$OUTPUT" | sed -nE 's/^[[:space:]]*Executable .*\((.+)\)$/\1/p')
+          [ ${#binaries[@]} -gt 0 ] || { echo "no test binaries found"; exit 1; }
           for binary in "${binaries[@]}"; do
+            case "$(basename "$binary")" in
+              # tests/integration is the integration_tests job's payload:
+              # run_integration_tests.sh runs it against the supervisor
+              # devnet, which provides the network manifest that
+              # enclave-server fatally requires at startup. It cannot pass
+              # in this job's bare environment. Do NOT add further entries
+              # here without a matching reason.
+              integration-*)
+                echo "SKIPPING $binary (integration_tests job's payload; needs the devnet)"
+                continue
+                ;;
+            esac
             echo "Running binary: $binary"
             sudo "$binary"
           done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,10 @@ jobs:
       - name: Run tests for seismic-enclave
         run: |
           cd crates/enclave
-          OUTPUT=$(cargo test -p seismic-enclave --no-run 2>&1)
+          # CARGO_TERM_COLOR=never: the workflow forces color globally, and
+          # the ANSI codes around cargo's status verbs would break the
+          # line-anchored sed below.
+          OUTPUT=$(CARGO_TERM_COLOR=never cargo test -p seismic-enclave --no-run 2>&1)
           echo "$OUTPUT"
           # Parse cargo's `Executable ... (path)` lines rather than grepping
           # for crate-named binaries: name greps silently skip standalone
@@ -113,7 +116,10 @@ jobs:
       - name: Run tests for seismic-enclave-server
         run: |
           cd crates/enclave-server
-          OUTPUT=$(cargo test -p seismic-enclave-server --no-run 2>&1)
+          # CARGO_TERM_COLOR=never: the workflow forces color globally, and
+          # the ANSI codes around cargo's status verbs would break the
+          # line-anchored sed below.
+          OUTPUT=$(CARGO_TERM_COLOR=never cargo test -p seismic-enclave-server --no-run 2>&1)
           echo "$OUTPUT"
           # Parse cargo's `Executable ... (path)` lines rather than grepping
           # for crate-named binaries: name greps silently skip standalone


### PR DESCRIPTION
The test_enclave and test_enclave_server jobs discovered test binaries by grepping cargo output for crate-named files, which only matches the lib/bin unittest binaries. Standalone tests/*.rs targets compile to binaries named after the test file, so the grep silently skipped them — the job stayed green while running less than it appeared to.

Parse cargo's `Executable ... (path)` lines instead, which enumerate every test binary regardless of name, and fail the job outright if parsing finds none rather than green-washing an empty loop.

The one binary this surfaces, enclave-server's tests/integration, is deliberately skipped with a printed reason: it is the integration_tests job's payload (run_integration_tests.sh runs it against the supervisor devnet, which provides the network manifest that enclave-server fatally requires at startup) and cannot pass in this job's bare environment.