### PR TITLE
feat(crypto): re-export secp256k1

### DIFF
--- a/crates/crypto/src/lib.rs
+++ b/crates/crypto/src/lib.rs
@@ -6,6 +6,10 @@ use anyhow::anyhow;
 use hkdf::Hkdf;
 pub use schnorrkel::keys::Keypair as SchnorrkelKeypair;
 use schnorrkel::{ExpansionMode, MiniSecretKey};
+// Re-exported so consumers version-match the secp256k1 this crate's API
+// exposes (`derive_aes_key` takes its `SharedSecret`; the sample-key fns
+// return its key types).
+pub use secp256k1;
 use secp256k1::{Message, PublicKey, Secp256k1, SecretKey, ecdh::SharedSecret, ecdsa::Signature};
 use sha2::{Digest, Sha256};
 use std::{fs, io::Read, io::Write};


### PR DESCRIPTION
seismic-crypto's public API exposes secp256k1 types (`derive_aes_key` takes its `SharedSecret`; the sample-key fns return its key types), so consumers need the exact same secp256k1 build to name those types. Re-export the crate so version-matching is automatic — the same pattern the `seismic-enclave` facade uses. First consumer: seismic-revm's ECDH precompile imports `seismic_crypto::secp256k1` rather than pinning its own copy of the dependency, which its workspace can't do cleanly (the sign precompile shares a different secp256k1 major with revm-precompile).