### PR TITLE
fix(enclave-crypto): domain-separate AES keys derived from ECDH secrets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5214,6 +5214,7 @@ version = "0.1.0"
 dependencies = [
  "aes-gcm",
  "anyhow",
+ "hex",
  "hkdf",
  "rand 0.9.2",
  "schnorrkel",

--- a/crates/crypto/Cargo.toml
+++ b/crates/crypto/Cargo.toml
@@ -18,3 +18,6 @@ schnorrkel.workspace = true
 secp256k1.workspace = true
 serde.workspace = true
 sha2.workspace = true
+
+[dev-dependencies]
+hex.workspace = true

--- a/crates/crypto/src/lib.rs
+++ b/crates/crypto/src/lib.rs
@@ -188,23 +188,60 @@ pub fn aes_decrypt_aead(
         .map_err(|_| anyhow!("AES-AEAD decryption failed. Authentication tag does not match the given ciphertext/nonce/aad"))
 }
 
-/// Derives an AES key from a shared secret using HKDF and SHA-256.
+/// Domain-separation registry for every AES key derived from an ECDH shared
+/// secret. One variant per protocol context; [`derive_aes_key`] is the only
+/// HKDF-expand over this input-keying-material class, so this enum is the
+/// exhaustive list of its labels.
 ///
-/// This function takes a `SharedSecret` and derives a 256-bit AES key using
-/// the HKDF (HMAC-based Extract-and-Expand Key Derivation Function) with SHA-256.
-///
-/// # Arguments
-/// * `shared_secret` - The shared secret from which the AES key will be derived.
-///
-/// # Returns
-/// A `Result` containing the derived AES key, or an error if key derivation fails.
-pub fn derive_aes_key(shared_secret: &SharedSecret) -> Result<Key<Aes256Gcm>, hkdf::InvalidLength> {
-    // Initialize HKDF with SHA-256
-    let hk = Hkdf::<Sha256>::new(None, &shared_secret.secret_bytes());
+/// Two derived keys are independent unless both the shared secret AND the
+/// label match. Keeping labels distinct per context makes key independence a
+/// structural property rather than an assumption about which keypairs are
+/// (re)used where — including adversarially, via the on-chain ECDH precompile,
+/// which lets any contract evaluate the [`EcdhPrecompile`](Self::EcdhPrecompile)
+/// derivation on caller-chosen keys.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AesKeyDomain {
+    /// Client-to-TEE transaction I/O: encrypted calldata and signed-read
+    /// requests. Clients encrypt, TEEs decrypt.
+    TxRequest,
+    /// TEE-to-client transaction I/O: signed-read return data. TEEs encrypt,
+    /// clients decrypt. Independent from [`TxRequest`](Self::TxRequest) so a
+    /// request/response pair can carry one public nonce without repeating an
+    /// AES-GCM `(key, nonce)` pair.
+    TxResponse,
+    /// The ECDH precompile's on-chain key derivation. Consensus-frozen: its
+    /// output is observable by contracts, so this label can never change, and
+    /// no other domain may ever reuse it.
+    EcdhPrecompile,
+    /// The enclave-to-enclave root-key bootstrap handshake. Both sides ship
+    /// in the same release and nothing wrapped is persisted, so this label
+    /// (unlike the precompile's) can rotate with a coordinated upgrade.
+    RootKeyWrap,
+}
 
-    // Output a 32-byte key for AES-256
+impl AesKeyDomain {
+    const fn hkdf_info(self) -> &'static [u8] {
+        match self {
+            Self::TxRequest => b"seismic/request/aes-256-gcm/v1",
+            Self::TxResponse => b"seismic/response/aes-256-gcm/v1",
+            // Cannot change: live on testnet. Contracts observe (and may
+            // persist data keyed by) this precompile's output, and no fork
+            // can make data derived under an old label reachable again.
+            Self::EcdhPrecompile => b"aes-gcm key",
+            Self::RootKeyWrap => b"seismic/root-key-wrap/aes-256-gcm/v1",
+        }
+    }
+}
+
+/// Derives a domain-separated AES-256 key from an ECDH shared secret using
+/// HKDF-SHA256. See [`AesKeyDomain`] for the label registry.
+pub fn derive_aes_key(
+    shared_secret: &SharedSecret,
+    domain: AesKeyDomain,
+) -> Result<Key<Aes256Gcm>, hkdf::InvalidLength> {
+    let hk = Hkdf::<Sha256>::new(None, &shared_secret.secret_bytes());
     let mut okm = [0u8; 32];
-    hk.expand(b"aes-gcm key", &mut okm)?;
+    hk.expand(domain.hkdf_info(), &mut okm)?;
     Ok(*Key::<Aes256Gcm>::from_slice(&okm))
 }
 
