### PR TITLE
feat(custodian-ipc): define API for standalone key custody

### DIFF
--- a/crates/custodian-ipc/src/client.rs
+++ b/crates/custodian-ipc/src/client.rs
@@ -8,7 +8,8 @@
 use crate::error::IpcError;
 use crate::framing::{read_frame, write_frame};
 use crate::messages::{
-    Request, Response, RngKeypairBytes, SnapshotKeyBytes, TxIoKeypairBytes, WrappedRootKeyBytes,
+    Request, Response, RngKeypairBytes, RootKeyBootstrapAttemptBytes, SnapshotKeyBytes,
+    TxIoKeypairBytes, TxIoPublicKeyBytes, WrappedRootKeyBytes,
 };
 use std::path::Path;
 use tokio::net::UnixStream;
@@ -32,6 +33,7 @@ impl CustodianClient {
         match read_frame(&mut self.stream).await? {
             Some(Response::Denied { message }) => Err(IpcError::Denied(message)),
             Some(Response::Error { message }) => Err(IpcError::Custodian(message)),
+            Some(Response::RootKeyAbsent) => Err(IpcError::RootKeyAbsent),
             Some(response) => Ok(response),
             None => Err(std::io::Error::new(
                 std::io::ErrorKind::UnexpectedEof,
@@ -44,34 +46,57 @@ impl CustodianClient {
     pub async fn ping(&mut self) -> Result<(), IpcError> {
         match self.call(&Request::Ping).await? {
             Response::Pong => Ok(()),
-            _ => Err(IpcError::UnexpectedResponse { method: "ping" }),
+            response => Err(unexpected_response("ping", &response)),
         }
     }
 
     pub async fn get_tx_io_keypair(&mut self, epoch: u64) -> Result<TxIoKeypairBytes, IpcError> {
         match self.call(&Request::GetTxIoKeypair { epoch }).await? {
             Response::TxIoKeypair(keys) => Ok(keys),
-            _ => Err(IpcError::UnexpectedResponse {
-                method: "get_tx_io_keypair",
-            }),
+            response => Err(unexpected_response("get_tx_io_keypair", &response)),
+        }
+    }
+
+    pub async fn get_tx_io_public_key(
+        &mut self,
+        epoch: u64,
+    ) -> Result<TxIoPublicKeyBytes, IpcError> {
+        match self.call(&Request::GetTxIoPublicKey { epoch }).await? {
+            Response::TxIoPublicKey(key) => Ok(key),
+            response => Err(unexpected_response("get_tx_io_public_key", &response)),
         }
     }
 
     pub async fn get_rng_keypair(&mut self, epoch: u64) -> Result<RngKeypairBytes, IpcError> {
         match self.call(&Request::GetRngKeypair { epoch }).await? {
             Response::RngKeypair(keys) => Ok(keys),
-            _ => Err(IpcError::UnexpectedResponse {
-                method: "get_rng_keypair",
-            }),
+            response => Err(unexpected_response("get_rng_keypair", &response)),
         }
     }
 
     pub async fn get_snapshot_key(&mut self, epoch: u64) -> Result<SnapshotKeyBytes, IpcError> {
         match self.call(&Request::GetSnapshotKey { epoch }).await? {
             Response::SnapshotKey(key) => Ok(key),
-            _ => Err(IpcError::UnexpectedResponse {
-                method: "get_snapshot_key",
-            }),
+            response => Err(unexpected_response("get_snapshot_key", &response)),
+        }
+    }
+
+    /// Start requester-side bootstrap. `RootKeyAlreadyPresent` is an expected
+    /// outcome after an attestation-service restart, not an IPC failure.
+    pub async fn create_root_key_bootstrap_attempt(
+        &mut self,
+    ) -> Result<CreateRootKeyBootstrapAttemptResult, IpcError> {
+        match self.call(&Request::CreateRootKeyBootstrapAttempt).await? {
+            Response::RootKeyBootstrapAttemptCreated(attempt) => {
+                Ok(CreateRootKeyBootstrapAttemptResult::Created(attempt))
+            }
+            Response::RootKeyAlreadyPresent => {
+                Ok(CreateRootKeyBootstrapAttemptResult::RootKeyAlreadyPresent)
+            }
+            response => Err(unexpected_response(
+                "create_root_key_bootstrap_attempt",
+                &response,
+            )),
         }
     }
 
@@ -88,9 +113,190 @@ impl CustodianClient {
             .await?
         {
             Response::WrappedRootKey(wrapped) => Ok(wrapped),
-            _ => Err(IpcError::UnexpectedResponse {
-                method: "wrap_root_key",
-            }),
+            response => Err(unexpected_response("wrap_root_key", &response)),
         }
+    }
+
+    pub async fn install_root_key_from_verified_bootstrap_response(
+        &mut self,
+        attempt_id: [u8; 32],
+        root_key_request_binding: [u8; 32],
+        responder_eph_pk: [u8; 33],
+        wrapped_root_key: Vec<u8>,
+    ) -> Result<InstallRootKeyFromVerifiedBootstrapResponseResult, IpcError> {
+        match self
+            .call(&Request::InstallRootKeyFromVerifiedBootstrapResponse {
+                attempt_id,
+                root_key_request_binding,
+                responder_eph_pk,
+                wrapped_root_key,
+            })
+            .await?
+        {
+            Response::RootKeyInstalled => {
+                Ok(InstallRootKeyFromVerifiedBootstrapResponseResult::Installed)
+            }
+            Response::RootKeyAlreadyPresent => {
+                Ok(InstallRootKeyFromVerifiedBootstrapResponseResult::RootKeyAlreadyPresent)
+            }
+            response => Err(unexpected_response(
+                "install_root_key_from_verified_bootstrap_response",
+                &response,
+            )),
+        }
+    }
+}
+
+fn unexpected_response(method: &'static str, response: &Response) -> IpcError {
+    IpcError::UnexpectedResponse {
+        method,
+        received: response.kind(),
+    }
+}
+
+/// Outcome of [`CustodianClient::create_root_key_bootstrap_attempt`].
+#[derive(Debug, Clone)]
+pub enum CreateRootKeyBootstrapAttemptResult {
+    /// A fresh requester ephemeral secret is retained under this attempt.
+    Created(RootKeyBootstrapAttemptBytes),
+    /// Bootstrap is unnecessary because this custodian already holds the key.
+    RootKeyAlreadyPresent,
+}
+
+/// Outcome of
+/// [`CustodianClient::install_root_key_from_verified_bootstrap_response`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InstallRootKeyFromVerifiedBootstrapResponseResult {
+    /// The wrapped response was opened and its root key installed.
+    Installed,
+    /// The custodian already held a root key, so it installed nothing.
+    RootKeyAlreadyPresent,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn scripted_client(response: Response) -> (CustodianClient, tokio::task::JoinHandle<Request>) {
+        let (client_stream, mut server_stream) = UnixStream::pair().expect("UnixStream pair");
+        let server = tokio::spawn(async move {
+            let request = read_frame(&mut server_stream)
+                .await
+                .expect("read request")
+                .expect("request frame");
+            write_frame(&mut server_stream, &response)
+                .await
+                .expect("write response");
+            request
+        });
+        (
+            CustodianClient {
+                stream: client_stream,
+            },
+            server,
+        )
+    }
+
+    #[tokio::test]
+    async fn new_methods_map_successful_responses() {
+        let (mut client, server) =
+            scripted_client(Response::TxIoPublicKey(TxIoPublicKeyBytes { pk: [2; 33] }));
+        let public_key = client.get_tx_io_public_key(7).await.expect("public key");
+        assert_eq!(public_key.pk, [2; 33]);
+        assert!(matches!(
+            server.await.expect("server task"),
+            Request::GetTxIoPublicKey { epoch: 7 }
+        ));
+
+        let attempt = RootKeyBootstrapAttemptBytes {
+            attempt_id: [3; 32],
+            requester_eph_pk: [4; 33],
+        };
+        let (mut client, server) =
+            scripted_client(Response::RootKeyBootstrapAttemptCreated(attempt.clone()));
+        let result = client
+            .create_root_key_bootstrap_attempt()
+            .await
+            .expect("create attempt");
+        let CreateRootKeyBootstrapAttemptResult::Created(created) = result else {
+            panic!("expected a created attempt");
+        };
+        assert_eq!(created.attempt_id, attempt.attempt_id);
+        assert_eq!(created.requester_eph_pk, attempt.requester_eph_pk);
+        assert!(matches!(
+            server.await.expect("server task"),
+            Request::CreateRootKeyBootstrapAttempt
+        ));
+
+        let (mut client, server) = scripted_client(Response::RootKeyInstalled);
+        let result = client
+            .install_root_key_from_verified_bootstrap_response(
+                [5; 32],
+                [6; 32],
+                [7; 33],
+                vec![8; 60],
+            )
+            .await
+            .expect("install root key");
+        assert_eq!(
+            result,
+            InstallRootKeyFromVerifiedBootstrapResponseResult::Installed
+        );
+        let Request::InstallRootKeyFromVerifiedBootstrapResponse {
+            attempt_id,
+            root_key_request_binding,
+            responder_eph_pk,
+            wrapped_root_key,
+        } = server.await.expect("server task")
+        else {
+            panic!("expected install request");
+        };
+        assert_eq!(attempt_id, [5; 32]);
+        assert_eq!(root_key_request_binding, [6; 32]);
+        assert_eq!(responder_eph_pk, [7; 33]);
+        assert_eq!(wrapped_root_key, vec![8; 60]);
+    }
+
+    #[tokio::test]
+    async fn state_and_handler_failures_remain_typed() {
+        let (mut client, server) = scripted_client(Response::RootKeyAbsent);
+        let error = client.get_rng_keypair(0).await.expect_err("must fail");
+        assert!(matches!(error, IpcError::RootKeyAbsent));
+        server.await.expect("server task");
+
+        let (mut client, server) = scripted_client(Response::Error {
+            message: "stable custodian error".into(),
+        });
+        let error = client.get_snapshot_key(0).await.expect_err("must fail");
+        assert!(matches!(
+            error,
+            IpcError::Custodian(message) if message == "stable custodian error"
+        ));
+        server.await.expect("server task");
+    }
+
+    #[tokio::test]
+    async fn unexpected_response_reports_only_its_kind() {
+        let (mut client, server) = scripted_client(Response::TxIoKeypair(TxIoKeypairBytes {
+            sk: [0xA5; 32],
+            pk: [2; 33],
+        }));
+        let error = client
+            .get_tx_io_public_key(0)
+            .await
+            .expect_err("wrong response variant must fail");
+        let rendered = error.to_string();
+        assert!(matches!(
+            error,
+            IpcError::UnexpectedResponse {
+                method: "get_tx_io_public_key",
+                received: "tx_io_keypair"
+            }
+        ));
+        assert!(
+            !rendered.contains("165"),
+            "secret payload leaked: {rendered}"
+        );
+        server.await.expect("server task");
     }
 }

--- a/crates/custodian-ipc/src/error.rs
+++ b/crates/custodian-ipc/src/error.rs
@@ -18,8 +18,16 @@ pub enum IpcError {
     /// ([`crate::Response::Error`]).
     #[error("custodian: {0}")]
     Custodian(String),
+    /// The custodian received a root-key-dependent request while no root key
+    /// was present in its memory.
+    #[error("custodian root key is absent")]
+    RootKeyAbsent,
     /// The custodian answered, but with a variant that doesn't match the
     /// request — a protocol bug on one side or the other.
-    #[error("unexpected response variant to {method}")]
-    UnexpectedResponse { method: &'static str },
+    #[error("unexpected response variant to {method}: received {received}")]
+    UnexpectedResponse {
+        method: &'static str,
+        /// Payload-free [`crate::Response::kind`] label; never key material.
+        received: &'static str,
+    },
 }

--- a/crates/custodian-ipc/src/lib.rs
+++ b/crates/custodian-ipc/src/lib.rs
@@ -28,7 +28,10 @@ mod messages;
 pub mod server;
 
 #[cfg(feature = "client")]
-pub use client::CustodianClient;
+pub use client::{
+    CreateRootKeyBootstrapAttemptResult, CustodianClient,
+    InstallRootKeyFromVerifiedBootstrapResponseResult,
+};
 pub use error::IpcError;
 // The pure encode/decode internals stay crate-private; consumers frame
 // messages through these I/O functions (or the client/server above them).
@@ -38,7 +41,8 @@ pub use framing::{MAX_FRAME_BODY_LEN, read_frame_blocking, write_frame_blocking}
 #[cfg(feature = "client")]
 pub use framing::{read_frame, write_frame};
 pub use messages::{
-    Request, Response, RngKeypairBytes, SnapshotKeyBytes, TxIoKeypairBytes, WrappedRootKeyBytes,
+    Request, Response, RngKeypairBytes, RootKeyBootstrapAttemptBytes, SnapshotKeyBytes,
+    TxIoKeypairBytes, TxIoPublicKeyBytes, WrappedRootKeyBytes,
 };
 
 /// Where enclave-server hosts the custodian socket on a node. `/run/seismic`

--- a/crates/custodian-ipc/src/messages.rs
+++ b/crates/custodian-ipc/src/messages.rs
@@ -21,26 +21,69 @@ use zeroize::{Zeroize, ZeroizeOnDrop};
 pub enum Request {
     /// Liveness probe; carries no key material in either direction.
     Ping,
+
+    // ==================== Purpose-key access ====================
     /// Derive this epoch's tx-io ECDH keypair (TxSeismic calldata
     /// encryption). Epochs are fixed at 0 until a consensus-driven manual
     /// rotation exists; same for the other purposes below.
     GetTxIoKeypair { epoch: u64 },
+    /// Derive only the public half of this epoch's tx-io key. The
+    /// attestation service uses this to mint tx-io evidence without gaining
+    /// access to `tx_io_sk`.
+    GetTxIoPublicKey { epoch: u64 },
     /// Derive this epoch's RNG-precompile keypair.
     GetRngKeypair { epoch: u64 },
     /// Derive this epoch's snapshot encryption key.
     GetSnapshotKey { epoch: u64 },
+
+    // ==================== Root-key bootstrap ====================
+    /// Start requester-side bootstrap without exposing the requester's
+    /// ephemeral ECDH secret to the network-facing attestation service.
+    ///
+    /// At most one attempt is retained. Starting another attempt invalidates
+    /// and drops the previous one.
+    CreateRootKeyBootstrapAttempt,
     /// AEAD-wrap the root key for an attestation-verified peer.
     ///
-    /// `root_key_request_binding` is the digest of the request transcript the
-    /// *caller* already verified (it becomes the AEAD AAD; the custodian
-    /// carries it opaquely). Sending this request asserts that verification
-    /// succeeded — the ACL must confine it to the attestation-service.
+    /// Verify the bootstrap requester before calling this method: recompute
+    /// its expected request binding from the local network ID, requester nonce,
+    /// and requester ephemeral public key, then verify its evidence against
+    /// that binding. Calling this method authorizes release of the wrapped root
+    /// key, so the ACL must confine it to the attestation service.
     WrapRootKey {
+        /// SHA-256 binding of the original bootstrap request transcript:
+        /// `root_key_request_binding(network_id, nonce_b, eph_pk_b)`. The
+        /// custodian carries it opaquely into the root-key ciphertext as AEAD
+        /// AAD.
         #[serde(with = "serde_bytes")]
         root_key_request_binding: [u8; 32],
         /// Peer's ephemeral ECDH public key, 33-byte compressed SEC1.
         #[serde(with = "serde_bytes")]
         peer_eph_pk: [u8; 33],
+    },
+    /// Install a root key from a verified bootstrap response.
+    ///
+    /// Verify the responder's evidence and response transcript before calling
+    /// this method. Raw evidence deliberately does not cross this boundary;
+    /// possession of the ACL grant is the authorization assertion.
+    InstallRootKeyFromVerifiedBootstrapResponse {
+        /// Opaque attempt identifier returned by the initial
+        /// [`Request::CreateRootKeyBootstrapAttempt`] call. It selects the
+        /// requester ephemeral secret retained for this bootstrap exchange.
+        #[serde(with = "serde_bytes")]
+        attempt_id: [u8; 32],
+        /// SHA-256 binding of the original bootstrap request transcript:
+        /// `root_key_request_binding(network_id, nonce_b, eph_pk_b)`. This must
+        /// be the same value supplied to [`Request::WrapRootKey`] by the
+        /// responder; the custodian uses it as AEAD AAD when unwrapping.
+        #[serde(with = "serde_bytes")]
+        root_key_request_binding: [u8; 32],
+        /// Responder ephemeral ECDH public key, 33-byte compressed SEC1.
+        #[serde(with = "serde_bytes")]
+        responder_eph_pk: [u8; 33],
+        /// `nonce(12) || AES-256-GCM ciphertext+tag` over the root key.
+        #[serde(with = "serde_bytes")]
+        wrapped_root_key: Vec<u8>,
     },
 }
 
@@ -50,34 +93,73 @@ impl Request {
         match self {
             Request::Ping => "ping",
             Request::GetTxIoKeypair { .. } => "get_tx_io_keypair",
+            Request::GetTxIoPublicKey { .. } => "get_tx_io_public_key",
             Request::GetRngKeypair { .. } => "get_rng_keypair",
             Request::GetSnapshotKey { .. } => "get_snapshot_key",
+            Request::CreateRootKeyBootstrapAttempt => "create_root_key_bootstrap_attempt",
             Request::WrapRootKey { .. } => "wrap_root_key",
+            Request::InstallRootKeyFromVerifiedBootstrapResponse { .. } => {
+                "install_root_key_from_verified_bootstrap_response"
+            }
         }
     }
 }
 
-/// One response; variants mirror [`Request`] plus two failure variants,
-/// split by which layer failed the request: [`Response::Denied`] is minted
-/// only by the transport's ACL loop, [`Response::Error`] only by the host's
-/// dispatch handler.
+/// One response over the custodian socket. Method-specific results are joined
+/// by explicit root-key state outcomes plus two failures split by layer:
+/// [`Response::Denied`] is minted only by the transport's ACL loop, while
+/// [`Response::Error`] is minted only by the host's dispatch handler.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum Response {
     Pong,
     TxIoKeypair(TxIoKeypairBytes),
+    TxIoPublicKey(TxIoPublicKeyBytes),
     RngKeypair(RngKeypairBytes),
     SnapshotKey(SnapshotKeyBytes),
+    RootKeyBootstrapAttemptCreated(RootKeyBootstrapAttemptBytes),
     WrappedRootKey(WrappedRootKeyBytes),
+    RootKeyInstalled,
+    /// A create/install request arrived while the root key was already
+    /// present. Kept distinct from an internal error so a restarted
+    /// attestation service can proceed without a state-query RPC.
+    RootKeyAlreadyPresent,
+    /// The requested derivation/wrap needs `root_key`, but none is present in
+    /// the custodian's memory.
+    RootKeyAbsent,
     /// The ACL refused this peer the method; the handler never saw the
     /// request. Retrying cannot succeed until the node's ACL changes.
     Denied {
         message: String,
     },
     /// The handler accepted the request but the operation failed (bad
-    /// argument or internal error); no partial output is returned.
+    /// argument or internal error); no partial output is returned. Hosts must
+    /// put only stable, sanitized text here; detailed errors stay in their
+    /// local logs.
     Error {
         message: String,
     },
+}
+
+impl Response {
+    /// Stable, payload-free variant label for protocol diagnostics. This is
+    /// safe to include in client errors even when the response variant carries
+    /// secret key material.
+    pub fn kind(&self) -> &'static str {
+        match self {
+            Response::Pong => "pong",
+            Response::TxIoKeypair(_) => "tx_io_keypair",
+            Response::TxIoPublicKey(_) => "tx_io_public_key",
+            Response::RngKeypair(_) => "rng_keypair",
+            Response::SnapshotKey(_) => "snapshot_key",
+            Response::RootKeyBootstrapAttemptCreated(_) => "root_key_bootstrap_attempt_created",
+            Response::WrappedRootKey(_) => "wrapped_root_key",
+            Response::RootKeyInstalled => "root_key_installed",
+            Response::RootKeyAlreadyPresent => "root_key_already_present",
+            Response::RootKeyAbsent => "root_key_absent",
+            Response::Denied { .. } => "denied",
+            Response::Error { .. } => "error",
+        }
+    }
 }
 
 /// secp256k1 tx-io keypair as raw bytes. Zeroized on drop: `sk` is a secret.
@@ -98,6 +180,26 @@ impl fmt::Debug for TxIoKeypairBytes {
             .field("pk", &self.pk)
             .finish()
     }
+}
+
+/// Public half of a tx-io keypair, returned to the attestation service.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TxIoPublicKeyBytes {
+    /// 33-byte compressed SEC1 public key.
+    #[serde(with = "serde_bytes")]
+    pub pk: [u8; 33],
+}
+
+/// One pending requester-side root-key bootstrap attempt. The matching
+/// ephemeral secret remains in the custodian process.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RootKeyBootstrapAttemptBytes {
+    /// Opaque correlation token used to select the retained ephemeral secret.
+    #[serde(with = "serde_bytes")]
+    pub attempt_id: [u8; 32],
+    /// Requester ephemeral ECDH public key, 33-byte compressed SEC1.
+    #[serde(with = "serde_bytes")]
+    pub requester_eph_pk: [u8; 33],
 }
 
 /// schnorrkel RNG keypair as raw bytes (`Keypair::to_bytes()`, 96 bytes,
