### PR TITLE
docs(custodian-service): rename the example caller to `attestation`

### DIFF
--- a/bin/custodian-service/src/acl.rs
+++ b/bin/custodian-service/src/acl.rs
@@ -116,7 +116,7 @@ mod tests {
     fn fake_resolve(user: &str) -> Result<u32> {
         match user {
             "reth" => Ok(1001),
-            "enclave-attest" => Ok(1002),
+            "attestation" => Ok(1002),
             other => bail!("user '{other}' does not exist"),
         }
     }
@@ -128,7 +128,7 @@ mod tests {
         let acl = build_acl(
             &[
                 "reth:tx-io,rng".to_string(),
-                "enclave-attest:tx-io-public,create-root-key-bootstrap-attempt,\
+                "attestation:tx-io-public,create-root-key-bootstrap-attempt,\
                  wrap-root-key,install-root-key-from-verified-bootstrap-response"
                     .to_string(),
             ],

--- a/bin/custodian-service/src/main.rs
+++ b/bin/custodian-service/src/main.rs
@@ -49,7 +49,7 @@ struct Args {
              Purposes: {}.\n\n\
              The two intended callers and their grants:\n  \
              --allow reth:tx-io,rng\n  \
-             --allow enclave-attest:tx-io-public,create-root-key-bootstrap-attempt,\
+             --allow attestation:tx-io-public,create-root-key-bootstrap-attempt,\
              wrap-root-key,install-root-key-from-verified-bootstrap-response",
             acl::VALID_PURPOSES
         )


### PR DESCRIPTION
The seismic-images units run the service pair as bare `custodian` and `attestation` users — named after their units, like tdx-init/reth/summit — retiring the enclave- prefix along with the rest of the pre-split vocabulary. Follow suit in the `--allow` help example and the ACL tests. Illustrative strings only: the ACL resolves whatever names the unit passes.