### PR TITLE
feat(key-custodian-host): add standalone key-custodian binary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5269,6 +5269,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "seismic-key-custodian-host"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "libc",
+ "rand 0.9.2",
+ "secp256k1",
+ "seismic-custodian-ipc",
+ "seismic-key-custodian",
+ "tempfile",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "seismic-network-manifest"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "crates/enclave-contract", "crates/enclave",
     "crates/enclave-crypto",
     "crates/key-custodian",
+    "crates/key-custodian-host",
     "crates/network-manifest",
     "crates/seismic-attestation",
     "crates/tdx-init",

--- a/crates/key-custodian-host/Cargo.toml
+++ b/crates/key-custodian-host/Cargo.toml
@@ -1,0 +1,39 @@
+[package]
+name = "seismic-key-custodian-host"
+edition.workspace = true
+version.workspace = true
+repository.workspace = true
+homepage.workspace = true
+authors.workspace = true
+license.workspace = true
+readme.workspace = true
+description = "Standalone host process for the Seismic key custodian"
+
+[[bin]]
+name = "seismic-key-custodian"
+path = "src/main.rs"
+
+[dependencies]
+seismic-key-custodian.workspace = true
+# default-features = false is this binary's no-async-runtime guarantee: only
+# the wire types plus the synchronous `server` transport are linked. CAUTION:
+# under cargo feature unification the guarantee holds only when this binary is
+# built in its own cargo invocation — see the feature note in
+# crates/custodian-ipc/Cargo.toml. A path dependency rather than `workspace =
+# true` because workspace inheritance cannot turn default features off.
+seismic-custodian-ipc = { path = "../custodian-ipc", default-features = false, features = ["server"] }
+
+anyhow.workspace = true
+clap.workspace = true
+libc.workspace = true
+rand.workspace = true
+secp256k1.workspace = true
+tracing.workspace = true
+tracing-subscriber.workspace = true
+
+[dev-dependencies]
+# Tests drive the served socket with the async client. Dev-only: resolver v2
+# keeps dev-dep features out of `cargo build`, so the binary stays tokio-free.
+seismic-custodian-ipc = { workspace = true, features = ["client"] }
+tempfile = "3.17.1"
+tokio.workspace = true

