### PR TITLE
fix(custodian-ipc): isolate socket in runtime directory

### DIFF
--- a/crates/custodian-ipc/src/bin/custodian-ipc-cli.rs
+++ b/crates/custodian-ipc/src/bin/custodian-ipc-cli.rs
@@ -7,14 +7,14 @@
 
 use anyhow::Result;
 use clap::{Parser, Subcommand};
-use seismic_custodian_ipc::{CUSTODIAN_SOCKET_PATH, CustodianClient};
+use seismic_custodian_ipc::{CustodianClient, DEFAULT_CUSTODIAN_SOCKET_PATH};
 use sha2::{Digest as _, Sha256};
 
 #[derive(Parser)]
 #[command(about = "Debug client for the Seismic key-custodian Unix socket")]
 struct Cli {
     /// Path to the custodian socket.
-    #[arg(long, default_value = CUSTODIAN_SOCKET_PATH)]
+    #[arg(long, default_value = DEFAULT_CUSTODIAN_SOCKET_PATH)]
     socket: std::path::PathBuf,
 
     #[command(subcommand)]

--- a/crates/custodian-ipc/src/lib.rs
+++ b/crates/custodian-ipc/src/lib.rs
@@ -47,4 +47,4 @@ pub use messages::{
 
 /// Default path for the custodian IPC socket. seismic-images creates the
 /// dedicated tmpfs directory before enclave-server starts.
-pub const CUSTODIAN_SOCKET_PATH: &str = "/run/seismic/custodian/custodian.sock";
+pub const DEFAULT_CUSTODIAN_SOCKET_PATH: &str = "/run/seismic/custodian/custodian.sock";

--- a/crates/custodian-ipc/src/lib.rs
+++ b/crates/custodian-ipc/src/lib.rs
@@ -45,6 +45,6 @@ pub use messages::{
     TxIoKeypairBytes, TxIoPublicKeyBytes, WrappedRootKeyBytes,
 };
 
-/// Where enclave-server hosts the custodian socket on a node. `/run/seismic`
-/// is tmpfs, created by tdx-init before enclave-server starts.
-pub const CUSTODIAN_SOCKET_PATH: &str = "/run/seismic/custodian.sock";
+/// Default path for the custodian IPC socket. seismic-images creates the
+/// dedicated tmpfs directory before enclave-server starts.
+pub const CUSTODIAN_SOCKET_PATH: &str = "/run/seismic/custodian/custodian.sock";

--- a/crates/enclave-server/src/lib.rs
+++ b/crates/enclave-server/src/lib.rs
@@ -11,8 +11,9 @@ pub const ENCLAVE_DEFAULT_ENDPOINT_PORT: u16 = 7878;
 
 use anyhow::Result;
 use clap::Parser;
+use seismic_custodian_ipc::DEFAULT_CUSTODIAN_SOCKET_PATH;
 use seismic_enclave::mock::start_mock_server;
-use std::net::SocketAddr;
+use std::{net::SocketAddr, path::PathBuf};
 use tracing::info;
 
 /// Command line arguments for the enclave server
@@ -35,6 +36,10 @@ pub struct Args {
     /// Required when `genesis_node` is false.
     #[arg(long, env = "SEISMIC_ENCLAVE_PEERS", value_delimiter = ',')]
     pub peers: Vec<String>,
+
+    /// Filesystem path for the custodian IPC socket.
+    #[arg(long, default_value = DEFAULT_CUSTODIAN_SOCKET_PATH)]
+    pub custodian_socket: PathBuf,
 
     /// Run the dev-only mock server instead of the real enclave.
     ///

--- a/crates/enclave-server/src/server.rs
+++ b/crates/enclave-server/src/server.rs
@@ -24,10 +24,9 @@ use seismic_attestation::{
 use seismic_attestation_rpc::{
     AttestationRpcClient as _, AttestationRpcServer, TxIoAttestationResponse,
 };
-use seismic_custodian_ipc::CUSTODIAN_SOCKET_PATH;
 use seismic_enclave::{GetPurposeKeysResponse, LuksProvisioningStatus, api::TdxQuoteRpcServer};
 use seismic_key_custodian::Custodian;
-use std::{net::SocketAddr, path::Path, sync::Arc, time::Duration};
+use std::{net::SocketAddr, sync::Arc, time::Duration};
 use tracing::{info, warn};
 
 /// Attestation type this build mints and verifies evidence for. Azure TDX +
@@ -128,6 +127,8 @@ impl AttestationRpcServer for TdxQuoteServer {
 }
 
 pub async fn start_server(addr: SocketAddr, args: Args) -> anyhow::Result<()> {
+    let custodian_socket = args.custodian_socket;
+
     // Derive this node's network identity from the manifest tdx-init dropped on
     // tmpfs. Fatal if absent/malformed: without it every attestation binding is
     // unscoped, so we refuse to serve rather than fall back to an unbound quote.
@@ -169,12 +170,11 @@ pub async fn start_server(addr: SocketAddr, args: Args) -> anyhow::Result<()> {
     // production caller connects yet: in-process users call `Custodian`
     // directly and reth still fetches keys over HTTP `getPurposeKeys`, so
     // until the split moves them onto the socket, only the debug CLI (and
-    // tests) exercise it. Bind failure is fatal anyway: a
-    // node that can't serve the socket should fail this boot, not at the
-    // split, and /run/seismic already had to exist for the manifest read.
+    // tests) exercise it. The local key interface is part of node readiness,
+    // so bind failure is fatal.
     let custodian = Arc::new(custodian);
-    let ipc_listener = seismic_custodian_ipc::server::bind(Path::new(CUSTODIAN_SOCKET_PATH))
-        .with_context(|| format!("binding custodian socket {CUSTODIAN_SOCKET_PATH}"))?;
+    let ipc_listener = seismic_custodian_ipc::server::bind(&custodian_socket)
+        .with_context(|| format!("binding custodian socket {}", custodian_socket.display()))?;
     let ipc_custodian = custodian.clone();
     std::thread::spawn(move || {
         seismic_custodian_ipc::server::serve(

--- a/crates/enclave-server/tests/integration/integration.rs
+++ b/crates/enclave-server/tests/integration/integration.rs
@@ -37,23 +37,35 @@ async fn test_get_wrapped_root_key_bootstrap() {
     }
 
     // Start first enclave as genesis node
-    let args1 = get_args(0, true, Default::default());
+    let node1_runtime = tempfile::tempdir().expect("create genesis runtime directory");
+    let args1 = get_args(
+        0,
+        true,
+        Default::default(),
+        node1_runtime.path().join("custodian.sock"),
+    );
     let enclave_one_url = format!("http://localhost:{}", args1.port);
-    let node1_handle = tokio::spawn(args1.start());
+    let mut node1_handle = tokio::spawn(args1.start());
     let client1 = HttpClientBuilder::default()
         .build(enclave_one_url.clone())
         .expect("Unable to create enclave 1 client");
-    wait_for_health(&client1, "genesis enclave").await;
+    wait_for_health(&client1, "genesis enclave", &mut node1_handle).await;
 
     // Start the second enclave with node 1 as its peer. Its RPC listener comes
     // up after the attested root-key exchange completes.
-    let args2 = get_args(1, false, vec![enclave_one_url]);
+    let node2_runtime = tempfile::tempdir().expect("create joining runtime directory");
+    let args2 = get_args(
+        1,
+        false,
+        vec![enclave_one_url],
+        node2_runtime.path().join("custodian.sock"),
+    );
     let enclave_two_url = format!("http://localhost:{}", args2.port);
-    let node2_handle = tokio::spawn(args2.start());
+    let mut node2_handle = tokio::spawn(args2.start());
     let client2 = HttpClientBuilder::default()
         .build(enclave_two_url)
         .expect("Unable to create enclave 2 client");
-    wait_for_health(&client2, "joining enclave").await;
+    wait_for_health(&client2, "joining enclave", &mut node2_handle).await;
 
     // Get keys from both and make sure they match
 
@@ -143,7 +155,11 @@ fn test_measurement_policy() -> SeismicMeasurementPolicy {
 ///
 /// The joining server binds its RPC listener after fetching and installing the
 /// root key, so readiness also confirms that its bootstrap exchange completed.
-async fn wait_for_health(client: &HttpClient, service: &str) {
+async fn wait_for_health(
+    client: &HttpClient,
+    service: &str,
+    server_handle: &mut tokio::task::JoinHandle<anyhow::Result<()>>,
+) {
     let deadline = tokio::time::Instant::now() + NODE_STARTUP_TIMEOUT;
 
     loop {
@@ -157,7 +173,12 @@ async fn wait_for_health(client: &HttpClient, service: &str) {
             tokio::time::Instant::now() < deadline,
             "{service} did not become healthy within {NODE_STARTUP_TIMEOUT:?}: {last_error}"
         );
-        tokio::time::sleep(RETRY_INTERVAL).await;
+        tokio::select! {
+            result = &mut *server_handle => {
+                panic!("{service} exited before becoming healthy: {result:?}")
+            }
+            () = tokio::time::sleep(RETRY_INTERVAL) => {}
+        }
     }
 }
 

--- a/crates/enclave-server/tests/integration/utils.rs
+++ b/crates/enclave-server/tests/integration/utils.rs
@@ -1,12 +1,14 @@
 use seismic_enclave_server::Args;
+use std::path::PathBuf;
 
-pub fn get_args(n: u16, genesis_node: bool, peers: Vec<String>) -> Args {
+pub fn get_args(n: u16, genesis_node: bool, peers: Vec<String>, custodian_socket: PathBuf) -> Args {
     let port = 7878 + n;
     Args {
         ip: "0.0.0.0".to_string(),
         port,
         genesis_node,
         peers,
+        custodian_socket,
         mock: false,
     }
 }


### PR DESCRIPTION
The real enclave server now binds the custodian IPC socket while running as the unprivileged enclave user. Binding it directly under /run/seismic either fails against the root-owned directory, as observed during the four-node Azure bootstrap, or requires granting enclave write access to the shared runtime namespace.

Move the socket into a dedicated custodian subdirectory so seismic-images can grant enclave ownership only there while leaving /run/seismic root-owned. The directory's group can later gate the local reth and attestation-service clients during the process split.

## Also fixed integration test

The live bootstrap integration runs two enclave-server instances. Both previously used the same custodian socket path, so the second bind unlinked and replaced the first server's socket. The test still passed because it exercised only HTTP, but the bug would surface once it began asserting either server's IPC interface.

Add --custodian-socket and give each test server an independent temporary socket. Watch the spawned server tasks during readiness polling so startup failures are reported immediately rather than hidden behind the health timeout.

Rename the shared path constant to DEFAULT_CUSTODIAN_SOCKET_PATH to distinguish the deployment default from caller-provided paths.