### PR TITLE
test(attestation-service): four-node root-key distribution over live TDX

### DIFF
--- a/bin/attestation-service/src/utils.rs
+++ b/bin/attestation-service/src/utils.rs
@@ -50,19 +50,30 @@ pub fn is_sudo() -> bool {
 }
 
 pub fn init_tracing() {
-    // Read log level from RUST_LOG, default to "debug" if unset.
-    let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("debug"));
+    // Read log level from RUST_LOG, default to "info" if unset — the same
+    // default as the custodian service and the production unit files.
+    let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
 
     let subscriber = FmtSubscriber::builder().with_env_filter(filter).finish();
 
-    tracing::subscriber::set_global_default(subscriber).expect("Failed to set tracing subscriber");
-
-    info!("Attestation service tracing initialized");
+    // Keep the first subscriber on repeat calls: every integration test in
+    // the shared test process initializes tracing.
+    if tracing::subscriber::set_global_default(subscriber).is_ok() {
+        info!("Attestation service tracing initialized");
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // Every integration test in one process initializes tracing; a repeat
+    // call must keep the first subscriber rather than panic.
+    #[test]
+    fn init_tracing_is_idempotent() {
+        init_tracing();
+        init_tracing();
+    }
 
     #[test]
     fn rpc_errors_expose_only_stable_messages() {

--- a/bin/attestation-service/tests/integration/integration.rs
+++ b/bin/attestation-service/tests/integration/integration.rs
@@ -1,9 +1,9 @@
 //! Live-TEE integration coverage run through
 //! `scripts/run_integration_tests.sh`. The script prepares the runtime
-//! manifest, frees the TPM, and executes this test with the required
+//! manifest, frees the TPM, and executes these tests with the required
 //! privileges.
 
-use std::time::Duration;
+use std::{path::PathBuf, time::Duration};
 
 use crate::utils::{get_args, spawn_custodian};
 use jsonrpsee::http_client::{HttpClient, HttpClientBuilder};
@@ -15,11 +15,12 @@ use seismic_attestation::{
 use seismic_attestation_rpc::{AttestationRpcClient as _, TxIoAttestationResponse};
 use seismic_attestation_service::utils::{init_tracing, is_sudo};
 use seismic_custodian::Custodian;
+use seismic_custodian_ipc::CustodianClient;
 use seismic_custodian_service::state::CustodianState;
 use seismic_enclave::{NodeStatusRpcClient as _, PurposeKeysRpcClient as _};
 
 // The server reads its manifest through the same fixed `/run/seismic` handoff
-// used in production, which keeps this test covering the tdx-init →
+// used in production, which keeps these tests covering the tdx-init →
 // attestation-service startup contract. This fixture is the manifest trusted by the
 // relying client; the test script installs the same fixture for the server, and
 // evidence verification confirms that both sides use the same network ID.
@@ -29,84 +30,69 @@ const NODE_STARTUP_TIMEOUT: Duration = Duration::from_secs(5 * 60);
 const EVIDENCE_RPC_TIMEOUT: Duration = Duration::from_secs(5 * 60);
 const RETRY_INTERVAL: Duration = Duration::from_secs(2);
 
+/// The two-node bootstrap exchange: a genesis custodian/attestation-service
+/// pair plus one joiner, over real sockets with real quote generation and
+/// verification. The joiner's health wait spans the attested wrapped-root-key
+/// exchange, so its return is the join completing; asserts the join's
+/// observable effects — the LUKS keyfile handoff and identical purpose keys
+/// over HTTP `getPurposeKeys`.
 #[serial_test::serial(attestation_evidence)]
 #[tokio::test]
-async fn test_get_wrapped_root_key_bootstrap() {
+async fn test_two_node_root_key_bootstrap() {
     init_tracing();
-    // Check the starting conditions are as expected
     if !is_sudo() {
-        panic!("test_get_wrapped_root_key_bootstrap: skipped (requires sudo privileges)");
+        panic!("test_two_node_root_key_bootstrap: skipped (requires sudo privileges)");
     }
 
-    // Start the genesis node's process pair: a key custodian holding a fresh
-    // root key, served over its own socket, plus the attestation service.
-    let node1_runtime = tempfile::tempdir().expect("create genesis runtime directory");
-    let node1_socket = node1_runtime.path().join("custodian.sock");
-    spawn_custodian(
-        CustodianState::new_with_root_key(
-            Custodian::new_as_genesis().expect("generate genesis root key"),
-            node1_runtime.path().join("luks-keys"),
-        )
-        .expect("construct genesis custodian"),
-        &node1_socket,
-    );
-    let args1 = get_args(0, Default::default(), node1_socket);
-    let enclave_one_url = format!("http://localhost:{}", args1.port);
-    let mut node1_handle = tokio::spawn(args1.start());
-    let client1 = HttpClientBuilder::default()
-        .build(enclave_one_url.clone())
-        .expect("Unable to create enclave 1 client");
-    wait_for_health(&client1, "genesis enclave", &mut node1_handle).await;
-
-    // Start the joining node's pair with node 1 as its peer: a custodian that
-    // awaits its root key through the bootstrap methods, plus the attestation
-    // service. The service's RPC listener comes up after the attested
-    // root-key exchange completes.
-    let node2_runtime = tempfile::tempdir().expect("create joining runtime directory");
-    let node2_socket = node2_runtime.path().join("custodian.sock");
-    spawn_custodian(
-        CustodianState::new_awaiting_root_key(node2_runtime.path().join("luks-keys")),
-        &node2_socket,
-    );
-    let args2 = get_args(1, vec![enclave_one_url], node2_socket);
-    let enclave_two_url = format!("http://localhost:{}", args2.port);
-    let mut node2_handle = tokio::spawn(args2.start());
-    let client2 = HttpClientBuilder::default()
-        .build(enclave_two_url)
-        .expect("Unable to create enclave 2 client");
-    wait_for_health(&client2, "joining enclave", &mut node2_handle).await;
+    let genesis = start_node("genesis node", 0, None).await;
+    let joiner = start_node("joining node", 1, Some(vec![genesis.url.clone()])).await;
 
     // The bootstrap installed the root key in the joiner's custodian, which
     // wrote the LUKS keyfile handoff as part of that transition.
-    let luks_metadata = std::fs::metadata(node2_runtime.path().join("luks-keys"))
+    let luks_metadata = std::fs::metadata(joiner.runtime.path().join("luks-keys"))
         .expect("joining custodian wrote its LUKS keyfile");
     assert_eq!(luks_metadata.len(), 64);
 
-    // Get keys from both and make sure they match
-
-    let keys1 = client1
+    // Both nodes serve identical purpose keys over HTTP `getPurposeKeys`.
+    let keys1 = genesis
+        .client
         .get_purpose_keys(0)
         .await
         .expect("Unable to get purpose keys");
-    let keys2 = client2
+    let keys2 = joiner
+        .client
         .get_purpose_keys(0)
         .await
         .expect("Unable to get purpose keys");
-
-    // Ensure they are the same from both nodes
     assert_eq!(keys1.rng_keypair.secret, keys2.rng_keypair.secret);
     assert_eq!(keys1.snapshot_key_bytes, keys2.snapshot_key_bytes);
     assert_eq!(keys1.tx_io_sk, keys2.tx_io_sk);
 
-    assert_eq!(client1.health_check().await.unwrap(), "OK".to_string());
+    genesis.handle.abort();
+    joiner.handle.abort();
+}
 
-    // Act as the relying party for tx-io evidence: derive the expected binding
-    // independently from the manifest bytes, response key, and requested
-    // epoch, then verify through seismic-attestation.
+/// The relying-party path for the network's tx-io key advertisement, against
+/// a single genesis pair: what a wallet/SDK runs before encrypting to
+/// `tx_io_pk`. The client fetches `getTxIoAttestationEvidence`, derives the
+/// expected binding independently from its own trusted manifest copy, and
+/// verifies the evidence through `seismic-attestation`; the same evidence
+/// must fail against a wrong-epoch binding and as a tampered document.
+#[serial_test::serial(attestation_evidence)]
+#[tokio::test]
+async fn test_tx_io_evidence_relying_party() {
+    init_tracing();
+    if !is_sudo() {
+        panic!("test_tx_io_evidence_relying_party: skipped (requires sudo privileges)");
+    }
+
+    let node = start_node("genesis node", 20, None).await;
+
     let epoch = 0;
-    let response = get_tx_io_attestation_evidence(&client1, epoch).await;
+    let response = get_tx_io_attestation_evidence(&node.client, epoch).await;
     assert_eq!(response.epoch, epoch);
-    assert_eq!(response.tx_io_pk, keys1.tx_io_pk);
+    // The advertised key is the custodian's own, per its socket.
+    assert_eq!(response.tx_io_pk.serialize(), tx_io_pk(&node).await);
 
     NetworkManifestV1::from_json_bytes(EXPECTED_NETWORK_MANIFEST)
         .expect("Relying client's network manifest is invalid");
@@ -155,8 +141,72 @@ async fn test_get_wrapped_root_key_bootstrap() {
         "tampered evidence verified successfully"
     );
 
-    node1_handle.abort();
-    node2_handle.abort();
+    node.handle.abort();
+}
+
+/// The N=4 companion to [`test_two_node_root_key_bootstrap`]: one
+/// genesis custodian/attestation-service pair plus three joining pairs, each
+/// with its own socket, LUKS-key path, and HTTP port. Arrows show root-key
+/// flow, responder to requester:
+///
+/// ```text
+/// genesis ----> joiner a ----> joiner c
+///    |
+///    +--------> joiner b
+/// ```
+///
+/// So the same responder serves repeat joins (genesis -> a, b) and the root
+/// key travels onward through an already-bootstrapped, non-genesis node
+/// (a -> c). Nodes come up sequentially — each health wait spans the full
+/// attested exchange — so quote generation never runs concurrently on the
+/// runner's single vTPM (all four logical nodes legitimately share its one
+/// measured image).
+///
+/// Covers the process boundary, requester-secret retention, IPC, and N=4
+/// root-key distribution; image assembly, systemd, LUKS devices, separate
+/// vTPMs, and deploy tooling are deliberately out of scope.
+#[serial_test::serial(attestation_evidence)]
+#[tokio::test]
+async fn test_four_node_root_key_distribution() {
+    init_tracing();
+    if !is_sudo() {
+        panic!("test_four_node_root_key_distribution: skipped (requires sudo privileges)");
+    }
+
+    let genesis = start_node("genesis node", 10, None).await;
+    let joiner_a = start_node("joiner a", 11, Some(vec![genesis.url.clone()])).await;
+    let joiner_b = start_node("joiner b", 12, Some(vec![genesis.url.clone()])).await;
+    let joiner_c = start_node("joiner c", 13, Some(vec![joiner_a.url.clone()])).await;
+    let nodes = [genesis, joiner_a, joiner_b, joiner_c];
+
+    // Every join completed: each joining custodian installed the root key and
+    // wrote the LUKS keyfile handoff as part of that transition.
+    for joiner in &nodes[1..] {
+        let luks_metadata = std::fs::metadata(joiner.runtime.path().join("luks-keys"))
+            .unwrap_or_else(|e| panic!("{} wrote no LUKS keyfile: {e}", joiner.label));
+        assert_eq!(
+            luks_metadata.len(),
+            64,
+            "{} LUKS keyfile size",
+            joiner.label
+        );
+    }
+
+    // All four custodians derive the same tx_io_pk, asked directly over each
+    // custodian's own socket rather than through the attestation service.
+    let genesis_tx_io_pk = tx_io_pk(&nodes[0]).await;
+    for joiner in &nodes[1..] {
+        assert_eq!(
+            tx_io_pk(joiner).await,
+            genesis_tx_io_pk,
+            "{} derived a different tx_io_pk than the genesis node",
+            joiner.label
+        );
+    }
+
+    for node in &nodes {
+        node.handle.abort();
+    }
 }
 
 /// The bootstrap path uses the same intentionally temporary permissive policy.
@@ -195,6 +245,69 @@ async fn wait_for_health(
             () = tokio::time::sleep(RETRY_INTERVAL) => {}
         }
     }
+}
+
+/// One logical node under test: the custodian/attestation-service process
+/// pair over a real socket, with its own runtime directory and HTTP port.
+struct NodePair {
+    label: &'static str,
+    runtime: tempfile::TempDir,
+    socket: PathBuf,
+    url: String,
+    client: HttpClient,
+    handle: tokio::task::JoinHandle<anyhow::Result<()>>,
+}
+
+/// Start a node's process pair and wait until its RPC listener is healthy.
+///
+/// `peers: None` starts the genesis node (fresh root key); `Some(urls)`
+/// starts a joiner whose custodian acquires the root key from those peers, so
+/// returning implies the join completed. `n` offsets the HTTP port; keep
+/// offsets distinct across tests — they share one process, and a just-aborted
+/// listener may still hold its port.
+async fn start_node(label: &'static str, n: u16, peers: Option<Vec<String>>) -> NodePair {
+    let runtime = tempfile::tempdir().expect("create node runtime directory");
+    let socket = runtime.path().join("custodian.sock");
+    let luks_keyfile = runtime.path().join("luks-keys");
+    let state = if peers.is_none() {
+        CustodianState::new_with_root_key(
+            Custodian::new_as_genesis().expect("generate genesis root key"),
+            luks_keyfile,
+        )
+        .expect("construct genesis custodian")
+    } else {
+        CustodianState::new_awaiting_root_key(luks_keyfile)
+    };
+    spawn_custodian(state, &socket);
+
+    let args = get_args(n, peers.unwrap_or_default(), socket.clone());
+    let url = format!("http://localhost:{}", args.port);
+    let mut handle = tokio::spawn(args.start());
+    let client = HttpClientBuilder::default()
+        .build(url.clone())
+        .unwrap_or_else(|e| panic!("create {label} client: {e}"));
+    wait_for_health(&client, label, &mut handle).await;
+
+    NodePair {
+        label,
+        runtime,
+        socket,
+        url,
+        client,
+        handle,
+    }
+}
+
+/// Fetch a node's `tx_io_pk` at epoch 0 straight from its custodian socket.
+async fn tx_io_pk(node: &NodePair) -> [u8; 33] {
+    let mut custodian = CustodianClient::connect(&node.socket)
+        .await
+        .unwrap_or_else(|e| panic!("connect to {} custodian: {e}", node.label));
+    custodian
+        .get_tx_io_public_key(0)
+        .await
+        .unwrap_or_else(|e| panic!("fetch {} tx_io_pk: {e}", node.label))
+        .pk
 }
 
 async fn get_tx_io_attestation_evidence(

--- a/bin/attestation-service/tests/integration/integration.rs
+++ b/bin/attestation-service/tests/integration/integration.rs
@@ -10,7 +10,9 @@
 //! the script keeps other processes off the device, the shared
 //! `serial(attestation_evidence)` key runs these tests one at a time within
 //! this binary, and each test starts its nodes sequentially so a single test
-//! never has two quote operations in flight.
+//! never has two quote operations in flight. Relaxations are tracked
+//! upstream (kinvolk/azure-cvm-tooling#92/#93, flashbots/attested-tls#72/#73);
+//! `seismic_attestation::generate_evidence`'s docs carry the cost model.
 
 use std::{path::PathBuf, time::Duration};
 

--- a/bin/attestation-service/tests/integration/integration.rs
+++ b/bin/attestation-service/tests/integration/integration.rs
@@ -2,6 +2,15 @@
 //! `scripts/run_integration_tests.sh`. The script prepares the runtime
 //! manifest, frees the TPM, and executes these tests with the required
 //! privileges.
+//!
+//! Quote generation opens the raw TPM device, which the kernel hands to one
+//! process at a time (az-cvm-vtpm hardcodes tss-esapi's default TCTI,
+//! `/dev/tpm0`; only `/dev/tpmrm0` multiplexes). Evidence operations must
+//! therefore never overlap, and each level of concurrency has its own guard:
+//! the script keeps other processes off the device, the shared
+//! `serial(attestation_evidence)` key runs these tests one at a time within
+//! this binary, and each test starts its nodes sequentially so a single test
+//! never has two quote operations in flight.
 
 use std::{path::PathBuf, time::Duration};
 

--- a/crates/attestation/src/lib.rs
+++ b/crates/attestation/src/lib.rs
@@ -43,6 +43,21 @@ use thiserror::Error;
 ///
 /// This is generic over the backend [`AttestationType`] and delegates evidence
 /// creation directly to Flashbots `attestation`.
+///
+/// Operational note (AzureTdx): the backend opens the raw TPM device
+/// (`/dev/tpm0`, exclusive-open) and binds `binding` through the vTPM's
+/// shared report-data NV index — a write, a fixed 3-second wait, and an IMDS
+/// round-trip per call. Each call therefore costs seconds, and evidence
+/// generation must be serialized machine-wide: a concurrent TPM client fails
+/// the device open, and a concurrent report-data writer yields a report that
+/// fails verification. Upstream RFEs: TCTI configurability
+/// ([azure-cvm-tooling#92], [attested-tls#72]) and report-readiness polling
+/// ([azure-cvm-tooling#93], [attested-tls#73]).
+///
+/// [azure-cvm-tooling#92]: https://github.com/kinvolk/azure-cvm-tooling/issues/92
+/// [azure-cvm-tooling#93]: https://github.com/kinvolk/azure-cvm-tooling/issues/93
+/// [attested-tls#72]: https://github.com/flashbots/attested-tls/issues/72
+/// [attested-tls#73]: https://github.com/flashbots/attested-tls/issues/73
 pub fn generate_evidence(
     attestation_type: AttestationType,
     binding: [u8; 64],

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,21 +1,27 @@
 # Integration Tests
 
 `run_integration_tests.sh` runs the live-TEE attestation-service integration
-test on the self-hosted Azure TDX runner.
+tests on the self-hosted Azure TDX runner.
 
-## Covered flow
+## Covered flows
 
-`test_get_wrapped_root_key_bootstrap` starts two custodian +
-attestation-service pairs over real custodian sockets and checks that:
+`test_two_node_root_key_bootstrap` starts two custodian + attestation-service
+pairs over real custodian sockets and checks that the joining pair completes
+the mutually attested wrapped-root-key bootstrap, with its custodian
+installing the key and writing the LUKS keyfile handoff, and that both pairs
+then serve the same purpose keys.
 
-1. the joining pair completes the mutually attested wrapped-root-key
-   bootstrap, with its custodian installing the key and writing the LUKS
-   keyfile handoff;
-2. both pairs derive the same purpose keys;
-3. a relying client fetches `getTxIoAttestationEvidence`, independently derives
-   the expected network/key/epoch binding, and verifies the complete evidence
-   envelope through `seismic-attestation`;
-4. wrong bindings and malformed evidence are rejected.
+`test_tx_io_evidence_relying_party` runs the client side of the network's
+tx-io key advertisement against a single genesis pair: a relying client
+fetches `getTxIoAttestationEvidence`, independently derives the expected
+network/key/epoch binding, and verifies the complete evidence envelope
+through `seismic-attestation`; wrong bindings and malformed evidence are
+rejected.
+
+`test_four_node_root_key_distribution` starts one genesis pair plus three
+joining pairs — two bootstrapping from the genesis node, one from an
+already-bootstrapped joiner — and checks that every join completes and all
+four custodians derive the same `tx_io_pk`.
 
 TODO: add contract-backed bootstrap-admission coverage as a distinct
 reth-backed integration test with PCR policy seeded in genesis.

--- a/scripts/run_integration_tests.sh
+++ b/scripts/run_integration_tests.sh
@@ -20,10 +20,10 @@ sudo install -m 0644 \
 
 # Free the TPM before the tests start their node pairs: quote generation
 # opens the raw TPM device (/dev/tpm0), which the kernel hands to one process
-# at a time. Seismic images may have a Supervisor-managed server; stock CI
-# runners do not. The Supervisor program keeps its deployed name
-# (enclave-server) until the runner image is regenerated with the split
-# services.
+# at a time (tpmrm0 support is kinvolk/azure-cvm-tooling#92). Seismic images
+# may have a Supervisor-managed server; stock CI runners do not. The
+# Supervisor program keeps its deployed name (enclave-server) until the
+# runner image is regenerated with the split services.
 if command -v supervisorctl >/dev/null 2>&1 && \
     sudo supervisorctl status enclave-server >/dev/null 2>&1; then
     sudo supervisorctl stop enclave-server

--- a/scripts/run_integration_tests.sh
+++ b/scripts/run_integration_tests.sh
@@ -18,10 +18,12 @@ sudo install -m 0644 \
     crates/network-manifest/fixtures/network-manifest-v1.json \
     /run/seismic/conf/network-manifest.json
 
-# Free the TPM before the test starts its two node pairs. Seismic images may
-# have a Supervisor-managed server; stock CI runners do not. The Supervisor
-# program keeps its deployed name (enclave-server) until the runner image is
-# regenerated with the split services.
+# Free the TPM before the tests start their node pairs: quote generation
+# opens the raw TPM device (/dev/tpm0), which the kernel hands to one process
+# at a time. Seismic images may have a Supervisor-managed server; stock CI
+# runners do not. The Supervisor program keeps its deployed name
+# (enclave-server) until the runner image is regenerated with the split
+# services.
 if command -v supervisorctl >/dev/null 2>&1 && \
     sudo supervisorctl status enclave-server >/dev/null 2>&1; then
     sudo supervisorctl stop enclave-server
@@ -39,11 +41,14 @@ if [ ${#binaries[@]} -eq 0 ]; then
     exit 1
 fi
 
-# Run every test in the target. The tests serialize themselves around the
-# runner's single vTPM (serial_test), so no filtering or thread capping here.
+# The target compiles to one test binary that runs every test in a single
+# process, serialized around the runner's single vTPM by serial_test — no
+# filtering or thread capping needed. The loop only covers cargo ever listing
+# more executables. sudo strips the environment, so pass the log/backtrace
+# config through explicitly.
 for binary in "${binaries[@]}"; do
     echo "🚀 Executing: sudo $binary"
-    sudo "$binary"
+    sudo env RUST_LOG="$RUST_LOG" RUST_BACKTRACE="$RUST_BACKTRACE" "$binary"
 done
 
 echo "🎉 All attestation-service integration tests passed!"

--- a/scripts/run_integration_tests.sh
+++ b/scripts/run_integration_tests.sh
@@ -39,9 +39,11 @@ if [ ${#binaries[@]} -eq 0 ]; then
     exit 1
 fi
 
+# Run every test in the target. The tests serialize themselves around the
+# runner's single vTPM (serial_test), so no filtering or thread capping here.
 for binary in "${binaries[@]}"; do
-    echo "🚀 Executing: sudo $binary test_get_wrapped_root_key_bootstrap"
-    sudo "$binary" test_get_wrapped_root_key_bootstrap
+    echo "🚀 Executing: sudo $binary"
+    sudo "$binary"
 done
 
 echo "🎉 All attestation-service integration tests passed!"


### PR DESCRIPTION
Extend the live Azure-TDX integration coverage from the two-node pair topology to N=4: one genesis custodian/attestation-service pair plus three joining pairs, each with its own custodian socket, LUKS-key path, and HTTP port. Two joiners bootstrap from the genesis node and the third from an already-bootstrapped joiner, so the same responder serves repeat joins and the root key travels onward through a non-genesis node. Nodes start sequentially, so quote generation never runs concurrently on the runner's single vTPM. The test asserts every join completes (LUKS keyfile handoff written) and all four custodians serve the same tx_io_pk over their own sockets.

Split the pre-existing test into its two concerns so a red CI run names the broken subsystem: test_two_node_root_key_bootstrap (attested join + purpose-key equality over HTTP) and test_tx_io_evidence_relying_party (client-side verification of the tx-io key advertisement against a single genesis pair, including wrong-binding and tampered-evidence rejection). All three tests share a new start_node helper, and the runner script now executes the whole test target instead of one named test.