--- a/crates/key-custodian-host/src/acl.rs
+++ b/crates/key-custodian-host/src/acl.rs
@@ -1,0 +1,181 @@
+//! `--allow <user>:<purpose>[,<purpose>...]` grants → [`MethodAcl`].
+//!
+//! Grants name users, never numeric UIDs: sysusers-allocated UIDs are not
+//! stable across image builds, while usernames are pinned by the same image
+//! that defines them — the systemd unit passing `--allow` lives next to the
+//! user definitions in seismic-images, and both are part of the measured
+//! image, so there is deliberately no runtime-mutation path. Names resolve
+//! once at startup via `getpwnam_r`; an unresolvable name fails the boot so
+//! a typo'd grant surfaces immediately instead of as a runtime deny.
+
+use anyhow::{Context as _, Result, bail};
+use seismic_custodian_ipc::server::MethodAcl;
+use std::ffi::CString;
+
+/// Valid purpose labels: kebab-case of the [`MethodAcl`] field each one
+/// populates. `ping` is not grantable — it is open to anyone who can connect.
+/// Single source for both the `--allow` help text and the grant-parse error,
+/// so the two stay in lockstep.
+pub(crate) const VALID_PURPOSES: &str = "tx-io, tx-io-public, rng, snapshot, \
+     create-root-key-bootstrap-attempt, wrap-root-key, \
+     install-root-key-from-verified-bootstrap-response";
+
+/// Build the socket ACL from repeated `--allow` values. No specs yields the
+/// default deny-all ACL.
+pub fn method_acl_from_allow_specs(specs: &[String]) -> Result<MethodAcl> {
+    build_acl(specs, resolve_uid)
+}
+
+/// Username→UID lookup: always [`resolve_uid`] in production (wired by
+/// [`method_acl_from_allow_specs`]), but made generic for testing, so
+/// the grant matrix and purpose validation are exercised against a fixed
+/// user set instead of the host's user database.
+type ResolveUid = fn(&str) -> Result<u32>;
+
+/// Core of [`method_acl_from_allow_specs`], split out for the tests.
+fn build_acl(specs: &[String], resolve: ResolveUid) -> Result<MethodAcl> {
+    let mut acl = MethodAcl::default();
+    for spec in specs {
+        let Some((user, purposes)) = spec.split_once(':') else {
+            bail!("--allow '{spec}': expected <user>:<purpose>[,<purpose>...]");
+        };
+        let uid = resolve(user).with_context(|| format!("--allow '{spec}'"))?;
+        for purpose in purposes.split(',') {
+            let grants = match purpose {
+                "tx-io" => &mut acl.tx_io,
+                "tx-io-public" => &mut acl.tx_io_public,
+                "rng" => &mut acl.rng,
+                "snapshot" => &mut acl.snapshot,
+                "create-root-key-bootstrap-attempt" => &mut acl.create_root_key_bootstrap_attempt,
+                "wrap-root-key" => &mut acl.wrap_root_key,
+                "install-root-key-from-verified-bootstrap-response" => {
+                    &mut acl.install_root_key_from_verified_bootstrap_response
+                }
+                other => {
+                    bail!("--allow '{spec}': unknown purpose '{other}' (valid: {VALID_PURPOSES})")
+                }
+            };
+            grants.insert(uid);
+        }
+    }
+    Ok(acl)
+}
+
+/// Resolve a username to its UID via `getpwnam_r` (libc is already linked
+/// for `SO_PEERCRED`; no extra dependency).
+fn resolve_uid(user: &str) -> Result<u32> {
+    let c_user = CString::new(user).context("username contains a NUL byte")?;
+
+    // Start at the libc's suggested buffer size and grow on ERANGE; the cap
+    // only bounds a pathological NSS backend.
+    // SAFETY: sysconf takes an integer selector and touches no caller memory.
+    let mut buf_len = match unsafe { libc::sysconf(libc::_SC_GETPW_R_SIZE_MAX) } {
+        len if len > 0 => len as usize,
+        _ => 1024,
+    };
+    const MAX_BUF_LEN: usize = 1 << 20;
+
+    loop {
+        let mut buf = vec![0u8; buf_len];
+        // SAFETY: a zeroed passwd is only read if `result` is non-null, in
+        // which case getpwnam_r has fully initialized it.
+        let mut passwd: libc::passwd = unsafe { std::mem::zeroed() };
+        let mut result: *mut libc::passwd = std::ptr::null_mut();
+        // SAFETY: all pointers are live locals; getpwnam_r writes at most
+        // `buf.len()` bytes into `buf` and points `result` at `passwd` (or
+        // null) before returning.
+        let rc = unsafe {
+            libc::getpwnam_r(
+                c_user.as_ptr(),
+                &mut passwd,
+                buf.as_mut_ptr().cast(),
+                buf.len(),
+                &mut result,
+            )
+        };
+        if rc == libc::ERANGE && buf_len < MAX_BUF_LEN {
+            buf_len *= 2;
+            continue;
+        }
+        if rc != 0 {
+            return Err(std::io::Error::from_raw_os_error(rc))
+                .with_context(|| format!("resolving user '{user}'"));
+        }
+        if result.is_null() {
+            bail!("user '{user}' does not exist on this system");
+        }
+        return Ok(passwd.pw_uid);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use seismic_custodian_ipc::Request;
+
+    fn fake_resolve(user: &str) -> Result<u32> {
+        match user {
+            "reth" => Ok(1001),
+            "enclave-attest" => Ok(1002),
+            other => bail!("user '{other}' does not exist"),
+        }
+    }
+
+    // The production grant matrix: reth gets exactly its two secret purposes,
+    // the attestation service gets public tx-io data plus bootstrap authority.
+    #[test]
+    fn grants_map_to_method_acl_sets() {
+        let acl = build_acl(
+            &[
+                "reth:tx-io,rng".to_string(),
+                "enclave-attest:tx-io-public,create-root-key-bootstrap-attempt,\
+                 wrap-root-key,install-root-key-from-verified-bootstrap-response"
+                    .to_string(),
+            ],
+            fake_resolve,
+        )
+        .expect("valid specs");
+
+        assert!(acl.allows(1001, &Request::GetTxIoKeypair { epoch: 0 }));
+        assert!(acl.allows(1001, &Request::GetRngKeypair { epoch: 0 }));
+        assert!(!acl.allows(1001, &Request::GetSnapshotKey { epoch: 0 }));
+        assert!(!acl.allows(1001, &Request::CreateRootKeyBootstrapAttempt));
+
+        assert!(acl.allows(1002, &Request::GetTxIoPublicKey { epoch: 0 }));
+        assert!(acl.allows(1002, &Request::CreateRootKeyBootstrapAttempt));
+        assert!(!acl.allows(1002, &Request::GetTxIoKeypair { epoch: 0 }));
+
+        // Ping stays open even to ungranted UIDs.
+        assert!(acl.allows(4242, &Request::Ping));
+        assert!(!acl.allows(4242, &Request::GetTxIoKeypair { epoch: 0 }));
+    }
+
+    #[test]
+    fn no_specs_is_deny_by_default() {
+        let acl = build_acl(&[], fake_resolve).expect("empty specs");
+        assert!(!acl.allows(1001, &Request::GetTxIoKeypair { epoch: 0 }));
+        assert!(acl.allows(1001, &Request::Ping));
+    }
+
+    #[test]
+    fn malformed_specs_fail_the_boot() {
+        for spec in [
+            "reth",           // no colon
+            "reth:",          // empty purpose list
+            "reth:tx-io,",    // trailing comma
+            "reth:snapshots", // misspelled purpose
+            "ghost:tx-io",    // unresolvable user
+        ] {
+            assert!(
+                build_acl(&[spec.to_string()], fake_resolve).is_err(),
+                "spec '{spec}' must be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn resolve_uid_finds_root_and_rejects_unknown_users() {
+        assert_eq!(resolve_uid("root").expect("root exists"), 0);
+        assert!(resolve_uid("no-such-user-seismic-custodian-test").is_err());
+    }
+}

--- a/crates/key-custodian-host/src/dispatch.rs
+++ b/crates/key-custodian-host/src/dispatch.rs
@@ -1,0 +1,442 @@
+//! Dispatch for the custodian Unix socket: the shim between the wire
+//! protocol and the host's [`CustodianState`].
+//!
+//! The transport — bind semantics, peer credentials, ACL-before-dispatch,
+//! the frame loop — lives in `seismic_custodian_ipc::server`; this module is
+//! only the part that must live next to the key: mapping authorized requests
+//! onto the custodian state, including the bootstrap transitions through
+//! which a joining node acquires its root key.
+
+use crate::state::{CreateAttemptOutcome, CustodianState, InstallOutcome};
+use anyhow::Context as _;
+use seismic_custodian_ipc::{
+    Request, Response, RngKeypairBytes, RootKeyBootstrapAttemptBytes, SnapshotKeyBytes,
+    TxIoKeypairBytes, TxIoPublicKeyBytes, WrappedRootKeyBytes,
+};
+use seismic_key_custodian::{Custodian, VerifiedPeerAuthorization};
+use tracing::{error, info, warn};
+
+/// Map one ACL-authorized socket request onto the custodian state.
+///
+/// One outcome is process-fatal: an installed root key whose LUKS keyfile
+/// can't be written exits the host (see the install arm).
+pub fn dispatch(state: &CustodianState, request: Request) -> Response {
+    match request {
+        Request::Ping => Response::Pong,
+        Request::GetTxIoKeypair { epoch } => state
+            .with_custodian(|custodian| {
+                Response::TxIoKeypair(TxIoKeypairBytes {
+                    sk: custodian.get_tx_io_sk(epoch).secret_bytes(),
+                    pk: custodian.get_tx_io_pk(epoch).serialize(),
+                })
+            })
+            .unwrap_or(Response::RootKeyAbsent),
+        Request::GetTxIoPublicKey { epoch } => state
+            .with_custodian(|custodian| {
+                Response::TxIoPublicKey(TxIoPublicKeyBytes {
+                    pk: custodian.get_tx_io_pk(epoch).serialize(),
+                })
+            })
+            .unwrap_or(Response::RootKeyAbsent),
+        Request::GetRngKeypair { epoch } => state
+            .with_custodian(|custodian| {
+                Response::RngKeypair(RngKeypairBytes {
+                    keypair: custodian.get_rng_keypair(epoch).to_bytes().to_vec(),
+                })
+            })
+            .unwrap_or(Response::RootKeyAbsent),
+        Request::GetSnapshotKey { epoch } => state
+            .with_custodian(|custodian| {
+                Response::SnapshotKey(SnapshotKeyBytes {
+                    key: custodian.get_snapshot_key(epoch).into(),
+                })
+            })
+            .unwrap_or(Response::RootKeyAbsent),
+        Request::CreateRootKeyBootstrapAttempt => match state.create_bootstrap_attempt() {
+            CreateAttemptOutcome::Created {
+                attempt_id,
+                requester_eph_pk,
+            } => {
+                info!("retained a fresh root-key bootstrap attempt");
+                Response::RootKeyBootstrapAttemptCreated(RootKeyBootstrapAttemptBytes {
+                    attempt_id,
+                    requester_eph_pk,
+                })
+            }
+            CreateAttemptOutcome::RootKeyAlreadyPresent => Response::RootKeyAlreadyPresent,
+        },
+        Request::WrapRootKey {
+            root_key_request_binding,
+            peer_eph_pk,
+        } => match state.with_custodian(|custodian| {
+            wrap_root_key(custodian, root_key_request_binding, &peer_eph_pk)
+        }) {
+            None => Response::RootKeyAbsent,
+            Some(Ok(wrapped)) => Response::WrappedRootKey(wrapped),
+            Some(Err(error)) => {
+                // Detailed failures stay local to the key-holding process.
+                // The wire response is stable and cannot accidentally include
+                // key bytes from a future lower-level error implementation.
+                warn!(?error, "custodian root-key wrap failed");
+                Response::Error {
+                    message: "root-key wrap failed".to_string(),
+                }
+            }
+        },
+        Request::InstallRootKeyFromVerifiedBootstrapResponse {
+            attempt_id,
+            root_key_request_binding,
+            responder_eph_pk,
+            wrapped_root_key,
+        } => match state.install_root_key(
+            attempt_id,
+            root_key_request_binding,
+            responder_eph_pk,
+            &wrapped_root_key,
+        ) {
+            InstallOutcome::Installed => {
+                info!("root key installed; LUKS keyfile written");
+                Response::RootKeyInstalled
+            }
+            InstallOutcome::LuksKeyfileWriteFailed(error) => {
+                // Without the LUKS handoff the node can't mount /persistent,
+                // so this boot cannot proceed: exit and let the supervisor
+                // restart us into a clean re-bootstrap (root_key is RAM-only,
+                // so nothing is lost). Skipping the reply is deliberate — the
+                // dropped connection tells the caller the exchange died.
+                error!(?error, "LUKS keyfile write failed after root-key recovery");
+                std::process::exit(1);
+            }
+            InstallOutcome::RootKeyAlreadyPresent => Response::RootKeyAlreadyPresent,
+            InstallOutcome::UnknownAttempt => {
+                warn!("root-key install refused: no matching bootstrap attempt");
+                Response::Error {
+                    message: "no matching bootstrap attempt".to_string(),
+                }
+            }
+            InstallOutcome::InstallFailed(error) => {
+                warn!(?error, "custodian root-key install failed");
+                Response::Error {
+                    message: "root-key install failed".to_string(),
+                }
+            }
+        },
+    }
+}
+
+fn wrap_root_key(
+    custodian: &Custodian,
+    root_key_request_binding: [u8; 32],
+    peer_eph_pk: &[u8; 33],
+) -> anyhow::Result<WrappedRootKeyBytes> {
+    let peer_pk = secp256k1::PublicKey::from_slice(peer_eph_pk)
+        .context("peer_eph_pk is not a valid compressed secp256k1 point")?;
+    let auth = VerifiedPeerAuthorization {
+        root_key_request_binding,
+    };
+    let wrapped = custodian.wrap_root_key_for_peer(&auth, &peer_pk)?;
+    Ok(WrappedRootKeyBytes {
+        responder_eph_pk: wrapped.responder_eph_pk.serialize(),
+        wrapped: wrapped.wrapped,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::os::unix::fs::PermissionsExt as _;
+    use std::path::{Path, PathBuf};
+
+    const ROOT_KEY: [u8; 32] = [7u8; 32];
+    const BINDING: [u8; 32] = [0x33; 32];
+
+    fn tmp_luks() -> (tempfile::TempDir, PathBuf) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("luks-keys");
+        (dir, path)
+    }
+
+    fn with_root_key(luks_keyfile: &Path) -> CustodianState {
+        CustodianState::new_with_root_key(Custodian::new(ROOT_KEY), luks_keyfile.to_path_buf())
+            .expect("write LUKS keyfile")
+    }
+
+    fn awaiting(luks_keyfile: &Path) -> CustodianState {
+        CustodianState::new_awaiting_root_key(luks_keyfile.to_path_buf())
+    }
+
+    #[test]
+    fn purpose_keys_match_direct_derivation() {
+        let (_dir, luks) = tmp_luks();
+        let state = with_root_key(&luks);
+        let custodian = Custodian::new(ROOT_KEY);
+
+        let Response::TxIoKeypair(tx_io) = dispatch(&state, Request::GetTxIoKeypair { epoch: 0 })
+        else {
+            panic!("expected tx-io keypair");
+        };
+        assert_eq!(tx_io.sk, custodian.get_tx_io_sk(0).secret_bytes());
+        assert_eq!(tx_io.pk, custodian.get_tx_io_pk(0).serialize());
+
+        let Response::TxIoPublicKey(tx_io_public) =
+            dispatch(&state, Request::GetTxIoPublicKey { epoch: 0 })
+        else {
+            panic!("expected tx-io public key");
+        };
+        assert_eq!(tx_io_public.pk, tx_io.pk);
+
+        let Response::RngKeypair(rng) = dispatch(&state, Request::GetRngKeypair { epoch: 0 })
+        else {
+            panic!("expected rng keypair");
+        };
+        assert_eq!(
+            rng.keypair,
+            custodian.get_rng_keypair(0).to_bytes().to_vec()
+        );
+
+        let Response::SnapshotKey(snapshot) =
+            dispatch(&state, Request::GetSnapshotKey { epoch: 0 })
+        else {
+            panic!("expected snapshot key");
+        };
+        let expected: [u8; 32] = custodian.get_snapshot_key(0).into();
+        assert_eq!(snapshot.key, expected);
+    }
+
+    #[test]
+    fn awaiting_root_key_answers_root_key_absent() {
+        let (_dir, luks) = tmp_luks();
+        let state = awaiting(&luks);
+        for request in [
+            Request::GetTxIoKeypair { epoch: 0 },
+            Request::GetTxIoPublicKey { epoch: 0 },
+            Request::GetRngKeypair { epoch: 0 },
+            Request::GetSnapshotKey { epoch: 0 },
+            Request::WrapRootKey {
+                root_key_request_binding: BINDING,
+                peer_eph_pk: [0; 33],
+            },
+        ] {
+            let method = request.method();
+            assert!(
+                matches!(dispatch(&state, request), Response::RootKeyAbsent),
+                "{method} must answer RootKeyAbsent while awaiting"
+            );
+        }
+    }
+
+    // The full N=2 root-key distribution through dispatch alone: a "genesis"
+    // host wraps for a joining host's retained attempt, the joiner installs,
+    // then derives the same keys and has written its LUKS keyfile.
+    #[test]
+    fn bootstrap_over_dispatch_installs_and_writes_luks_keyfile() {
+        let (_genesis_dir, genesis_luks) = tmp_luks();
+        let (_joiner_dir, joiner_luks) = tmp_luks();
+        let genesis = with_root_key(&genesis_luks);
+        let joiner = awaiting(&joiner_luks);
+
+        let Response::RootKeyBootstrapAttemptCreated(attempt) =
+            dispatch(&joiner, Request::CreateRootKeyBootstrapAttempt)
+        else {
+            panic!("expected a created attempt");
+        };
+        let Response::WrappedRootKey(wrapped) = dispatch(
+            &genesis,
+            Request::WrapRootKey {
+                root_key_request_binding: BINDING,
+                peer_eph_pk: attempt.requester_eph_pk,
+            },
+        ) else {
+            panic!("expected a wrapped root key");
+        };
+        let installed = dispatch(
+            &joiner,
+            Request::InstallRootKeyFromVerifiedBootstrapResponse {
+                attempt_id: attempt.attempt_id,
+                root_key_request_binding: BINDING,
+                responder_eph_pk: wrapped.responder_eph_pk,
+                wrapped_root_key: wrapped.wrapped,
+            },
+        );
+        assert!(matches!(installed, Response::RootKeyInstalled));
+
+        // The joiner now derives the genesis keys...
+        let Response::TxIoKeypair(joiner_keys) =
+            dispatch(&joiner, Request::GetTxIoKeypair { epoch: 0 })
+        else {
+            panic!("expected tx-io keypair");
+        };
+        assert_eq!(
+            joiner_keys.sk,
+            Custodian::new(ROOT_KEY).get_tx_io_sk(0).secret_bytes()
+        );
+
+        // ...and wrote the LUKS keyfile on install: 64 bytes, mode 0400.
+        let metadata = std::fs::metadata(&joiner_luks).expect("keyfile written");
+        assert_eq!(metadata.len(), 64);
+        assert_eq!(metadata.permissions().mode() & 0o777, 0o400);
+
+        // Restart probe: a fresh create now reports the key present.
+        assert!(matches!(
+            dispatch(&joiner, Request::CreateRootKeyBootstrapAttempt),
+            Response::RootKeyAlreadyPresent
+        ));
+    }
+
+    #[test]
+    fn install_failures_return_stable_sanitized_errors() {
+        let (_dir, luks) = tmp_luks();
+        let joiner = awaiting(&luks);
+
+        let Response::Error { message } = dispatch(
+            &joiner,
+            Request::InstallRootKeyFromVerifiedBootstrapResponse {
+                attempt_id: [1; 32],
+                root_key_request_binding: BINDING,
+                responder_eph_pk: [3; 33],
+                wrapped_root_key: vec![4; 60],
+            },
+        ) else {
+            panic!("expected a sanitized error");
+        };
+        assert_eq!(message, "no matching bootstrap attempt");
+
+        // A garbage responder point on a live attempt: sanitized failure, no
+        // secp256k1/AEAD detail on the wire.
+        let Response::RootKeyBootstrapAttemptCreated(attempt) =
+            dispatch(&joiner, Request::CreateRootKeyBootstrapAttempt)
+        else {
+            panic!("expected a created attempt");
+        };
+        let Response::Error { message } = dispatch(
+            &joiner,
+            Request::InstallRootKeyFromVerifiedBootstrapResponse {
+                attempt_id: attempt.attempt_id,
+                root_key_request_binding: BINDING,
+                responder_eph_pk: [0; 33],
+                wrapped_root_key: vec![0; 60],
+            },
+        ) else {
+            panic!("expected a sanitized error");
+        };
+        assert_eq!(message, "root-key install failed");
+    }
+
+    #[test]
+    fn wrap_root_key_rejects_invalid_peer_point() {
+        let (_dir, luks) = tmp_luks();
+        let state = with_root_key(&luks);
+        let response = dispatch(
+            &state,
+            Request::WrapRootKey {
+                root_key_request_binding: [0u8; 32],
+                peer_eph_pk: [0u8; 33],
+            },
+        );
+        let Response::Error { message } = response else {
+            panic!("expected sanitized custodian error");
+        };
+        assert_eq!(message, "root-key wrap failed");
+    }
+
+    /// Coverage over real `UnixListener`s: two served custodians — one
+    /// genesis, one joining — complete the root-key distribution through the
+    /// crate server + async client, exactly the calls the attestation service
+    /// will make (attestation itself deliberately absent: evidence never
+    /// reaches the custodian). Needs an environment permitting `AF_UNIX`
+    /// bind; in a sandbox that forbids it, skip with `-- --skip real_socket`.
+    mod real_socket {
+        use super::*;
+        use crate::state::CustodianState;
+        use seismic_custodian_ipc::server::{MethodAcl, bind, serve};
+        use seismic_custodian_ipc::{
+            CreateRootKeyBootstrapAttemptResult, CustodianClient,
+            InstallRootKeyFromVerifiedBootstrapResponseResult, IpcError,
+        };
+
+        fn spawn_host(state: CustodianState, dir: &tempfile::TempDir) -> PathBuf {
+            let socket = dir.path().join("custodian.sock");
+            let listener = bind(&socket).expect("bind");
+            std::thread::spawn(move || {
+                serve(listener, MethodAcl::own_uid_only(), move |request| {
+                    dispatch(&state, request)
+                })
+            });
+            socket
+        }
+
+        #[tokio::test]
+        async fn full_bootstrap_between_two_custodians() {
+            let genesis_dir = tempfile::tempdir().expect("tempdir");
+            let joiner_dir = tempfile::tempdir().expect("tempdir");
+            let genesis_socket = spawn_host(
+                with_root_key(&genesis_dir.path().join("luks-keys")),
+                &genesis_dir,
+            );
+            let joiner_socket =
+                spawn_host(awaiting(&joiner_dir.path().join("luks-keys")), &joiner_dir);
+
+            let mut genesis = CustodianClient::connect(&genesis_socket)
+                .await
+                .expect("connect");
+            let mut joiner = CustodianClient::connect(&joiner_socket)
+                .await
+                .expect("connect");
+
+            // Before bootstrap, the joiner serves no keys.
+            let error = joiner.get_tx_io_keypair(0).await.expect_err("no key yet");
+            assert!(matches!(error, IpcError::RootKeyAbsent));
+
+            let CreateRootKeyBootstrapAttemptResult::Created(attempt) = joiner
+                .create_root_key_bootstrap_attempt()
+                .await
+                .expect("create attempt")
+            else {
+                panic!("joiner must not already hold a root key");
+            };
+
+            // The attestation service's role in between — verifying evidence
+            // and computing the transcript binding — is opaque to both
+            // custodians; any 32 bytes stand in for the binding here.
+            let wrapped = genesis
+                .wrap_root_key(BINDING, attempt.requester_eph_pk)
+                .await
+                .expect("wrap root key");
+
+            let installed = joiner
+                .install_root_key_from_verified_bootstrap_response(
+                    attempt.attempt_id,
+                    BINDING,
+                    wrapped.responder_eph_pk,
+                    wrapped.wrapped,
+                )
+                .await
+                .expect("install root key");
+            assert_eq!(
+                installed,
+                InstallRootKeyFromVerifiedBootstrapResponseResult::Installed
+            );
+
+            // Both custodians now serve identical purpose keys.
+            let genesis_keys = genesis.get_tx_io_keypair(0).await.expect("genesis keys");
+            let joiner_keys = joiner.get_tx_io_keypair(0).await.expect("joiner keys");
+            assert_eq!(genesis_keys.sk, joiner_keys.sk);
+
+            // The joiner wrote its LUKS keyfile on install.
+            let metadata =
+                std::fs::metadata(joiner_dir.path().join("luks-keys")).expect("keyfile written");
+            assert_eq!(metadata.len(), 64);
+
+            // Restarted-service probe: create against a custodian holding the
+            // key reports it present instead of erroring.
+            let probe = joiner
+                .create_root_key_bootstrap_attempt()
+                .await
+                .expect("probe");
+            assert!(matches!(
+                probe,
+                CreateRootKeyBootstrapAttemptResult::RootKeyAlreadyPresent
+            ));
+        }
+    }
+}

--- a/crates/key-custodian-host/src/main.rs
+++ b/crates/key-custodian-host/src/main.rs
@@ -1,0 +1,107 @@
+//! `seismic-key-custodian` — the standalone host for the network root key.
+//!
+//! Owns the [`Custodian`]'s root key in process memory and serves derivation
+//! and wrapping to local callers over a Unix socket, each authenticated by
+//! kernel-reported UID (`SO_PEERCRED`) against the `--allow` grants. The
+//! process is kept explicitly minimal — a synchronous socket server with a
+//! tiny dependency footprint — to reduce the attack surface around the root
+//! key; see the `seismic-key-custodian` crate docs for the boundary rule.
+
+use anyhow::{Context as _, Result};
+use clap::Parser;
+use seismic_custodian_ipc::DEFAULT_CUSTODIAN_SOCKET_PATH;
+use seismic_custodian_ipc::server::{bind, serve};
+use seismic_key_custodian::Custodian;
+use state::CustodianState;
+use std::path::PathBuf;
+use tracing::info;
+use tracing_subscriber::EnvFilter;
+
+mod acl;
+mod dispatch;
+mod state;
+
+/// Default drop-zone for the LUKS keyfile, in this service's runtime
+/// directory. The path is a deployment contract with `setup-persistent-luks`
+/// (seismic-images), which polls for the file and shreds it after use.
+const DEFAULT_LUKS_KEYFILE_PATH: &str = "/run/seismic/custodian/luks-keys";
+
+#[derive(Parser, Debug)]
+#[command(author, version, about, long_about = None)]
+struct Args {
+    /// Filesystem path for the custodian IPC socket.
+    #[arg(long, default_value = DEFAULT_CUSTODIAN_SOCKET_PATH)]
+    socket: PathBuf,
+
+    /// Generate a fresh network root key at startup instead of awaiting one
+    /// via the bootstrap methods. Set on exactly one node in the deployment;
+    /// setting it on multiple nodes causes a silent network split.
+    #[arg(long, env = "SEISMIC_CUSTODIAN_GENESIS_NODE", default_value_t = false)]
+    genesis_node: bool,
+
+    /// Path the LUKS keyfile is written to once the root key exists
+    /// and the LUKS key has been derived from it.
+    #[arg(long, default_value = DEFAULT_LUKS_KEYFILE_PATH)]
+    luks_keyfile: PathBuf,
+
+    /// Grant a local user custodian methods; repeatable, deny-by-default.
+    #[arg(
+        long = "allow",
+        value_name = "USER:PURPOSES",
+        long_help = format!(
+            "Grant a local user custodian methods; repeatable, deny-by-default.\n\n\
+             Purposes: {}.\n\n\
+             The two intended callers and their grants:\n  \
+             --allow reth:tx-io,rng\n  \
+             --allow enclave-attest:tx-io-public,create-root-key-bootstrap-attempt,\
+             wrap-root-key,install-root-key-from-verified-bootstrap-response",
+            acl::VALID_PURPOSES
+        )
+    )]
+    allow: Vec<String>,
+}
+
+fn main() -> Result<()> {
+    init_tracing();
+    let args = Args::parse();
+
+    // Resolve grants before any key material exists: an unresolvable user
+    // name is a deployment bug and must fail the boot, not become a silent
+    // runtime deny.
+    let acl = acl::method_acl_from_allow_specs(&args.allow)?;
+
+    // The state owns the LUKS keyfile handoff: it is written whenever the
+    // root key becomes present. For a genesis node that is right here — a
+    // failure is fatal, since without the keys reaching setup-persistent-luks
+    // the node can't proceed past this boot.
+    let state = if args.genesis_node {
+        info!("genesis node: generating fresh network root key");
+        CustodianState::new_with_root_key(Custodian::new_as_genesis()?, args.luks_keyfile)?
+    } else {
+        info!("joining node: awaiting root key via the bootstrap methods");
+        CustodianState::new_awaiting_root_key(args.luks_keyfile)
+    };
+
+    let listener = bind(&args.socket)
+        .with_context(|| format!("binding custodian socket {}", args.socket.display()))?;
+    serve(listener, acl, move |request| {
+        dispatch::dispatch(&state, request)
+    });
+    unreachable!("the custodian accept loop never returns");
+}
+
+fn init_tracing() {
+    let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
+    tracing_subscriber::fmt().with_env_filter(filter).init();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::CommandFactory as _;
+
+    #[test]
+    fn args_parse() {
+        Args::command().debug_assert();
+    }
+}

--- a/crates/key-custodian-host/src/state.rs
+++ b/crates/key-custodian-host/src/state.rs
@@ -1,0 +1,385 @@
+//! Root-key lifecycle for the standalone custodian host.
+//!
+//! A genesis node starts with a freshly generated root key present. A joining
+//! node binds the socket before it holds a root key and acquires it *through*
+//! the socket: it starts awaiting, retains at most one requester-side
+//! bootstrap attempt, and installs the root key from a verified, wrapped
+//! bootstrap response. The requester's ephemeral ECDH secret never leaves
+//! this process — the network-facing attestation service drives the evidence
+//! exchange and sees only the public half.
+//!
+//! Both ways a root key becomes present — genesis construction and a verified
+//! install — write the LUKS keyfile before the key is observable, so a
+//! present root key always implies the handoff to `setup-persistent-luks`
+//! has happened.
+
+use anyhow::{Context as _, Result, anyhow};
+use rand::{TryRngCore as _, rngs::OsRng};
+use secp256k1::PublicKey;
+use seismic_key_custodian::{Custodian, EphemeralKeypair, unwrap_root_key};
+use std::path::{Path, PathBuf};
+use std::sync::{Mutex, MutexGuard, PoisonError};
+use tracing::info;
+
+/// The host's one custodian slot, shared by every connection thread.
+pub struct CustodianState {
+    inner: Mutex<RootKeyState>,
+    /// Drop-zone for the LUKS keyfile, written whenever the root key becomes
+    /// present.
+    luks_keyfile: PathBuf,
+}
+
+// Variant names mirror the wire vocabulary (`RootKeyAlreadyPresent`,
+// `RootKeyAbsent` in custodian-ipc).
+enum RootKeyState {
+    /// No root key yet (a joining node): only the bootstrap methods act.
+    Absent { attempt: Option<PendingAttempt> },
+    /// Root key held: derivations and wraps are served.
+    Present(Custodian),
+}
+
+/// One requester-side bootstrap attempt: the ephemeral secret retained for
+/// exactly one exchange, addressed by an opaque id.
+struct PendingAttempt {
+    id: [u8; 32],
+    eph: EphemeralKeypair,
+}
+
+/// Outcome of [`CustodianState::create_bootstrap_attempt`].
+pub enum CreateAttemptOutcome {
+    Created {
+        attempt_id: [u8; 32],
+        requester_eph_pk: [u8; 33],
+    },
+    RootKeyAlreadyPresent,
+}
+
+/// Outcome of [`CustodianState::install_root_key`].
+pub enum InstallOutcome {
+    Installed,
+    RootKeyAlreadyPresent,
+    /// No retained attempt matches the id: none was created, a newer attempt
+    /// replaced it, or a previous install consumed it.
+    UnknownAttempt,
+    /// The wrapped key failed to open (bad point or AEAD mismatch). The
+    /// matching attempt is consumed: a retry must start a fresh exchange, so
+    /// a failed one leaks nothing reusable.
+    InstallFailed(anyhow::Error),
+    /// The root key was recovered but the LUKS keyfile write failed, so
+    /// nothing was installed. Without the handoff the node cannot finish this
+    /// boot; the host treats this as fatal.
+    LuksKeyfileWriteFailed(anyhow::Error),
+}
+
+impl CustodianState {
+    pub fn new_awaiting_root_key(luks_keyfile: PathBuf) -> Self {
+        Self {
+            inner: Mutex::new(RootKeyState::Absent { attempt: None }),
+            luks_keyfile,
+        }
+    }
+
+    /// Errors if the LUKS keyfile write fails: a root key is never present
+    /// without the handoff done.
+    pub fn new_with_root_key(custodian: Custodian, luks_keyfile: PathBuf) -> Result<Self> {
+        write_luks_keyfile(&custodian, &luks_keyfile)?;
+        Ok(Self {
+            inner: Mutex::new(RootKeyState::Present(custodian)),
+            luks_keyfile,
+        })
+    }
+
+    /// Run `f` against the custodian, or `None` while no root key is present
+    /// (callers answer `RootKeyAbsent`).
+    pub fn with_custodian<T>(&self, f: impl FnOnce(&Custodian) -> T) -> Option<T> {
+        match &*self.lock() {
+            RootKeyState::Present(custodian) => Some(f(custodian)),
+            RootKeyState::Absent { .. } => None,
+        }
+    }
+
+    /// Start a requester-side bootstrap attempt, replacing (and thereby
+    /// invalidating) any previous one: one live exchange at a time, with a
+    /// fresh ephemeral key per exchange.
+    pub fn create_bootstrap_attempt(&self) -> CreateAttemptOutcome {
+        match &mut *self.lock() {
+            RootKeyState::Present(_) => CreateAttemptOutcome::RootKeyAlreadyPresent,
+            RootKeyState::Absent { attempt } => {
+                let mut id = [0u8; 32];
+                OsRng
+                    .try_fill_bytes(&mut id)
+                    .expect("OS RNG must produce an attempt id");
+                let eph = EphemeralKeypair::generate();
+                let requester_eph_pk = eph.pk_compressed();
+                *attempt = Some(PendingAttempt { id, eph });
+                CreateAttemptOutcome::Created {
+                    attempt_id: id,
+                    requester_eph_pk,
+                }
+            }
+        }
+    }
+
+    /// Open a verified, wrapped bootstrap response with the retained attempt's
+    /// ephemeral secret and install the recovered root key, writing the LUKS
+    /// keyfile as part of the transition.
+    ///
+    /// The caller asserts, via its ACL grant, that the responder's evidence
+    /// over this exact response transcript has been verified — mirroring
+    /// `VerifiedPeerAuthorization` on the wrap side, the binding is opaque
+    /// bytes here and the AEAD tag is the only local check.
+    pub fn install_root_key(
+        &self,
+        attempt_id: [u8; 32],
+        root_key_request_binding: [u8; 32],
+        responder_eph_pk: [u8; 33],
+        wrapped_root_key: &[u8],
+    ) -> InstallOutcome {
+        let mut state = self.lock();
+        let attempt = match &mut *state {
+            RootKeyState::Present(_) => return InstallOutcome::RootKeyAlreadyPresent,
+            // take_if: consume the attempt only on an id match — a stale id
+            // must not invalidate a newer live attempt.
+            RootKeyState::Absent { attempt } => {
+                match attempt.take_if(|pending| pending.id == attempt_id) {
+                    Some(pending) => pending,
+                    None => return InstallOutcome::UnknownAttempt,
+                }
+            }
+        };
+
+        let responder_pk = match PublicKey::from_slice(&responder_eph_pk) {
+            Ok(pk) => pk,
+            Err(e) => {
+                return InstallOutcome::InstallFailed(anyhow!(
+                    "responder_eph_pk is not a valid compressed secp256k1 point: {e}"
+                ));
+            }
+        };
+        match unwrap_root_key(
+            &attempt.eph.sk,
+            &responder_pk,
+            wrapped_root_key,
+            &root_key_request_binding,
+        ) {
+            Ok(root_key) => {
+                let custodian = Custodian::new(root_key);
+                // The handoff precedes the transition: a present root key
+                // always implies the LUKS keyfile has been written.
+                if let Err(e) = write_luks_keyfile(&custodian, &self.luks_keyfile) {
+                    return InstallOutcome::LuksKeyfileWriteFailed(e);
+                }
+                *state = RootKeyState::Present(custodian);
+                InstallOutcome::Installed
+            }
+            Err(e) => InstallOutcome::InstallFailed(e),
+        }
+    }
+
+    /// A panicking connection thread must not wedge every later request, so
+    /// recover from poisoning; every transition assigns a whole variant, so
+    /// no partially-updated state can be observed.
+    fn lock(&self) -> MutexGuard<'_, RootKeyState> {
+        self.inner.lock().unwrap_or_else(PoisonError::into_inner)
+    }
+}
+
+/// Hand the LUKS keys off to `setup-persistent-luks` (seismic-images), which
+/// polls for the file and shreds it after use.
+fn write_luks_keyfile(custodian: &Custodian, path: &Path) -> Result<()> {
+    custodian
+        .write_luks_keyfile(path)
+        .with_context(|| format!("writing LUKS keyfile {}", path.display()))?;
+    info!(path = %path.display(), "wrote LUKS keyfile for setup-persistent-luks");
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use seismic_key_custodian::VerifiedPeerAuthorization;
+    use std::os::unix::fs::PermissionsExt as _;
+
+    const ROOT_KEY: [u8; 32] = [7u8; 32];
+    const BINDING: [u8; 32] = [0x33; 32];
+
+    fn tmp_luks() -> (tempfile::TempDir, PathBuf) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("luks-keys");
+        (dir, path)
+    }
+
+    fn awaiting(luks_keyfile: &Path) -> CustodianState {
+        CustodianState::new_awaiting_root_key(luks_keyfile.to_path_buf())
+    }
+
+    fn with_root_key(luks_keyfile: &Path) -> CustodianState {
+        CustodianState::new_with_root_key(Custodian::new(ROOT_KEY), luks_keyfile.to_path_buf())
+            .expect("write LUKS keyfile")
+    }
+
+    /// Responder side of the handshake, straight against the library.
+    fn wrap_for(responder: &Custodian, requester_eph_pk: [u8; 33]) -> ([u8; 33], Vec<u8>) {
+        let pk = PublicKey::from_slice(&requester_eph_pk).expect("valid requester point");
+        let wrapped = responder
+            .wrap_root_key_for_peer(
+                &VerifiedPeerAuthorization {
+                    root_key_request_binding: BINDING,
+                },
+                &pk,
+            )
+            .expect("wrap");
+        (wrapped.responder_eph_pk.serialize(), wrapped.wrapped)
+    }
+
+    fn created(state: &CustodianState) -> ([u8; 32], [u8; 33]) {
+        let CreateAttemptOutcome::Created {
+            attempt_id,
+            requester_eph_pk,
+        } = state.create_bootstrap_attempt()
+        else {
+            panic!("expected a created attempt");
+        };
+        (attempt_id, requester_eph_pk)
+    }
+
+    /// The deployment contract with setup-persistent-luks: 64 raw bytes
+    /// (`storage_key || header_mac_key`), owner-read-only.
+    fn assert_luks_keyfile(path: &Path) {
+        let metadata = std::fs::metadata(path).expect("LUKS keyfile written");
+        assert_eq!(metadata.len(), 64);
+        assert_eq!(metadata.permissions().mode() & 0o777, 0o400);
+    }
+
+    #[test]
+    fn present_root_key_reports_already_present() {
+        let (_dir, luks) = tmp_luks();
+        let state = with_root_key(&luks);
+        assert!(state.with_custodian(|_| ()).is_some());
+        assert!(matches!(
+            state.create_bootstrap_attempt(),
+            CreateAttemptOutcome::RootKeyAlreadyPresent
+        ));
+        assert!(matches!(
+            state.install_root_key([0; 32], BINDING, [0; 33], &[]),
+            InstallOutcome::RootKeyAlreadyPresent
+        ));
+    }
+
+    #[test]
+    fn awaiting_state_withholds_the_custodian_and_refuses_blind_installs() {
+        let (_dir, luks) = tmp_luks();
+        let state = awaiting(&luks);
+        assert!(state.with_custodian(|_| ()).is_none());
+        assert!(matches!(
+            state.install_root_key([0; 32], BINDING, [0; 33], &[]),
+            InstallOutcome::UnknownAttempt
+        ));
+    }
+
+    #[test]
+    fn root_key_construction_writes_the_luks_keyfile() {
+        let (_dir, luks) = tmp_luks();
+        let _state = with_root_key(&luks);
+        assert_luks_keyfile(&luks);
+    }
+
+    #[test]
+    fn construction_fails_when_the_luks_keyfile_is_unwritable() {
+        let (dir, _) = tmp_luks();
+        let unwritable = dir.path().join("missing-dir").join("luks-keys");
+        assert!(CustodianState::new_with_root_key(Custodian::new(ROOT_KEY), unwritable).is_err());
+    }
+
+    #[test]
+    fn bootstrap_roundtrip_installs_the_wrapped_root_key() {
+        let (_dir, luks) = tmp_luks();
+        let responder = Custodian::new(ROOT_KEY);
+        let state = awaiting(&luks);
+
+        let (attempt_id, requester_eph_pk) = created(&state);
+        let (responder_eph_pk, wrapped) = wrap_for(&responder, requester_eph_pk);
+        assert!(matches!(
+            state.install_root_key(attempt_id, BINDING, responder_eph_pk, &wrapped),
+            InstallOutcome::Installed
+        ));
+
+        // Both custodians now derive identical purpose keys, and the install
+        // wrote the LUKS handoff.
+        let installed_sk = state
+            .with_custodian(|c| c.get_tx_io_sk(0))
+            .expect("root key present");
+        assert_eq!(installed_sk, responder.get_tx_io_sk(0));
+        assert_luks_keyfile(&luks);
+    }
+
+    #[test]
+    fn failed_luks_write_leaves_the_root_key_absent() {
+        let (dir, _) = tmp_luks();
+        let unwritable = dir.path().join("missing-dir").join("luks-keys");
+        let responder = Custodian::new(ROOT_KEY);
+        let state = awaiting(&unwritable);
+
+        let (attempt_id, requester_eph_pk) = created(&state);
+        let (responder_eph_pk, wrapped) = wrap_for(&responder, requester_eph_pk);
+        assert!(matches!(
+            state.install_root_key(attempt_id, BINDING, responder_eph_pk, &wrapped),
+            InstallOutcome::LuksKeyfileWriteFailed(_)
+        ));
+        assert!(state.with_custodian(|_| ()).is_none());
+    }
+
+    #[test]
+    fn stale_attempt_id_is_refused_without_consuming_the_live_attempt() {
+        let (_dir, luks) = tmp_luks();
+        let responder = Custodian::new(ROOT_KEY);
+        let state = awaiting(&luks);
+
+        let (stale_id, _) = created(&state);
+        let (live_id, requester_eph_pk) = created(&state);
+        assert_ne!(stale_id, live_id);
+
+        let (responder_eph_pk, wrapped) = wrap_for(&responder, requester_eph_pk);
+        assert!(matches!(
+            state.install_root_key(stale_id, BINDING, responder_eph_pk, &wrapped),
+            InstallOutcome::UnknownAttempt
+        ));
+        assert!(matches!(
+            state.install_root_key(live_id, BINDING, responder_eph_pk, &wrapped),
+            InstallOutcome::Installed
+        ));
+    }
+
+    #[test]
+    fn failed_install_consumes_the_attempt() {
+        let (_dir, luks) = tmp_luks();
+        let responder = Custodian::new(ROOT_KEY);
+        let state = awaiting(&luks);
+
+        let (attempt_id, requester_eph_pk) = created(&state);
+        let (responder_eph_pk, wrapped) = wrap_for(&responder, requester_eph_pk);
+
+        // Wrapped under BINDING, opened under a foreign binding: AEAD fails.
+        assert!(matches!(
+            state.install_root_key(attempt_id, [0xFF; 32], responder_eph_pk, &wrapped),
+            InstallOutcome::InstallFailed(_)
+        ));
+        // The attempt is gone: even the correct binding can't reuse it.
+        assert!(matches!(
+            state.install_root_key(attempt_id, BINDING, responder_eph_pk, &wrapped),
+            InstallOutcome::UnknownAttempt
+        ));
+        assert!(state.with_custodian(|_| ()).is_none());
+    }
+
+    #[test]
+    fn invalid_responder_point_fails_the_install() {
+        let (_dir, luks) = tmp_luks();
+        let state = awaiting(&luks);
+        let (attempt_id, _) = created(&state);
+        assert!(matches!(
+            state.install_root_key(attempt_id, BINDING, [0; 33], &[0; 60]),
+            InstallOutcome::InstallFailed(_)
+        ));
+    }
+}