@@ -163,11 +265,19 @@ mod tests {
         let requests = [
             Request::Ping,
             Request::GetTxIoKeypair { epoch: 7 },
+            Request::GetTxIoPublicKey { epoch: 7 },
             Request::GetRngKeypair { epoch: 8 },
             Request::GetSnapshotKey { epoch: 9 },
+            Request::CreateRootKeyBootstrapAttempt,
             Request::WrapRootKey {
                 root_key_request_binding: [0xAB; 32],
                 peer_eph_pk: [0xCD; 33],
+            },
+            Request::InstallRootKeyFromVerifiedBootstrapResponse {
+                attempt_id: [0x11; 32],
+                root_key_request_binding: [0xAB; 32],
+                responder_eph_pk: [0xCD; 33],
+                wrapped_root_key: vec![0xEF; 60],
             },
         ];
         for request in requests {
@@ -202,6 +312,33 @@ mod tests {
         };
         assert_eq!(rng.keypair, vec![4; 96]);
 
+        let response = Response::TxIoPublicKey(TxIoPublicKeyBytes { pk: [5; 33] });
+        let Response::TxIoPublicKey(tx_io) = from_cbor(&to_cbor(&response)) else {
+            panic!("wrong variant");
+        };
+        assert_eq!(tx_io.pk, [5; 33]);
+
+        let response = Response::RootKeyBootstrapAttemptCreated(RootKeyBootstrapAttemptBytes {
+            attempt_id: [6; 32],
+            requester_eph_pk: [7; 33],
+        });
+        let Response::RootKeyBootstrapAttemptCreated(attempt) = from_cbor(&to_cbor(&response))
+        else {
+            panic!("wrong variant");
+        };
+        assert_eq!(attempt.attempt_id, [6; 32]);
+        assert_eq!(attempt.requester_eph_pk, [7; 33]);
+
+        for response in [
+            Response::RootKeyInstalled,
+            Response::RootKeyAlreadyPresent,
+            Response::RootKeyAbsent,
+        ] {
+            let expected_kind = response.kind();
+            let decoded: Response = from_cbor(&to_cbor(&response));
+            assert_eq!(decoded.kind(), expected_kind);
+        }
+
         // The two failure variants must stay distinct across the wire.
         let response = Response::Denied {
             message: "not authorized".into(),
@@ -226,6 +363,22 @@ mod tests {
             encoded.windows(marker.len()).any(|w| w == marker),
             "expected 32-byte byte-string header in {encoded:02x?}"
         );
+    }
+
+    #[test]
+    fn response_kind_is_payload_free() {
+        let response = Response::TxIoKeypair(TxIoKeypairBytes {
+            sk: [0xA5; 32],
+            pk: [2; 33],
+        });
+        assert_eq!(response.kind(), "tx_io_keypair");
+        assert!(!response.kind().contains("a5"));
+
+        let response = Response::Error {
+            message: "private implementation detail".into(),
+        };
+        assert_eq!(response.kind(), "error");
+        assert!(!response.kind().contains("private"));
     }
 
     #[test]

--- a/crates/custodian-ipc/src/server.rs
+++ b/crates/custodian-ipc/src/server.rs
@@ -35,13 +35,22 @@ const MAX_CONNECTIONS: usize = 64;
 pub struct MethodAcl {
     /// UIDs allowed the tx-io keypair (reth: TxSeismic calldata).
     pub tx_io: HashSet<u32>,
+    /// UIDs allowed only the public half of the tx-io key (attestation
+    /// service: tx-io evidence generation).
+    pub tx_io_public: HashSet<u32>,
     /// UIDs allowed the RNG-precompile keypair (reth: EVM randomness).
     pub rng: HashSet<u32>,
     /// UIDs allowed the snapshot key (the snapshot service; NOT reth).
     pub snapshot: HashSet<u32>,
+    /// UIDs allowed to ask a custodian without a root key to retain a fresh
+    /// requester-side bootstrap secret.
+    pub create_root_key_bootstrap_attempt: HashSet<u32>,
     /// UIDs allowed to request root-key wraps. A caller here is trusted to
     /// have verified peer attestation first — confine to attestation-service.
     pub wrap_root_key: HashSet<u32>,
+    /// UIDs trusted to have verified a responder and install its wrapped root
+    /// key. Confine to attestation-service.
+    pub install_root_key_from_verified_bootstrap_response: HashSet<u32>,
 }
 
 impl MethodAcl {
@@ -54,9 +63,12 @@ impl MethodAcl {
         let own = HashSet::from([uid]);
         Self {
             tx_io: own.clone(),
+            tx_io_public: own.clone(),
             rng: own.clone(),
             snapshot: own.clone(),
-            wrap_root_key: own,
+            create_root_key_bootstrap_attempt: own.clone(),
+            wrap_root_key: own.clone(),
+            install_root_key_from_verified_bootstrap_response: own,
         }
     }
 
@@ -64,9 +76,16 @@ impl MethodAcl {
         match request {
             Request::Ping => true,
             Request::GetTxIoKeypair { .. } => self.tx_io.contains(&uid),
+            Request::GetTxIoPublicKey { .. } => self.tx_io_public.contains(&uid),
             Request::GetRngKeypair { .. } => self.rng.contains(&uid),
             Request::GetSnapshotKey { .. } => self.snapshot.contains(&uid),
+            Request::CreateRootKeyBootstrapAttempt => {
+                self.create_root_key_bootstrap_attempt.contains(&uid)
+            }
             Request::WrapRootKey { .. } => self.wrap_root_key.contains(&uid),
+            Request::InstallRootKeyFromVerifiedBootstrapResponse { .. } => self
+                .install_root_key_from_verified_bootstrap_response
+                .contains(&uid),
         }
     }
 }
@@ -281,9 +300,12 @@ mod tests {
         let own = HashSet::from([uid]);
         MethodAcl {
             tx_io: own.clone(),
+            tx_io_public: own.clone(),
             rng: own.clone(),
             snapshot: own.clone(),
-            wrap_root_key: own,
+            create_root_key_bootstrap_attempt: own.clone(),
+            wrap_root_key: own.clone(),
+            install_root_key_from_verified_bootstrap_response: own,
         }
     }
 
@@ -329,10 +351,11 @@ mod tests {
         assert!(matches!(responses[1], Response::Pong));
     }
 
-    // The point of per-purpose methods: a grant for one key purpose implies
-    // nothing about any other.
+    // The production grant matrix: reth receives only the key material needed
+    // for execution, while the attestation service receives public tx-io data
+    // and root-key bootstrap authority, never secret purpose keys.
     #[test]
-    fn purpose_grants_are_independent() {
+    fn caller_grants_are_independent() {
         let reth_like = MethodAcl {
             tx_io: HashSet::from([UID]),
             rng: HashSet::from([UID]),
@@ -340,15 +363,45 @@ mod tests {
         };
         assert!(reth_like.allows(UID, &Request::GetTxIoKeypair { epoch: 0 }));
         assert!(reth_like.allows(UID, &Request::GetRngKeypair { epoch: 0 }));
+        assert!(!reth_like.allows(UID, &Request::GetTxIoPublicKey { epoch: 0 }));
         assert!(!reth_like.allows(UID, &Request::GetSnapshotKey { epoch: 0 }));
-        assert!(!reth_like.allows(
-            UID,
-            &Request::WrapRootKey {
-                root_key_request_binding: [0; 32],
-                peer_eph_pk: [0; 33],
-            }
-        ));
+        assert!(!reth_like.allows(UID, &Request::CreateRootKeyBootstrapAttempt));
+        assert!(!reth_like.allows(UID, &wrap_request()));
+        assert!(!reth_like.allows(UID, &install_request()));
+
+        let attestation_like = MethodAcl {
+            tx_io_public: HashSet::from([UID]),
+            create_root_key_bootstrap_attempt: HashSet::from([UID]),
+            wrap_root_key: HashSet::from([UID]),
+            install_root_key_from_verified_bootstrap_response: HashSet::from([UID]),
+            ..MethodAcl::default()
+        };
+        assert!(attestation_like.allows(UID, &Request::GetTxIoPublicKey { epoch: 0 }));
+        assert!(attestation_like.allows(UID, &Request::CreateRootKeyBootstrapAttempt));
+        assert!(attestation_like.allows(UID, &wrap_request()));
+        assert!(attestation_like.allows(UID, &install_request()));
+        assert!(!attestation_like.allows(UID, &Request::GetTxIoKeypair { epoch: 0 }));
+        assert!(!attestation_like.allows(UID, &Request::GetRngKeypair { epoch: 0 }));
+        assert!(!attestation_like.allows(UID, &Request::GetSnapshotKey { epoch: 0 }));
+
         assert!(!reth_like.allows(UID + 1, &Request::GetTxIoKeypair { epoch: 0 }));
+        assert!(!attestation_like.allows(UID + 1, &wrap_request()));
+    }
+
+    fn wrap_request() -> Request {
+        Request::WrapRootKey {
+            root_key_request_binding: [0; 32],
+            peer_eph_pk: [0; 33],
+        }
+    }
+
+    fn install_request() -> Request {
+        Request::InstallRootKeyFromVerifiedBootstrapResponse {
+            attempt_id: [0; 32],
+            root_key_request_binding: [0; 32],
+            responder_eph_pk: [0; 33],
+            wrapped_root_key: Vec::new(),
+        }
     }
 
     #[test]

--- a/crates/enclave-server/src/ipc.rs
+++ b/crates/enclave-server/src/ipc.rs
@@ -8,9 +8,11 @@
 
 use anyhow::Context as _;
 use seismic_custodian_ipc::{
-    Request, Response, RngKeypairBytes, SnapshotKeyBytes, TxIoKeypairBytes, WrappedRootKeyBytes,
+    Request, Response, RngKeypairBytes, SnapshotKeyBytes, TxIoKeypairBytes, TxIoPublicKeyBytes,
+    WrappedRootKeyBytes,
 };
 use seismic_key_custodian::{Custodian, VerifiedPeerAuthorization};
+use tracing::warn;
 
 /// Map one ACL-authorized socket request onto the custodian.
 ///
@@ -25,21 +27,39 @@ pub fn dispatch(custodian: &Custodian, request: Request) -> Response {
             sk: custodian.get_tx_io_sk(epoch).secret_bytes(),
             pk: custodian.get_tx_io_pk(epoch).serialize(),
         }),
+        Request::GetTxIoPublicKey { epoch } => Response::TxIoPublicKey(TxIoPublicKeyBytes {
+            pk: custodian.get_tx_io_pk(epoch).serialize(),
+        }),
         Request::GetRngKeypair { epoch } => Response::RngKeypair(RngKeypairBytes {
             keypair: custodian.get_rng_keypair(epoch).to_bytes().to_vec(),
         }),
         Request::GetSnapshotKey { epoch } => Response::SnapshotKey(SnapshotKeyBytes {
             key: custodian.get_snapshot_key(epoch).into(),
         }),
+        // Transitional monolithic host: it binds the socket only after its
+        // root key is present, so creating a requester-side attempt cannot be
+        // meaningful here. The standalone custodian will implement this state
+        // transition while preserving the wire contract.
+        Request::CreateRootKeyBootstrapAttempt => Response::RootKeyAlreadyPresent,
         Request::WrapRootKey {
             root_key_request_binding,
             peer_eph_pk,
         } => match wrap_root_key(custodian, root_key_request_binding, &peer_eph_pk) {
             Ok(wrapped) => Response::WrappedRootKey(wrapped),
-            Err(e) => Response::Error {
-                message: format!("wrap_root_key: {e:#}"),
-            },
+            Err(error) => {
+                // Detailed failures stay local to the key-holding process.
+                // The wire response is stable and cannot accidentally include
+                // key bytes from a future lower-level error implementation.
+                warn!(?error, "custodian root-key wrap failed");
+                Response::Error {
+                    message: "root-key wrap failed".to_string(),
+                }
+            }
         },
+        // As above, the root key is already present in this transitional host.
+        Request::InstallRootKeyFromVerifiedBootstrapResponse { .. } => {
+            Response::RootKeyAlreadyPresent
+        }
     }
 }
 
@@ -90,6 +110,13 @@ mod tests {
         assert_eq!(tx_io.sk, custodian.get_tx_io_sk(0).secret_bytes());
         assert_eq!(tx_io.pk, custodian.get_tx_io_pk(0).serialize());
 
+        let Response::TxIoPublicKey(tx_io_public) =
+            dispatch(&custodian, Request::GetTxIoPublicKey { epoch: 0 })
+        else {
+            panic!("expected tx-io public key");
+        };
+        assert_eq!(tx_io_public.pk, tx_io.pk);
+
         let Response::RngKeypair(rng) = dispatch(&custodian, Request::GetRngKeypair { epoch: 0 })
         else {
             panic!("expected rng keypair");
@@ -113,6 +140,27 @@ mod tests {
             panic!("expected tx-io keypair");
         };
         assert_ne!(tx_io.sk, tx_io_epoch1.sk, "epochs must differ");
+    }
+
+    #[test]
+    fn transitional_host_reports_root_key_already_present() {
+        let custodian = Custodian::new(ROOT_KEY);
+        assert!(matches!(
+            dispatch(&custodian, Request::CreateRootKeyBootstrapAttempt),
+            Response::RootKeyAlreadyPresent
+        ));
+        assert!(matches!(
+            dispatch(
+                &custodian,
+                Request::InstallRootKeyFromVerifiedBootstrapResponse {
+                    attempt_id: [1; 32],
+                    root_key_request_binding: [2; 32],
+                    responder_eph_pk: [3; 33],
+                    wrapped_root_key: vec![4; 60],
+                }
+            ),
+            Response::RootKeyAlreadyPresent
+        ));
     }
 
     #[test]
@@ -147,7 +195,11 @@ mod tests {
                 peer_eph_pk: [0u8; 33],
             },
         );
-        assert!(matches!(response, Response::Error { .. }));
+        let Response::Error { message } = response else {
+            panic!("expected sanitized custodian error");
+        };
+        assert_eq!(message, "root-key wrap failed");
+        assert!(!message.contains("secp256k1"));
     }
 
     /// Coverage over a real `UnixListener`: bind semantics, `SO_PEERCRED`


### PR DESCRIPTION
seismic-enclave-server currently hosts both the network-facing attestation RPCs and the Custodian that holds root_key. This is the protocol precursor to moving the custodian into a separate process reachable only over a local Unix socket.

Extend the IPC contract with the operations needed across that boundary:

- create and retain requester-side root-key bootstrap attempts
- wrap root_key for an attestation-authorized peer
- install root_key from a response verified by the attestation service
- expose tx_io_pk without granting the attestation service tx_io_sk
- represent root-key-present/absent outcomes explicitly
- add independent ACL grants for each new operation
- sanitize custodian errors and safely label unexpected responses

Raw attestation evidence remains in the network-facing service, while the requester ephemeral secret and unwrapped root_key remain in the custodian.

This commit only defines and tests the wire, client, and ACL contract. Follow-up work will introduce the standalone custodian binary, move bootstrap unwrap/install and LUKS-key handoff into it, update the attestation service to use this IPC API, and cut reth over from the HTTP purpose-key endpoint to the custodian socket.