### PR TITLE
refactor!: retire the purpose-keys RPC (keys are fetched per-purpose from custodian socket)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5278,7 +5278,6 @@ name = "seismic-enclave"
 version = "0.1.0"
 dependencies = [
  "jsonrpsee",
- "schnorrkel",
  "secp256k1",
  "seismic-crypto",
  "serde",

--- a/bin/attestation-service/src/server.rs
+++ b/bin/attestation-service/src/server.rs
@@ -24,14 +24,8 @@ use seismic_attestation::{
 use seismic_attestation_rpc::{
     AttestationRpcClient as _, AttestationRpcServer, TxIoAttestationResponse,
 };
-use seismic_custodian_ipc::{
-    CreateRootKeyBootstrapAttemptResult, CustodianClient, IpcError, RngKeypairBytes,
-    SnapshotKeyBytes, TxIoKeypairBytes,
-};
-use seismic_enclave::{
-    GetPurposeKeysResponse, LuksProvisioningStatus, SchnorrkelKeypair,
-    api::{NodeStatusRpcServer, PurposeKeysRpcServer},
-};
+use seismic_custodian_ipc::{CreateRootKeyBootstrapAttemptResult, CustodianClient, IpcError};
+use seismic_enclave::{LuksProvisioningStatus, api::NodeStatusRpcServer};
 use std::{
     net::SocketAddr,
     path::{Path, PathBuf},
@@ -83,32 +77,6 @@ impl NodeStatusRpcServer for AttestationService {
     /// [`crate::luks_status`].
     async fn get_luks_provisioning_status(&self) -> RpcResult<LuksProvisioningStatus> {
         Ok(crate::luks_status::read())
-    }
-}
-
-#[async_trait]
-impl PurposeKeysRpcServer for AttestationService {
-    /// Serve reth's purpose-key startup fetch from the custodian socket.
-    async fn get_purpose_keys(&self, epoch: u64) -> RpcResult<GetPurposeKeysResponse> {
-        let mut custodian = self
-            .connect_custodian()
-            .await
-            .map_err(|error| internal_rpc_error("connecting to custodian", error))?;
-        let tx_io = custodian
-            .get_tx_io_keypair(epoch)
-            .await
-            .map_err(|error| internal_rpc_error("fetching tx-io keypair", error))?;
-        let rng = custodian
-            .get_rng_keypair(epoch)
-            .await
-            .map_err(|error| internal_rpc_error("fetching rng keypair", error))?;
-        let snapshot = custodian
-            .get_snapshot_key(epoch)
-            .await
-            .map_err(|error| internal_rpc_error("fetching snapshot key", error))?;
-
-        purpose_keys_response(&tx_io, &rng, &snapshot)
-            .map_err(|error| internal_rpc_error("decoding custodian key bytes", error))
     }
 }
 
@@ -170,23 +138,6 @@ impl AttestationRpcServer for AttestationService {
     }
 }
 
-/// Convert the custodian's raw key bytes into the typed purpose-key DTO.
-fn purpose_keys_response(
-    tx_io: &TxIoKeypairBytes,
-    rng: &RngKeypairBytes,
-    snapshot: &SnapshotKeyBytes,
-) -> anyhow::Result<GetPurposeKeysResponse> {
-    Ok(GetPurposeKeysResponse {
-        tx_io_sk: secp256k1::SecretKey::from_byte_array(&tx_io.sk)
-            .context("tx-io secret bytes are not a valid secp256k1 scalar")?,
-        tx_io_pk: PublicKey::from_slice(&tx_io.pk)
-            .context("tx-io public bytes are not a valid secp256k1 point")?,
-        snapshot_key_bytes: snapshot.key,
-        rng_keypair: SchnorrkelKeypair::from_bytes(&rng.keypair)
-            .map_err(|error| anyhow::anyhow!("rng bytes are not a schnorrkel keypair: {error}"))?,
-    })
-}
-
 pub async fn start_server(addr: SocketAddr, args: Args) -> anyhow::Result<()> {
     // Derive this node's network identity from the manifest tdx-init dropped on
     // tmpfs. Fatal if absent/malformed: without it every attestation binding is
@@ -204,7 +155,6 @@ pub async fn start_server(addr: SocketAddr, args: Args) -> anyhow::Result<()> {
 
     let service = AttestationService::new(args.custodian_socket, network_id);
     let mut rpc = NodeStatusRpcServer::into_rpc(service.clone());
-    rpc.merge(PurposeKeysRpcServer::into_rpc(service.clone()))?;
     rpc.merge(AttestationRpcServer::into_rpc(service))?;
     let handle = server.start(rpc);
 
@@ -374,73 +324,4 @@ fn bootstrap_measurement_policy() -> SeismicMeasurementPolicy {
          peer image measurements are NOT being checked against an allowlist"
     );
     SeismicMeasurementPolicy::dangerously_accept_any_for_testing(ATTESTATION_TYPE)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use seismic_custodian::Custodian;
-
-    const ROOT_KEY: [u8; 32] = [7u8; 32];
-
-    // Parity with the pre-split in-process handler: the custodian's socket
-    // bytes decode to exactly the keys it derives.
-    #[test]
-    fn purpose_keys_response_matches_custodian_derivation() {
-        let custodian = Custodian::new(ROOT_KEY);
-        let response = purpose_keys_response(
-            &TxIoKeypairBytes {
-                sk: custodian.get_tx_io_sk(0).secret_bytes(),
-                pk: custodian.get_tx_io_pk(0).serialize(),
-            },
-            &RngKeypairBytes {
-                keypair: custodian.get_rng_keypair(0).to_bytes().to_vec(),
-            },
-            &SnapshotKeyBytes {
-                key: custodian.get_snapshot_key(0).into(),
-            },
-        )
-        .expect("decode purpose keys");
-
-        assert_eq!(response.tx_io_sk, custodian.get_tx_io_sk(0));
-        assert_eq!(response.tx_io_pk, custodian.get_tx_io_pk(0));
-        assert_eq!(
-            response.rng_keypair.secret,
-            custodian.get_rng_keypair(0).secret
-        );
-        let expected_snapshot: [u8; 32] = custodian.get_snapshot_key(0).into();
-        assert_eq!(response.snapshot_key_bytes, expected_snapshot);
-    }
-
-    #[test]
-    fn purpose_keys_response_rejects_invalid_bytes() {
-        let custodian = Custodian::new(ROOT_KEY);
-        let tx_io = TxIoKeypairBytes {
-            sk: custodian.get_tx_io_sk(0).secret_bytes(),
-            pk: custodian.get_tx_io_pk(0).serialize(),
-        };
-        let rng = RngKeypairBytes {
-            keypair: custodian.get_rng_keypair(0).to_bytes().to_vec(),
-        };
-        let snapshot = SnapshotKeyBytes { key: [3; 32] };
-
-        // Zero is not a secp256k1 scalar; an all-zero prefix byte is not a
-        // valid compressed point; 4 bytes are not a schnorrkel keypair.
-        let bad_sk = TxIoKeypairBytes {
-            sk: [0; 32],
-            pk: tx_io.pk,
-        };
-        assert!(purpose_keys_response(&bad_sk, &rng, &snapshot).is_err());
-
-        let bad_pk = TxIoKeypairBytes {
-            sk: tx_io.sk,
-            pk: [0; 33],
-        };
-        assert!(purpose_keys_response(&bad_pk, &rng, &snapshot).is_err());
-
-        let bad_rng = RngKeypairBytes {
-            keypair: vec![0; 4],
-        };
-        assert!(purpose_keys_response(&tx_io, &bad_rng, &snapshot).is_err());
-    }
 }

--- a/bin/attestation-service/tests/integration/integration.rs
+++ b/bin/attestation-service/tests/integration/integration.rs
@@ -14,7 +14,10 @@
 //! upstream (kinvolk/azure-cvm-tooling#92/#93, flashbots/attested-tls#72/#73);
 //! `seismic_attestation::generate_evidence`'s docs carry the cost model.
 
-use std::{path::PathBuf, time::Duration};
+use std::{
+    path::{Path, PathBuf},
+    time::Duration,
+};
 
 use crate::utils::{get_args, spawn_custodian};
 use jsonrpsee::http_client::{HttpClient, HttpClientBuilder};
@@ -28,7 +31,7 @@ use seismic_attestation_service::utils::{init_tracing, is_sudo};
 use seismic_custodian::Custodian;
 use seismic_custodian_ipc::CustodianClient;
 use seismic_custodian_service::state::CustodianState;
-use seismic_enclave::{NodeStatusRpcClient as _, PurposeKeysRpcClient as _};
+use seismic_enclave::NodeStatusRpcClient as _;
 
 // The server reads its manifest through the same fixed `/run/seismic` handoff
 // used in production, which keeps these tests covering the tdx-init →
@@ -46,7 +49,7 @@ const RETRY_INTERVAL: Duration = Duration::from_secs(2);
 /// verification. The joiner's health wait spans the attested wrapped-root-key
 /// exchange, so its return is the join completing; asserts the join's
 /// observable effects — the LUKS keyfile handoff and identical purpose keys
-/// over HTTP `getPurposeKeys`.
+/// read from each custodian's socket.
 #[serial_test::serial(attestation_evidence)]
 #[tokio::test]
 async fn test_two_node_root_key_bootstrap() {
@@ -64,20 +67,12 @@ async fn test_two_node_root_key_bootstrap() {
         .expect("joining custodian wrote its LUKS keyfile");
     assert_eq!(luks_metadata.len(), 64);
 
-    // Both nodes serve identical purpose keys over HTTP `getPurposeKeys`.
-    let keys1 = genesis
-        .client
-        .get_purpose_keys(0)
-        .await
-        .expect("Unable to get purpose keys");
-    let keys2 = joiner
-        .client
-        .get_purpose_keys(0)
-        .await
-        .expect("Unable to get purpose keys");
-    assert_eq!(keys1.rng_keypair.secret, keys2.rng_keypair.secret);
-    assert_eq!(keys1.snapshot_key_bytes, keys2.snapshot_key_bytes);
-    assert_eq!(keys1.tx_io_sk, keys2.tx_io_sk);
+    // Both custodians hold the same root key now, so every purpose key they
+    // derive matches. Asked straight over each custodian's own socket — the
+    // key-holding boundary reth itself fetches from.
+    let keys1 = purpose_keys(&genesis.socket, 0).await;
+    let keys2 = purpose_keys(&joiner.socket, 0).await;
+    assert_eq!(keys1, keys2);
 
     genesis.handle.abort();
     joiner.handle.abort();
@@ -225,6 +220,38 @@ async fn test_four_node_root_key_distribution() {
 /// measurement admission is covered by the separately tracked on-chain policy.
 fn test_measurement_policy() -> SeismicMeasurementPolicy {
     SeismicMeasurementPolicy::dangerously_accept_any_for_testing(AttestationType::AzureTdx)
+}
+
+/// A node's derived purpose keys as raw bytes, for cross-node equality
+/// assertions. Test-only: production callers never hold all three at once.
+#[derive(Debug, PartialEq)]
+struct PurposeKeyBytes {
+    tx_io_sk: [u8; 32],
+    tx_io_pk: [u8; 33],
+    rng_ikm: [u8; 64],
+    snapshot_key: [u8; 32],
+}
+
+/// Fetch a node's purpose keys at `epoch` straight from its custodian socket.
+async fn purpose_keys(socket: &Path, epoch: u64) -> PurposeKeyBytes {
+    let mut custodian = CustodianClient::connect(socket)
+        .await
+        .expect("connect to custodian socket");
+    let tx_io = custodian
+        .get_tx_io_keypair(epoch)
+        .await
+        .expect("fetch tx-io keypair");
+    let rng = custodian.get_rng_ikm(epoch).await.expect("fetch rng ikm");
+    let snapshot = custodian
+        .get_snapshot_key(epoch)
+        .await
+        .expect("fetch snapshot key");
+    PurposeKeyBytes {
+        tx_io_sk: tx_io.sk,
+        tx_io_pk: tx_io.pk,
+        rng_ikm: rng.ikm,
+        snapshot_key: snapshot.key,
+    }
 }
 
 /// Wait until the server's `healthCheck` RPC returns `OK`.

--- a/bin/custodian-service/src/acl.rs
+++ b/bin/custodian-service/src/acl.rs
@@ -137,7 +137,7 @@ mod tests {
         .expect("valid specs");
 
         assert!(acl.allows(1001, &Request::GetTxIoKeypair { epoch: 0 }));
-        assert!(acl.allows(1001, &Request::GetRngKeypair { epoch: 0 }));
+        assert!(acl.allows(1001, &Request::GetRngIkm { epoch: 0 }));
         assert!(!acl.allows(1001, &Request::GetSnapshotKey { epoch: 0 }));
         assert!(!acl.allows(1001, &Request::CreateRootKeyBootstrapAttempt));
 

--- a/bin/custodian-service/src/dispatch.rs
+++ b/bin/custodian-service/src/dispatch.rs
@@ -11,7 +11,7 @@ use crate::state::{CreateAttemptOutcome, CustodianState, InstallOutcome};
 use anyhow::Context as _;
 use seismic_custodian::{Custodian, VerifiedPeerAuthorization};
 use seismic_custodian_ipc::{
-    Request, Response, RngKeypairBytes, RootKeyBootstrapAttemptBytes, SnapshotKeyBytes,
+    Request, Response, RngIkmBytes, RootKeyBootstrapAttemptBytes, SnapshotKeyBytes,
     TxIoKeypairBytes, TxIoPublicKeyBytes, WrappedRootKeyBytes,
 };
 use tracing::{error, info, warn};
@@ -38,10 +38,10 @@ pub fn dispatch(state: &CustodianState, request: Request) -> Response {
                 })
             })
             .unwrap_or(Response::RootKeyAbsent),
-        Request::GetRngKeypair { epoch } => state
+        Request::GetRngIkm { epoch } => state
             .with_custodian(|custodian| {
-                Response::RngKeypair(RngKeypairBytes {
-                    keypair: custodian.get_rng_keypair(epoch).to_bytes().to_vec(),
+                Response::RngIkm(RngIkmBytes {
+                    ikm: custodian.get_rng_ikm(epoch),
                 })
             })
             .unwrap_or(Response::RootKeyAbsent),
@@ -185,14 +185,10 @@ mod tests {
         };
         assert_eq!(tx_io_public.pk, tx_io.pk);
 
-        let Response::RngKeypair(rng) = dispatch(&state, Request::GetRngKeypair { epoch: 0 })
-        else {
-            panic!("expected rng keypair");
+        let Response::RngIkm(rng) = dispatch(&state, Request::GetRngIkm { epoch: 0 }) else {
+            panic!("expected rng ikm");
         };
-        assert_eq!(
-            rng.keypair,
-            custodian.get_rng_keypair(0).to_bytes().to_vec()
-        );
+        assert_eq!(rng.ikm, custodian.get_rng_ikm(0));
 
         let Response::SnapshotKey(snapshot) =
             dispatch(&state, Request::GetSnapshotKey { epoch: 0 })
@@ -210,7 +206,7 @@ mod tests {
         for request in [
             Request::GetTxIoKeypair { epoch: 0 },
             Request::GetTxIoPublicKey { epoch: 0 },
-            Request::GetRngKeypair { epoch: 0 },
+            Request::GetRngIkm { epoch: 0 },
             Request::GetSnapshotKey { epoch: 0 },
             Request::WrapRootKey {
                 root_key_request_binding: BINDING,

--- a/crates/custodian-ipc/src/bin/custodian-ipc-cli.rs
+++ b/crates/custodian-ipc/src/bin/custodian-ipc-cli.rs
@@ -52,11 +52,11 @@ async fn main() -> Result<()> {
                 }
                 Err(e) => println!("tx_io:               {e}"),
             }
-            match client.get_rng_keypair(epoch).await {
+            match client.get_rng_ikm(epoch).await {
                 Ok(keys) => {
-                    println!("rng_keypair sha256:  {}", fingerprint(&keys.keypair));
+                    println!("rng_ikm sha256:      {}", fingerprint(&keys.ikm));
                 }
-                Err(e) => println!("rng_keypair:         {e}"),
+                Err(e) => println!("rng_ikm:             {e}"),
             }
             match client.get_snapshot_key(epoch).await {
                 Ok(key) => {

--- a/crates/custodian-ipc/src/client.rs
+++ b/crates/custodian-ipc/src/client.rs
@@ -8,7 +8,7 @@
 use crate::error::IpcError;
 use crate::framing::{read_frame, write_frame};
 use crate::messages::{
-    Request, Response, RngKeypairBytes, RootKeyBootstrapAttemptBytes, SnapshotKeyBytes,
+    Request, Response, RngIkmBytes, RootKeyBootstrapAttemptBytes, SnapshotKeyBytes,
     TxIoKeypairBytes, TxIoPublicKeyBytes, WrappedRootKeyBytes,
 };
 use std::path::Path;
@@ -67,10 +67,10 @@ impl CustodianClient {
         }
     }
 
-    pub async fn get_rng_keypair(&mut self, epoch: u64) -> Result<RngKeypairBytes, IpcError> {
-        match self.call(&Request::GetRngKeypair { epoch }).await? {
-            Response::RngKeypair(keys) => Ok(keys),
-            response => Err(unexpected_response("get_rng_keypair", &response)),
+    pub async fn get_rng_ikm(&mut self, epoch: u64) -> Result<RngIkmBytes, IpcError> {
+        match self.call(&Request::GetRngIkm { epoch }).await? {
+            Response::RngIkm(ikm) => Ok(ikm),
+            response => Err(unexpected_response("get_rng_ikm", &response)),
         }
     }
 
@@ -260,7 +260,7 @@ mod tests {
     #[tokio::test]
     async fn state_and_handler_failures_remain_typed() {
         let (mut client, server) = scripted_client(Response::RootKeyAbsent);
-        let error = client.get_rng_keypair(0).await.expect_err("must fail");
+        let error = client.get_rng_ikm(0).await.expect_err("must fail");
         assert!(matches!(error, IpcError::RootKeyAbsent));
         server.await.expect("server task");
 

--- a/crates/custodian-ipc/src/lib.rs
+++ b/crates/custodian-ipc/src/lib.rs
@@ -41,7 +41,7 @@ pub use framing::{MAX_FRAME_BODY_LEN, read_frame_blocking, write_frame_blocking}
 #[cfg(feature = "client")]
 pub use framing::{read_frame, write_frame};
 pub use messages::{
-    Request, Response, RngKeypairBytes, RootKeyBootstrapAttemptBytes, SnapshotKeyBytes,
+    Request, Response, RngIkmBytes, RootKeyBootstrapAttemptBytes, SnapshotKeyBytes,
     TxIoKeypairBytes, TxIoPublicKeyBytes, WrappedRootKeyBytes,
 };
 

--- a/crates/custodian-ipc/src/messages.rs
+++ b/crates/custodian-ipc/src/messages.rs
@@ -31,8 +31,8 @@ pub enum Request {
     /// attestation service uses this to mint tx-io evidence without gaining
     /// access to `tx_io_sk`.
     GetTxIoPublicKey { epoch: u64 },
-    /// Derive this epoch's RNG-precompile keypair.
-    GetRngKeypair { epoch: u64 },
+    /// Derive this epoch's RNG-precompile input key material.
+    GetRngIkm { epoch: u64 },
     /// Derive this epoch's snapshot encryption key.
     GetSnapshotKey { epoch: u64 },
 
@@ -94,7 +94,7 @@ impl Request {
             Request::Ping => "ping",
             Request::GetTxIoKeypair { .. } => "get_tx_io_keypair",
             Request::GetTxIoPublicKey { .. } => "get_tx_io_public_key",
-            Request::GetRngKeypair { .. } => "get_rng_keypair",
+            Request::GetRngIkm { .. } => "get_rng_ikm",
             Request::GetSnapshotKey { .. } => "get_snapshot_key",
             Request::CreateRootKeyBootstrapAttempt => "create_root_key_bootstrap_attempt",
             Request::WrapRootKey { .. } => "wrap_root_key",
@@ -114,7 +114,7 @@ pub enum Response {
     Pong,
     TxIoKeypair(TxIoKeypairBytes),
     TxIoPublicKey(TxIoPublicKeyBytes),
-    RngKeypair(RngKeypairBytes),
+    RngIkm(RngIkmBytes),
     SnapshotKey(SnapshotKeyBytes),
     RootKeyBootstrapAttemptCreated(RootKeyBootstrapAttemptBytes),
     WrappedRootKey(WrappedRootKeyBytes),
@@ -149,7 +149,7 @@ impl Response {
             Response::Pong => "pong",
             Response::TxIoKeypair(_) => "tx_io_keypair",
             Response::TxIoPublicKey(_) => "tx_io_public_key",
-            Response::RngKeypair(_) => "rng_keypair",
+            Response::RngIkm(_) => "rng_ikm",
             Response::SnapshotKey(_) => "snapshot_key",
             Response::RootKeyBootstrapAttemptCreated(_) => "root_key_bootstrap_attempt_created",
             Response::WrappedRootKey(_) => "wrapped_root_key",
@@ -202,18 +202,18 @@ pub struct RootKeyBootstrapAttemptBytes {
     pub requester_eph_pk: [u8; 33],
 }
 
-/// schnorrkel RNG keypair as raw bytes (`Keypair::to_bytes()`, 96 bytes,
-/// secret half included). Zeroized on drop.
+/// HKDF input key material for the RNG precompile (64 bytes: the secret half
+/// of the derived rng key, `SecretKey::to_bytes()`). Zeroized on drop.
 #[derive(Clone, Serialize, Deserialize, Zeroize, ZeroizeOnDrop)]
-pub struct RngKeypairBytes {
+pub struct RngIkmBytes {
     #[serde(with = "serde_bytes")]
-    pub keypair: Vec<u8>,
+    pub ikm: [u8; 64],
 }
 
-impl fmt::Debug for RngKeypairBytes {
+impl fmt::Debug for RngIkmBytes {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("RngKeypairBytes")
-            .field("keypair", &"<redacted>")
+        f.debug_struct("RngIkmBytes")
+            .field("ikm", &"<redacted>")
             .finish()
     }
 }
@@ -266,7 +266,7 @@ mod tests {
             Request::Ping,
             Request::GetTxIoKeypair { epoch: 7 },
             Request::GetTxIoPublicKey { epoch: 7 },
-            Request::GetRngKeypair { epoch: 8 },
+            Request::GetRngIkm { epoch: 8 },
             Request::GetSnapshotKey { epoch: 9 },
             Request::CreateRootKeyBootstrapAttempt,
             Request::WrapRootKey {
@@ -304,13 +304,11 @@ mod tests {
         };
         assert_eq!(snapshot.key, [3; 32]);
 
-        let response = Response::RngKeypair(RngKeypairBytes {
-            keypair: vec![4; 96],
-        });
-        let Response::RngKeypair(rng) = from_cbor(&to_cbor(&response)) else {
+        let response = Response::RngIkm(RngIkmBytes { ikm: [4; 64] });
+        let Response::RngIkm(rng) = from_cbor(&to_cbor(&response)) else {
             panic!("wrong variant");
         };
-        assert_eq!(rng.keypair, vec![4; 96]);
+        assert_eq!(rng.ikm, [4; 64]);
 
         let response = Response::TxIoPublicKey(TxIoPublicKeyBytes { pk: [5; 33] });
         let Response::TxIoPublicKey(tx_io) = from_cbor(&to_cbor(&response)) else {
@@ -391,9 +389,7 @@ mod tests {
         assert!(debug.contains("<redacted>"));
         assert!(!debug.contains("1, 1"), "sk leaked: {debug}");
 
-        let rng = RngKeypairBytes {
-            keypair: vec![4; 96],
-        };
+        let rng = RngIkmBytes { ikm: [4; 64] };
         assert!(format!("{rng:?}").contains("<redacted>"));
 
         let snapshot = SnapshotKeyBytes { key: [3; 32] };

--- a/crates/custodian-ipc/src/server.rs
+++ b/crates/custodian-ipc/src/server.rs
@@ -77,7 +77,7 @@ impl MethodAcl {
             Request::Ping => true,
             Request::GetTxIoKeypair { .. } => self.tx_io.contains(&uid),
             Request::GetTxIoPublicKey { .. } => self.tx_io_public.contains(&uid),
-            Request::GetRngKeypair { .. } => self.rng.contains(&uid),
+            Request::GetRngIkm { .. } => self.rng.contains(&uid),
             Request::GetSnapshotKey { .. } => self.snapshot.contains(&uid),
             Request::CreateRootKeyBootstrapAttempt => {
                 self.create_root_key_bootstrap_attempt.contains(&uid)
@@ -362,7 +362,7 @@ mod tests {
             ..MethodAcl::default()
         };
         assert!(reth_like.allows(UID, &Request::GetTxIoKeypair { epoch: 0 }));
-        assert!(reth_like.allows(UID, &Request::GetRngKeypair { epoch: 0 }));
+        assert!(reth_like.allows(UID, &Request::GetRngIkm { epoch: 0 }));
         assert!(!reth_like.allows(UID, &Request::GetTxIoPublicKey { epoch: 0 }));
         assert!(!reth_like.allows(UID, &Request::GetSnapshotKey { epoch: 0 }));
         assert!(!reth_like.allows(UID, &Request::CreateRootKeyBootstrapAttempt));
@@ -381,7 +381,7 @@ mod tests {
         assert!(attestation_like.allows(UID, &wrap_request()));
         assert!(attestation_like.allows(UID, &install_request()));
         assert!(!attestation_like.allows(UID, &Request::GetTxIoKeypair { epoch: 0 }));
-        assert!(!attestation_like.allows(UID, &Request::GetRngKeypair { epoch: 0 }));
+        assert!(!attestation_like.allows(UID, &Request::GetRngIkm { epoch: 0 }));
         assert!(!attestation_like.allows(UID, &Request::GetSnapshotKey { epoch: 0 }));
 
         assert!(!reth_like.allows(UID + 1, &Request::GetTxIoKeypair { epoch: 0 }));

--- a/crates/custodian/src/custodian.rs
+++ b/crates/custodian/src/custodian.rs
@@ -114,8 +114,16 @@ impl Custodian {
         secp256k1::PublicKey::from_secret_key(&secp256k1::Secp256k1::new(), &sk)
     }
 
-    /// Retrieves the Schnorrkel keypair used for randomness generation.
-    pub fn get_rng_keypair(&self, epoch: u64) -> schnorrkel::keys::Keypair {
+    /// Derives the 64 bytes of HKDF input key material that seed the RNG
+    /// precompile: the secret half of a schnorrkel keypair expanded from the
+    /// purpose-derived mini secret.
+    // TODO: the schnorrkel mini-secret expansion is kept only for backward
+    // compatibility with the running testnet — the expansion determines the
+    // derived bytes, and the RNG precompile's outputs are consensus. On the
+    // next network reset, drop it and take the ikm straight from the purpose
+    // derivation: have `derive_purpose_key` expand 64 bytes here instead of
+    // 32, removing schnorrkel from the custodian.
+    pub fn get_rng_ikm(&self, epoch: u64) -> [u8; 64] {
         let mini_key = self
             .derive_purpose_key(KeyPurpose::RngPrecompile, epoch)
             .expect("purpose key derivation must succeed");
@@ -124,7 +132,7 @@ impl Custodian {
             .expect("mini_secret_key should be valid");
         mini_secret_key
             .expand(schnorrkel::ExpansionMode::Uniform)
-            .into()
+            .to_bytes()
     }
 
     /// Retrieves the AES-256-GCM encryption key used for snapshot operations.

--- a/crates/enclave/Cargo.toml
+++ b/crates/enclave/Cargo.toml
@@ -12,6 +12,5 @@ readme.workspace = true
 seismic-crypto.workspace = true
 
 jsonrpsee.workspace = true
-schnorrkel.workspace = true
 secp256k1.workspace = true
 serde.workspace = true

--- a/crates/enclave/src/api.rs
+++ b/crates/enclave/src/api.rs
@@ -23,25 +23,6 @@ pub trait NodeStatusRpc {
     async fn get_luks_provisioning_status(&self) -> RpcResult<LuksProvisioningStatus>;
 }
 
-/// Temporary HTTP surface for reth's purpose-key startup fetch — reth is its
-/// only consumer.
-///
-/// TODO: delete the whole trait once reth fetches its keys from the custodian
-/// socket directly (its socket grant replaces this).
-#[rpc(client, server)]
-pub trait PurposeKeysRpc {
-    #[method(name = "getPurposeKeys")]
-    async fn get_purpose_keys(&self, epoch: u64) -> RpcResult<GetPurposeKeysResponse>;
-}
-
-#[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct GetPurposeKeysResponse {
-    pub tx_io_sk: secp256k1::SecretKey,
-    pub tx_io_pk: secp256k1::PublicKey,
-    pub snapshot_key_bytes: [u8; 32],
-    pub rng_keypair: schnorrkel::keys::Keypair,
-}
-
 // TODO: this is intentionally scoped to just the first-boot LUKS wipe — the one
 // long, opaque phase the operator CLI needs a progress bar for. If we later want
 // a full node boot-status surface, this would grow into a richer enum covering

--- a/crates/enclave/src/lib.rs
+++ b/crates/enclave/src/lib.rs
@@ -4,10 +4,11 @@ pub use api::*;
 pub use secp256k1;
 // Compatibility re-export: the crypto helpers moved to their own crate so key
 // custody code can use them without pulling in this crate's JSON-RPC surface.
-// Existing users (seismic-reth) keep importing them from here unchanged.
+// Existing users (seismic-alloy, seismic-revm, seismic-foundry) keep importing
+// them from here unchanged.
 //
 // TODO: This facade is temporary. The plan is to split this crate and
 // the attestation service into small single-purpose crates (RPC types, crypto helpers,
-// sample keys, custodian client) that seismic-reth imports individually;
-// once reth is updated to do so, this re-export goes away.
+// sample keys, custodian client) that consumers import individually;
+// once the remaining users are updated to do so, this re-export goes away.
 pub use seismic_crypto::*;


### PR DESCRIPTION
Removes the last transitional piece of the process split: the attestation service no longer serves `getPurposeKeys` over HTTP, and the `PurposeKeysRpc` trait is deleted (#212 split it out of the facade trait so it could go whole). Nodes fetch their purpose keys straight from the custodian's Unix socket, per purpose (`GetTxIoKeypair` + `GetRngIkm`), which takes the network-facing process out of the key path entirely — matching the production ACL, where the attestation service is granted `tx_io_public` only.

- `GetPurposeKeysResponse` is deleted rather than trimmed. The bundle is a consumer-side convenience (reth threads it into the EVM factories), so its successor is defined consumer-side in seismic-evm. Custody here stays per-purpose: individual keys behind per-method ACL grants and per-key wire types, never an all-keys package.
- The rng purpose key narrows to the half consumers actually use: `Custodian::get_rng_ikm(epoch) -> [u8; 64]` and the wire type `RngIkmBytes { ikm: [u8; 64] }` replace the 96-byte schnorrkel keypair (`get_rng_keypair` / `RngKeypairBytes`). The bytes are HKDF input key material for the RNG precompile; no schnorrkel crypto is performed with them, and `schnorrkel` drops out of `seismic-enclave`. The derived bytes are unchanged (`secret.to_bytes()` of the same derived keypair), so consensus-visible RNG-precompile outputs are unaffected, and the custodian and reth ship atomically in one measured image, so the wire rename needs no compatibility window. The ACL purpose label stays `rng`, keeping existing `--allow` grants valid.
- The integration test proves key equality by reading both custodians' sockets directly instead of comparing HTTP responses.

`crates/enclave` is left with `NodeStatusRpc`, `LuksProvisioningStatus`, and the compatibility re-exports (seismic-alloy, seismic-revm, seismic-foundry).