### PR TITLE
feat(tdx-init)!: per-service operator config for the custodian split

### DIFF
--- a/bin/attestation-service/src/lib.rs
+++ b/bin/attestation-service/src/lib.rs
@@ -4,8 +4,10 @@ mod network;
 mod server;
 pub mod utils;
 
-const ENCLAVE_DEFAULT_ENDPOINT_IP: &str = "127.0.0.1";
-pub const ENCLAVE_DEFAULT_ENDPOINT_PORT: u16 = 7878;
+/// Loopback as a safe default but production should listen on `0.0.0.0` instead:
+/// joining peers fetch the wrapped root key from here and deploy tooling polls node status.
+const DEFAULT_ENDPOINT_IP: &str = "127.0.0.1";
+const DEFAULT_ENDPOINT_PORT: u16 = 7878;
 
 use anyhow::Result;
 use clap::Parser;
@@ -19,11 +21,11 @@ use tracing::info;
 #[command(author, version, about, long_about = None)]
 pub struct Args {
     /// The ip to bind the JSON-RPC server to.
-    #[arg(long, default_value_t = ENCLAVE_DEFAULT_ENDPOINT_IP.to_string())]
+    #[arg(long, default_value_t = DEFAULT_ENDPOINT_IP.to_string())]
     pub ip: String,
 
     /// The port to bind the server to
-    #[arg(long, default_value_t = ENCLAVE_DEFAULT_ENDPOINT_PORT)]
+    #[arg(long, default_value_t = DEFAULT_ENDPOINT_PORT)]
     pub port: u16,
 
     /// Comma-separated list of peer URLs (e.g. `http://10.0.0.1:7878`) to
@@ -31,7 +33,7 @@ pub struct Args {
     /// Required on every node whose custodian does not run with
     /// `--genesis-node`: with a keyless custodian and no peers there is no
     /// way to obtain the root key, so startup fails immediately.
-    #[arg(long, env = "SEISMIC_ENCLAVE_PEERS", value_delimiter = ',')]
+    #[arg(long, env = "SEISMIC_ROOT_KEY_PEERS", value_delimiter = ',')]
     pub peers: Vec<String>,
 
     /// Filesystem path for the custodian IPC socket.

--- a/bin/attestation-service/src/server.rs
+++ b/bin/attestation-service/src/server.rs
@@ -241,7 +241,7 @@ async fn ensure_root_key_present(
     if peers.is_empty() {
         anyhow::bail!(
             "The custodian holds no root key and no peers are configured. Either:\n  \
-             - set SEISMIC_ENCLAVE_PEERS to a comma-separated list of \
+             - set SEISMIC_ROOT_KEY_PEERS to a comma-separated list of \
              peer enclave URLs (e.g. http://10.0.0.1:7878) to fetch \
              the root_key from an existing peer, OR\n  \
              - run seismic-custodian-service with --genesis-node to bootstrap a new \

--- a/bin/tdx-init/README.md
+++ b/bin/tdx-init/README.md
@@ -36,7 +36,7 @@ Unknown top-level sections or fields are rejected — see
 name = "<your.public.dns.name>"     # FQDN clients reach this VM at
 email = "<contact@example.com>"     # ACME registration / renewal email
 
-[enclave]                           # optional; defaults applied if absent
+[root_key]                           # optional; defaults applied if absent
 genesis_node = false                # true on exactly one VM per network
 peers = ["http://10.0.0.1:7878"]    # required when genesis_node = false
 
@@ -71,7 +71,8 @@ After validation, tdx-init writes:
 | File | Schema | Consumer |
 |---|---|---|
 | `/run/seismic/conf/domain.env` | `DOMAIN_NAME=...`, `DOMAIN_EMAIL=...` | `setup-nginx-ssl` (seismic-images) — `source`'d before invoking certbot for Let's Encrypt cert issuance and renewal |
-| `/run/seismic/conf/enclave.env` | `SEISMIC_ENCLAVE_GENESIS_NODE=...`, `SEISMIC_ENCLAVE_PEERS=...` | `enclave.service` (seismic-images) — loaded via `EnvironmentFile=`; [`seismic-attestation-service`](../attestation-service) reads the peer list through clap `env=`, and the genesis flag maps to `seismic-custodian-service --genesis-node` |
+| `/run/seismic/conf/custodian.env` | `SEISMIC_CUSTODIAN_GENESIS_NODE=...` | `custodian.service` (seismic-images) — loaded via `EnvironmentFile=`; [`seismic-custodian-service`](../custodian-service) reads the genesis flag through clap `env=` |
+| `/run/seismic/conf/attestation.env` | `SEISMIC_ROOT_KEY_PEERS=...` | `attestation.service` (seismic-images) — loaded via `EnvironmentFile=`; [`seismic-attestation-service`](../attestation-service) reads the peer list through clap `env=` |
 | `/run/seismic/conf/network-manifest.json` | verbatim manifest bytes | [`seismic-attestation-service`](../attestation-service) — hashes the file itself to derive `network_id` for attestation bindings |
 | `/run/seismic/conf/reth-genesis.json` | verbatim reth genesis bytes | `reth.service` (seismic-images) — passed to `seismic-reth node --chain` |
 

--- a/bin/tdx-init/src/config.rs
+++ b/bin/tdx-init/src/config.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 pub struct InitConfig {
     pub domain: DomainConfig,
     #[serde(default)]
-    pub enclave: EnclaveConfig,
+    pub root_key: RootKeyConfig,
     /// Required: the attestation service reads `network-manifest.json` at startup to
     /// derive `network_id` and bind every attestation to it, and is fatal
     /// without it. A POST that omits `[network]` therefore 400s here rather
@@ -29,26 +29,28 @@ pub struct DomainConfig {
     pub name: String,
 }
 
-/// Bootstrap config for the enclave server. Fields get converted to env vars,
-/// and written to `enclave.env` under [`crate::CONF_DIR`] which
-/// `enclave.service` (in seismic-images) loads via `EnvironmentFile=`.
+/// Root-key bootstrap config. Fields get converted to env vars under
+/// [`crate::CONF_DIR`]: `genesis_node` to `custodian.env` for
+/// `custodian.service` and `peers` to `attestation.env` for
+/// `attestation.service` (both in seismic-images, loaded via
+/// `EnvironmentFile=`).
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
-pub struct EnclaveConfig {
-    /// True iff this node is the network's genesis enclave — the one that
-    /// generates `root_key` locally with OsRng. Every other node must
-    /// leave this `false` (the default) and fetch from peers. Setting
+pub struct RootKeyConfig {
+    /// True iff this node is the network's genesis node — the one whose
+    /// custodian generates `root_key` locally with OsRng. Every other node
+    /// must leave this `false` (the default) and fetch from peers. Setting
     /// it on multiple nodes causes a silent network split (each generates
     /// a different `root_key`; downstream nodes that fetch from one
     /// can't decrypt state from the other).
     #[serde(default)]
     pub genesis_node: bool,
 
-    /// Peer enclave URLs (e.g. `http://10.0.0.1:7878`). When
-    /// `genesis_node` is false, the enclave fetches `root_key` from one
-    /// of these peers via the `getWrappedRootKey` RPC. Required for
-    /// non-genesis nodes; the enclave fails fast at startup if this
-    /// list is empty and `genesis_node` is false.
+    /// Peer URLs (e.g. `http://10.0.0.1:7878`). When `genesis_node` is
+    /// false, the attestation service fetches `root_key` from one of these
+    /// peers via the `getWrappedRootKey` RPC. Required for non-genesis
+    /// nodes; the attestation service fails fast at startup if this list
+    /// is empty and the local custodian holds no root key.
     #[serde(default)]
     pub peers: Vec<String>,
 }
@@ -90,7 +92,7 @@ mod tests {
 name = "node1.example.com"
 email = "ops@example.com"
 
-[enclave]
+[root_key]
 genesis_node = true
 peers = ["http://10.0.0.1:7878", "http://10.0.0.2:7878"]
 
@@ -101,8 +103,8 @@ reth_genesis_base64 = "eyJjb25maWciOnt9fQ=="
         let cfg: InitConfig = toml::from_str(toml_input).unwrap();
         assert_eq!(cfg.domain.name, "node1.example.com");
         assert_eq!(cfg.domain.email, "ops@example.com");
-        assert!(cfg.enclave.genesis_node);
-        assert_eq!(cfg.enclave.peers.len(), 2);
+        assert!(cfg.root_key.genesis_node);
+        assert_eq!(cfg.root_key.peers.len(), 2);
         assert_eq!(
             cfg.network.manifest_base64,
             "eyJtYW5pZmVzdF92ZXJzaW9uIjogMX0K"
@@ -144,7 +146,7 @@ network_id = "0xabcd"
     }
 
     #[test]
-    fn enclave_section_is_optional_with_defaults() {
+    fn root_key_section_is_optional_with_defaults() {
         let toml_input = r#"
 [domain]
 name = "node1.example.com"
@@ -155,8 +157,8 @@ manifest_base64 = "eyJtYW5pZmVzdF92ZXJzaW9uIjogMX0K"
 reth_genesis_base64 = "eyJjb25maWciOnt9fQ=="
 "#;
         let cfg: InitConfig = toml::from_str(toml_input).unwrap();
-        assert!(!cfg.enclave.genesis_node);
-        assert!(cfg.enclave.peers.is_empty());
+        assert!(!cfg.root_key.genesis_node);
+        assert!(cfg.root_key.peers.is_empty());
     }
 
     #[test]
@@ -182,7 +184,7 @@ manifest_base64 = "eyJtYW5pZmVzdF92ZXJzaW9uIjogMX0K"
 name = "node1.example.com"
 email = "ops@example.com"
 
-[enclave]
+[root_key]
 genesis_node = true
 "#;
         let err = toml::from_str::<InitConfig>(toml_input).unwrap_err();
@@ -208,13 +210,13 @@ field = "value"
     }
 
     #[test]
-    fn rejects_unknown_field_in_enclave_section() {
+    fn rejects_unknown_field_in_root_key_section() {
         let toml_input = r#"
 [domain]
 name = "node1.example.com"
 email = "ops@example.com"
 
-[enclave]
+[root_key]
 genesis_node = false
 log_level = "trace"
 
@@ -229,7 +231,7 @@ reth_genesis_base64 = "eyJjb25maWciOnt9fQ=="
     #[test]
     fn requires_domain_section() {
         let toml_input = r#"
-[enclave]
+[root_key]
 genesis_node = true
 
 [network]

--- a/bin/tdx-init/src/writer.rs
+++ b/bin/tdx-init/src/writer.rs
@@ -21,7 +21,8 @@ pub const DEFAULT_FILE_MODE: u32 = 0o644;
 pub async fn write_service_configs(conf_dir: &Path, config: &InitConfig) -> Result<()> {
     fs::create_dir_all(conf_dir).await?;
     write_domain_env(conf_dir, config).await?;
-    write_enclave_env(conf_dir, config).await?;
+    write_custodian_env(conf_dir, config).await?;
+    write_attestation_env(conf_dir, config).await?;
     let manifest = crate::manifest::decode_and_validate(&config.network.manifest_base64)?;
     let genesis = crate::reth_genesis::decode_and_validate(
         &config.network.reth_genesis_base64,
@@ -69,12 +70,28 @@ async fn write_domain_env(conf_dir: &Path, config: &InitConfig) -> Result<()> {
     Ok(())
 }
 
-async fn write_enclave_env(conf_dir: &Path, config: &InitConfig) -> Result<()> {
-    let path = conf_dir.join("enclave.env");
+/// The custodian's unit loads this via `EnvironmentFile=`; the binary reads
+/// `SEISMIC_CUSTODIAN_GENESIS_NODE` (whether to generate a fresh root key)
+/// through clap `env=`.
+async fn write_custodian_env(conf_dir: &Path, config: &InitConfig) -> Result<()> {
+    let path = conf_dir.join("custodian.env");
     let content = format!(
-        "SEISMIC_ENCLAVE_GENESIS_NODE={}\nSEISMIC_ENCLAVE_PEERS={}\n",
-        config.enclave.genesis_node,
-        config.enclave.peers.join(","),
+        "SEISMIC_CUSTODIAN_GENESIS_NODE={}\n",
+        config.root_key.genesis_node,
+    );
+    write_with_mode(&path, &content, DEFAULT_FILE_MODE).await?;
+    info!("wrote {}", path.display());
+    Ok(())
+}
+
+/// The attestation service's unit loads this via `EnvironmentFile=`; the
+/// binary reads `SEISMIC_ROOT_KEY_PEERS` (where to fetch the root key when the
+/// local custodian starts without one) through clap `env=`.
+async fn write_attestation_env(conf_dir: &Path, config: &InitConfig) -> Result<()> {
+    let path = conf_dir.join("attestation.env");
+    let content = format!(
+        "SEISMIC_ROOT_KEY_PEERS={}\n",
+        config.root_key.peers.join(",")
     );
     write_with_mode(&path, &content, DEFAULT_FILE_MODE).await?;
     info!("wrote {}", path.display());
@@ -92,7 +109,7 @@ async fn write_with_mode(path: &Path, content: impl AsRef<[u8]>, mode: u32) -> R
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::{DomainConfig, EnclaveConfig, NetworkConfig};
+    use crate::config::{DomainConfig, NetworkConfig, RootKeyConfig};
     use base64::Engine as _;
     use tempfile::TempDir;
 
@@ -102,7 +119,7 @@ mod tests {
                 email: "ops@example.com".to_string(),
                 name: "node1.example.com".to_string(),
             },
-            enclave: EnclaveConfig {
+            root_key: RootKeyConfig {
                 genesis_node,
                 peers: peers.into_iter().map(String::from).collect(),
             },
@@ -121,7 +138,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn writes_both_files_with_expected_contents() {
+    async fn writes_env_files_with_expected_contents() {
         let tmp = TempDir::new().unwrap();
         let cfg = sample_config(true, vec!["http://10.0.0.1:7878", "http://10.0.0.2:7878"]);
 
@@ -133,11 +150,13 @@ mod tests {
             "DOMAIN_NAME=node1.example.com\nDOMAIN_EMAIL=ops@example.com\n"
         );
 
-        let enclave = std::fs::read_to_string(tmp.path().join("enclave.env")).unwrap();
+        let custodian = std::fs::read_to_string(tmp.path().join("custodian.env")).unwrap();
+        assert_eq!(custodian, "SEISMIC_CUSTODIAN_GENESIS_NODE=true\n");
+
+        let attestation = std::fs::read_to_string(tmp.path().join("attestation.env")).unwrap();
         assert_eq!(
-            enclave,
-            "SEISMIC_ENCLAVE_GENESIS_NODE=true\n\
-             SEISMIC_ENCLAVE_PEERS=http://10.0.0.1:7878,http://10.0.0.2:7878\n"
+            attestation,
+            "SEISMIC_ROOT_KEY_PEERS=http://10.0.0.1:7878,http://10.0.0.2:7878\n"
         );
     }
 
@@ -148,11 +167,8 @@ mod tests {
 
         write_service_configs(tmp.path(), &cfg).await.unwrap();
 
-        let enclave = std::fs::read_to_string(tmp.path().join("enclave.env")).unwrap();
-        assert_eq!(
-            enclave,
-            "SEISMIC_ENCLAVE_GENESIS_NODE=false\nSEISMIC_ENCLAVE_PEERS=\n"
-        );
+        let attestation = std::fs::read_to_string(tmp.path().join("attestation.env")).unwrap();
+        assert_eq!(attestation, "SEISMIC_ROOT_KEY_PEERS=\n");
     }
 
     #[tokio::test]
@@ -198,7 +214,7 @@ mod tests {
 
         write_service_configs(tmp.path(), &cfg).await.unwrap();
 
-        for name in ["domain.env", "enclave.env"] {
+        for name in ["domain.env", "custodian.env", "attestation.env"] {
             let meta = std::fs::metadata(tmp.path().join(name)).unwrap();
             let mode = meta.permissions().mode() & 0o777;
             assert_eq!(mode, DEFAULT_FILE_MODE);


### PR DESCRIPTION
The `[enclave]` config section named a process that no longer exists. Since the split (#211/#212) its two fields configure the two halves of one question — where this node's root_key comes from: whether the custodian generates it, and where the attestation service fetches it otherwise. Rename the schema and its outputs after what they carry:

- POST schema: `[enclave]` -> `[root_key]` (`RootKeyConfig`); the `genesis_node`/`peers` fields are unchanged
- outputs: `enclave.env` splits into one env file per consuming unit — `custodian.env` carries `SEISMIC_CUSTODIAN_GENESIS_NODE` (was `SEISMIC_ENCLAVE_GENESIS_NODE`; the attestation service lost its `--genesis-node` flag in #212) for custodian.service, and `attestation.env` carries `SEISMIC_ROOT_KEY_PEERS` (was `SEISMIC_ENCLAVE_PEERS`) for attestation.service. Each binary picks up its own variable through clap `env=`, and the key-holding process's environment no longer carries the other service's config.

BREAKING CHANGE: the operator POST schema and env-file contract move in lockstep with the deploy CLI (which assembles `[root_key]`) and the seismic-images units (which load the new env files). Version skew fails loudly rather than silently: tdx-init 400s unknown sections (`deny_unknown_fields`), and a unit whose `EnvironmentFile=` is missing refuses to start.