@@ -318,59 +355,63 @@ pub fn get_unsecure_sample_aesgcm_key() -> aes_gcm::Key<aes_gcm::Aes256Gcm> {
 pub fn ecdh_encrypt(
     pk: &PublicKey,
     sk: &SecretKey,
+    domain: AesKeyDomain,
     data: &[u8],
     nonce: impl Into<Nonce>,
 ) -> Result<Vec<u8>, anyhow::Error> {
     let shared_secret = SharedSecret::new(pk, sk);
-    let aes_key =
-        derive_aes_key(&shared_secret).map_err(|e| anyhow!("Error deriving AES key: {:?}", e))?;
+    let aes_key = derive_aes_key(&shared_secret, domain)
+        .map_err(|e| anyhow!("Error deriving AES key: {:?}", e))?;
     let encrypted_data = aes_encrypt(&aes_key, data, nonce)?;
     Ok(encrypted_data)
 }
 
-/// Decrypts the provided data using an AES key derived from
-/// the provided public key and the provided private key
+/// Decrypts the provided data using a domain-separated AES key derived from
+/// the provided public key and the provided private key.
 pub fn ecdh_decrypt(
     pk: &PublicKey,
     sk: &SecretKey,
+    domain: AesKeyDomain,
     data: &[u8],
     nonce: impl Into<Nonce>,
 ) -> Result<Vec<u8>, anyhow::Error> {
     let shared_secret = SharedSecret::new(pk, sk);
-    let aes_key =
-        derive_aes_key(&shared_secret).map_err(|e| anyhow!("Error deriving AES key: {:?}", e))?;
+    let aes_key = derive_aes_key(&shared_secret, domain)
+        .map_err(|e| anyhow!("Error deriving AES key: {:?}", e))?;
     let decrypted_data = aes_decrypt(&aes_key, data, nonce)?;
     Ok(decrypted_data)
 }
 
-/// Encrypts the provided data using AEAD with an AES key derived from
-/// the provided public key and the provided private key
+/// Encrypts the provided data using AEAD with a domain-separated AES key
+/// derived from the provided public key and the provided private key.
 pub fn ecdh_encrypt_aead(
     pk: &PublicKey,
     sk: &SecretKey,
+    domain: AesKeyDomain,
     data: &[u8],
     nonce: impl Into<Nonce>,
     aad: &[u8],
 ) -> Result<Vec<u8>, anyhow::Error> {
     let shared_secret = SharedSecret::new(pk, sk);
-    let aes_key =
-        derive_aes_key(&shared_secret).map_err(|e| anyhow!("Error deriving AES key: {:?}", e))?;
+    let aes_key = derive_aes_key(&shared_secret, domain)
+        .map_err(|e| anyhow!("Error deriving AES key: {:?}", e))?;
     let encrypted_data = aes_encrypt_aead(&aes_key, data, nonce, aad)?;
     Ok(encrypted_data)
 }
 
-/// Decrypts the provided data using AEAD with an AES key derived from
-/// the provided public key and the provided private key
+/// Decrypts the provided data using AEAD with a domain-separated AES key
+/// derived from the provided public key and the provided private key.
 pub fn ecdh_decrypt_aead(
     pk: &PublicKey,
     sk: &SecretKey,
+    domain: AesKeyDomain,
     data: &[u8],
     nonce: impl Into<Nonce>,
     aad: &[u8],
 ) -> Result<Vec<u8>, anyhow::Error> {
     let shared_secret = SharedSecret::new(pk, sk);
-    let aes_key =
-        derive_aes_key(&shared_secret).map_err(|e| anyhow!("Error deriving AES key: {:?}", e))?;
+    let aes_key = derive_aes_key(&shared_secret, domain)
+        .map_err(|e| anyhow!("Error deriving AES key: {:?}", e))?;
     let decrypted_data = aes_decrypt_aead(&aes_key, data, nonce, aad)?;
     Ok(decrypted_data)
 }
@@ -457,4 +498,86 @@ pub fn decrypt_file(
     fs::write(output_path, decrypted_data)
         .map_err(|e| anyhow::anyhow!("Failed to write output file {:?}: {:?}", output_path, e))?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Known-answer test shared with the TypeScript (aesKeygen.ts) and Python
+    /// (test_crypto.py) client suites. All three languages must derive these
+    /// exact keys from the same ECDH inputs; a label edit in any one of them
+    /// fails its copy of this test.
+    #[test]
+    fn domain_key_derivation_matches_cross_language_vectors() {
+        let client_sk =
+            SecretKey::from_str("a30363336e1bb949185292a2a302de86e447d98f3a43d823c8c234d9e3e5ad77")
+                .unwrap();
+        let tee_pk = PublicKey::from_str(
+            "028e76821eb4d77fd30223ca971c49738eb5b5b71eabe93f96b348fdce788ae5a0",
+        )
+        .unwrap();
+        let shared_secret = SharedSecret::new(&tee_pk, &client_sk);
+        assert_eq!(
+            hex::encode(shared_secret.secret_bytes()),
+            "46a4d6fce8eca748ba8362e726de51a5c62202c887d6bb81fa6f4df1fb360999"
+        );
+
+        let vectors = [
+            (
+                AesKeyDomain::TxRequest,
+                "d958b910e65af59475e767c5fdcb8b2e3388b5d8aa2fbfaa01c08c422be6fd07",
+            ),
+            (
+                AesKeyDomain::TxResponse,
+                "974b310e3990d555da33e2b0c1dc6036a9709400ec992dbfc9330cc00e673144",
+            ),
+            (
+                AesKeyDomain::EcdhPrecompile,
+                "bf0dd6556618d1bf8d1602bf80be3a0f7cc729973829bb9acb75bd77770d5b90",
+            ),
+            (
+                AesKeyDomain::RootKeyWrap,
+                "f48820f0d247f5841a1d91fe1c48f590e0172cac4bec879d2dcdf04e9d1f7647",
+            ),
+        ];
+        for (domain, expected) in vectors {
+            let key = derive_aes_key(&shared_secret, domain).unwrap();
+            assert_eq!(hex::encode(key.as_slice()), expected, "{domain:?}");
+        }
+    }
+
+    #[test]
+    fn request_and_response_keys_are_distinct() {
+        let shared_secret = SharedSecret::new(
+            &get_unsecure_sample_secp256k1_pk(),
+            &get_unsecure_sample_secp256k1_sk(),
+        );
+
+        let request_key = derive_aes_key(&shared_secret, AesKeyDomain::TxRequest).unwrap();
+        let response_key = derive_aes_key(&shared_secret, AesKeyDomain::TxResponse).unwrap();
+
+        assert_ne!(request_key.as_slice(), response_key.as_slice());
+    }
+
+    #[test]
+    fn ciphertext_cannot_be_opened_in_the_other_direction() {
+        let shared_secret = SharedSecret::new(
+            &get_unsecure_sample_secp256k1_pk(),
+            &get_unsecure_sample_secp256k1_sk(),
+        );
+        let request_key = derive_aes_key(&shared_secret, AesKeyDomain::TxRequest).unwrap();
+        let response_key = derive_aes_key(&shared_secret, AesKeyDomain::TxResponse).unwrap();
+        let nonce = [0x42; AESGCM_NONCE_SIZE];
+        let aad = b"transaction metadata";
+        let plaintext = b"request payload";
+
+        let ciphertext = aes_encrypt_aead(&request_key, plaintext, nonce, aad).unwrap();
+
+        assert!(aes_decrypt_aead(&response_key, &ciphertext, nonce, aad).is_err());
+        assert_eq!(
+            aes_decrypt_aead(&request_key, &ciphertext, nonce, aad).unwrap(),
+            plaintext
+        );
+    }
 }

--- a/crates/crypto/src/lib.rs
+++ b/crates/crypto/src/lib.rs
@@ -188,45 +188,47 @@ pub fn aes_decrypt_aead(
         .map_err(|_| anyhow!("AES-AEAD decryption failed. Authentication tag does not match the given ciphertext/nonce/aad"))
 }
 
-/// Domain-separation registry for every AES key derived from an ECDH shared
+/// Domain-separation labels for every AES key derived from an ECDH shared
 /// secret. One variant per protocol context; [`derive_aes_key`] is the only
 /// HKDF-expand over this input-keying-material class, so this enum is the
 /// exhaustive list of its labels.
 ///
 /// Two derived keys are independent unless both the shared secret AND the
-/// label match. Keeping labels distinct per context makes key independence a
-/// structural property rather than an assumption about which keypairs are
-/// (re)used where — including adversarially, via the on-chain ECDH precompile,
-/// which lets any contract evaluate the [`EcdhPrecompile`](Self::EcdhPrecompile)
-/// derivation on caller-chosen keys.
+/// label match.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AesKeyDomain {
-    /// Client-to-TEE transaction I/O: encrypted calldata and signed-read
-    /// requests. Clients encrypt, TEEs decrypt.
+    /// Client-to-TEE transaction I/O: Clients encrypts calldata, TEEs decrypt.
+    /// Use for both seismic txs and for signed-reads (eth_calls).
+    /// Signed reads request and response share the same nonce (sent as part of the tx)
+    /// and so must use a different domain.
     TxRequest,
     /// TEE-to-client transaction I/O: signed-read return data. TEEs encrypt,
-    /// clients decrypt. Independent from [`TxRequest`](Self::TxRequest) so a
-    /// request/response pair can carry one public nonce without repeating an
-    /// AES-GCM `(key, nonce)` pair.
+    /// clients decrypt. Distinct from [`TxRequest`](Self::TxRequest) so a
+    /// request/response pair sharing one public nonce never repeats an
+    /// AES-GCM `(key, nonce)` pair — the separation the nonce-reuse fix needs.
     TxResponse,
-    /// The ECDH precompile's on-chain key derivation. Consensus-frozen: its
-    /// output is observable by contracts, so this label can never change, and
-    /// no other domain may ever reuse it.
+    /// The ECDH precompile's on-chain key derivation. Also on the original
+    /// `"aes-gcm key"` label, and consensus-frozen: its output is observable
+    /// by contracts, so it can never change.
     EcdhPrecompile,
     /// The enclave-to-enclave root-key bootstrap handshake. Both sides ship
     /// in the same release and nothing wrapped is persisted, so this label
-    /// (unlike the precompile's) can rotate with a coordinated upgrade.
+    /// can rotate with a coordinated upgrade.
     RootKeyWrap,
 }
 
 impl AesKeyDomain {
     const fn hkdf_info(self) -> &'static [u8] {
         match self {
-            Self::TxRequest => b"seismic/request/aes-256-gcm/v1",
+            // Original pre domain-separation label, kept for backward compat and to
+            // prevent a consensus breaking change (request path is decrypted in the block executor).
+            // TxRequest and TxResponse MUST be different since they share the same key and nonce,
+            // but its fine for TxRequest to share a label with the unrelated EcdhPrecompile with
+            // which it doesn't share a key.
+            Self::TxRequest => b"aes-gcm key",
             Self::TxResponse => b"seismic/response/aes-256-gcm/v1",
-            // Cannot change: live on testnet. Contracts observe (and may
-            // persist data keyed by) this precompile's output, and no fork
-            // can make data derived under an old label reachable again.
+            // Same pre domain-separation label, kept for backward compatibility.
+            // Shared with TxRequest; see above.
             Self::EcdhPrecompile => b"aes-gcm key",
             Self::RootKeyWrap => b"seismic/root-key-wrap/aes-256-gcm/v1",
         }
@@ -525,8 +527,10 @@ mod tests {
 
         let vectors = [
             (
+                // Same as `EcdhPrecompile` below: both keep the original
+                // `"aes-gcm key"` label (see `AesKeyDomain::TxRequest`).
                 AesKeyDomain::TxRequest,
-                "d958b910e65af59475e767c5fdcb8b2e3388b5d8aa2fbfaa01c08c422be6fd07",
+                "bf0dd6556618d1bf8d1602bf80be3a0f7cc729973829bb9acb75bd77770d5b90",
             ),
             (
                 AesKeyDomain::TxResponse,
@@ -558,6 +562,14 @@ mod tests {
         let response_key = derive_aes_key(&shared_secret, AesKeyDomain::TxResponse).unwrap();
 
         assert_ne!(request_key.as_slice(), response_key.as_slice());
+    }
+
+    /// The request path must keep the original `"aes-gcm key"` label: it is
+    /// decrypted in the block executor, so a new label would be a consensus
+    /// break. Pin it so it can't change without a deliberate, reviewed edit.
+    #[test]
+    fn request_keeps_the_original_label() {
+        assert_eq!(AesKeyDomain::TxRequest.hkdf_info(), b"aes-gcm key");
     }
 
     #[test]

--- a/crates/custodian/src/root_key_wrap.rs
+++ b/crates/custodian/src/root_key_wrap.rs
@@ -12,7 +12,7 @@ use anyhow::{Context, Result, anyhow};
 use rand::{TryRngCore as _, rngs::OsRng};
 use secp256k1::{PublicKey, Secp256k1, SecretKey, ecdh::SharedSecret};
 use seismic_crypto::{
-    AESGCM_NONCE_SIZE, Nonce, aes_decrypt_aead, aes_encrypt_aead, derive_aes_key,
+    AESGCM_NONCE_SIZE, AesKeyDomain, Nonce, aes_decrypt_aead, aes_encrypt_aead, derive_aes_key,
 };
 
 /// A freshly minted ephemeral secp256k1 ECDH keypair for one handshake.
@@ -140,14 +140,16 @@ pub fn unwrap_root_key(
 
 /// Derive the symmetric handshake key from an ECDH shared secret.
 ///
-/// Reuses [`derive_aes_key`] so wrap and unwrap stay in lockstep with the rest
-/// of the enclave's ECDH-AES key schedule.
+/// Uses [`AesKeyDomain::RootKeyWrap`], the handshake's own domain-separation
+/// label: a key derived here is unusable in any other protocol context, and
+/// vice versa. Both custodian sides must run the same release.
 fn derive_handshake_key(
     sk: &SecretKey,
     pk: &PublicKey,
 ) -> Result<aes_gcm::Key<aes_gcm::Aes256Gcm>> {
     let shared = SharedSecret::new(pk, sk);
-    derive_aes_key(&shared).map_err(|e| anyhow!("deriving handshake AES key: {e}"))
+    derive_aes_key(&shared, AesKeyDomain::RootKeyWrap)
+        .map_err(|e| anyhow!("deriving handshake AES key: {e}"))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Bug

Every AES key was derived with one static HKDF info label (`"aes-gcm key"`), so a signed read's request and response — which share one public nonce — encrypted under the same AES-GCM `(key, nonce)` pair, allowing plaintext recovery.

## Fix

The bug only needs the request and response keys to differ, so we fix it **without a consensus-breaking change**: only the response direction gets a new HKDF label; the request path keeps the original `"aes-gcm key"`.

`derive_aes_key` now takes an `AesKeyDomain`, one HKDF label per protocol context:

- **TxRequest** — keeps the original `"aes-gcm key"` label. Request calldata is decrypted in the block executor, so changing its label would be a consensus break forcing every client to upgrade in lockstep. Only the response key needs to change, so we leave this untouched — existing clients and the calldata-decryption path are unaffected.
- **TxResponse** — new label `"seismic/response/aes-256-gcm/v1"`, so the request/response pair no longer repeats a `(key, nonce)` pair under the shared signed-read nonce. This is the only change the fix strictly requires, and it lives on the RPC read path, not consensus.
- **EcdhPrecompile** — keeps `"aes-gcm key"`; frozen because contracts observe (and may persist data keyed by) its output. `TxRequest` deliberately shares this label, which is safe because the precompile derives from a caller-supplied secret key and never the node key, so it can't be used as an oracle to reconstruct a request key.
- **RootKeyWrap** — its own label (ephemeral one-shot handshake, nothing persisted; both custodian sides ship in the same release).

Known-answer tests pin the exact key bytes per domain, shared with the TypeScript and Python client suites, so a label edit in any language fails its copy of the test.

See the full [key-schedule](https://github.com/SeismicSystems/seismic/pull/213) document for every key we derive and how — and to check for similar bugs in other derivations.

## Rollout

Because the request/tx-submission path is unchanged, this is **not** a consensus hard fork — existing transaction clients keep working. The remaining work is the response-key change on the signed-read path: reth (response encryption) and all 3 clients (rust, ts, python — response decryption) must adopt the new label together. That's an RPC-layer change coordinated across node and clients, not a testnet hard fork.

Downstream PRs:
- https://github.com/SeismicSystems/seismic-revm/pull/226
- https://github.com/SeismicSystems/seismic-alloy/pull/108
- https://github.com/SeismicSystems/seismic/pull/215
- https://github.com/SeismicSystems/seismic-reth/pull/448
- https://github.com/SeismicSystems/seismic-foundry/pull/217