### PR DESCRIPTION
seismic-enclave-server still hosts the Custodian that holds root_key in the same process as the network-facing attestation RPCs and their evidence parsers. This adds the process that custody moves into: a standalone seismic-key-custodian binary kept explicitly minimal to shrink the surface entrusted with root_key — it serves the custodian Unix socket synchronously (thread per connection, SO_PEERCRED peer auth) and links no async runtime.

The host implements the root-key lifecycle behind the IPC contract from #208:

- A genesis node generates a fresh root key at startup; a joining node binds the socket without one and acquires it through the bootstrap methods: CreateRootKeyBootstrapAttempt retains the requester-side ephemeral secret (at most one live attempt; a newer attempt or a failed install invalidates it), and InstallRootKeyFromVerifiedBootstrapResponse unwraps and installs the key. The ephemeral secret and raw root_key never leave the custodian process.

- The LUKS keyfile handoff is owned by the state transitions: both ways a root key becomes present (genesis construction, verified install) write the keyfile before the key is observable, so a present key always implies setup-persistent-luks got its handoff. A failed write is fatal — the boot cannot proceed without it.

- Method grants come from repeated --allow <user>:<purpose>[,...] flags, deny-by-default. Grants name users, never numeric UIDs (sysusers-allocated UIDs are not stable across image builds); names resolve once at startup via getpwnam_r, and an unresolvable name fails the boot.

The binary keeps tokio out by depending on seismic-custodian-ipc with default-features = false. Under cargo feature unification that holds only when it is built in its own cargo invocation (see the CAUTION in custodian-ipc's manifest); the seismic-images build must honor that.

Tests cover the state machine (attempt retention and invalidation, AEAD failure semantics, LUKS write failure leaving the key absent), the dispatch mapping with sanitized wire errors, the ACL grant matrix, and an N=2 root-key distribution between two custodians end-to-end over real Unix sockets with the async client.

No production caller connects yet: enclave-server is unchanged and still hosts its own in-process custodian. Follow-up work moves the attestation service onto this socket, adds the users/units/grants in seismic-images, and cuts reth over from the HTTP purpose-key fetch.