### PR TITLE
feat(tdx-init)!: reth devp2p env + [network]/[node] config split (root-key peers derived from bootnode)

### DIFF
--- a/bin/tdx-init/README.md
+++ b/bin/tdx-init/README.md
@@ -32,17 +32,18 @@ Unknown top-level sections or fields are rejected — see
 [`src/config.rs`](src/config.rs).
 
 ```toml
-[domain]
-name = "<your.public.dns.name>"     # FQDN clients reach this VM at
-email = "<contact@example.com>"     # ACME registration / renewal email
-
-[root_key]                           # optional; defaults applied if absent
-genesis_node = false                # true on exactly one VM per network
-peers = ["http://10.0.0.1:7878"]    # required when genesis_node = false
-
-[network]
+[network]                            # coordinator-produced; a function of the network, not of this node
 manifest_base64 = "eyJib290c3RyYXBfbWVhc3VyZW1lbn..."
 reth_genesis_base64 = "eyJjb25maWciOnsiY2hhaW5JZCI..."
+bootnodes = ["enode://<128 hex pubkey>@host:port"]  # the cohort's peers; [] only on the genesis node
+
+[node]                               # this node only
+external_ip = "203.0.113.7"          # this VM's public IP (reth --nat extip:)
+genesis_node = false                 # optional (default false); true on exactly one VM per network
+
+[node.domain]
+name = "<your.public.dns.name>"      # FQDN clients reach this VM at
+email = "<contact@example.com>"      # ACME registration / renewal email
 ```
 
 `manifest_base64` carries the network's `network-manifest.json` as opaque
@@ -64,6 +65,23 @@ matches the manifest's `eth.chain_id`. The block-hash commitment is
 enforced deploy-side and at ceremony time; see `src/reth_genesis.rs`.
 Written verbatim to `reth-genesis.json`.
 
+`[network].bootnodes` is the network-wide devp2p bootnode list — the single
+source for the cohort's peer machines. It feeds reth verbatim (rendered into
+`reth-p2p.env`, see below) and, derived, the root-key fetch list the
+attestation service uses (`attestation.env`): `http://<bootnode host>:7878`
+per bootnode, with this node's own entry dropped. Deriving the peers instead
+of delivering a second list makes skew between the two unrepresentable — the
+bootnodes and the root-key peers are the same machines by construction.
+
+`[node].external_ip` is this VM's public IP — Azure NICs hold private
+addresses, so reth's NAT autodetection can't be trusted; it is also what
+identifies the node's own enode in the bootnode set. Both fields are
+validated structurally at POST time (`src/peers.rs`): each bootnode must be
+`enode://<128 hex pubkey>@host:port`, `external_ip` must parse as an IP address, and
+a node with `genesis_node = false` must end up with at least one root-key
+peer; a bad value fails the deploy with `400`. `bootnodes = []` is valid only
+on the genesis node (nothing to dial; it mints `root_key` itself).
+
 ## Per-service outputs
 
 After validation, tdx-init writes:
@@ -72,9 +90,10 @@ After validation, tdx-init writes:
 |---|---|---|
 | `/run/seismic/conf/domain.env` | `DOMAIN_NAME=...`, `DOMAIN_EMAIL=...` | `setup-nginx-ssl` (seismic-images) — `source`'d before invoking certbot for Let's Encrypt cert issuance and renewal |
 | `/run/seismic/conf/custodian.env` | `SEISMIC_CUSTODIAN_GENESIS_NODE=...` | `custodian.service` (seismic-images) — loaded via `EnvironmentFile=`; [`seismic-custodian-service`](../custodian-service) reads the genesis flag through clap `env=` |
-| `/run/seismic/conf/attestation.env` | `SEISMIC_ROOT_KEY_PEERS=...` | `attestation.service` (seismic-images) — loaded via `EnvironmentFile=`; [`seismic-attestation-service`](../attestation-service) reads the peer list through clap `env=` |
+| `/run/seismic/conf/attestation.env` | `SEISMIC_ROOT_KEY_PEERS=...` | `attestation.service` (seismic-images) — loaded via `EnvironmentFile=`; [`seismic-attestation-service`](../attestation-service) reads the peer list through clap `env=`. Derived from `[network].bootnodes`, not a config field |
 | `/run/seismic/conf/network-manifest.json` | verbatim manifest bytes | [`seismic-attestation-service`](../attestation-service) — hashes the file itself to derive `network_id` for attestation bindings |
 | `/run/seismic/conf/reth-genesis.json` | verbatim reth genesis bytes | `reth.service` (seismic-images) — passed to `seismic-reth node --chain` |
+| `/run/seismic/conf/reth-p2p.env` | `RETH_BOOTNODES_FLAG=...`, `RETH_NAT_FLAG=...` | `reth.service` (seismic-images) — loaded via `EnvironmentFile=`; each var holds a whole flag (`--bootnodes <csv>` / `--nat extip:<ip>`) or is empty, and the unit places the unquoted `$RETH_BOOTNODES_FLAG $RETH_NAT_FLAG` on the command line so empty vars drop out |
 
 Each downstream service reads its own native format (env-var pairs,
 either via systemd `EnvironmentFile=` or shell `source`); tdx-init is

--- a/bin/tdx-init/src/config.rs
+++ b/bin/tdx-init/src/config.rs
@@ -1,20 +1,31 @@
 use serde::{Deserialize, Serialize};
 
 /// Operator-supplied initialization config, received over HTTP at deploy
-/// time and fanned out by tdx-init into per-component env files under
+/// time and fanned out by tdx-init into per-component config files under
 /// [`crate::CONF_DIR`].
+///
+/// Two sections, split by provenance: `[network]` is coordinator-produced —
+/// a function of the network at POST time, never tailored to the recipient —
+/// while `[node]` is this node only. Network-indexed is weaker than
+/// cohort-identical: the bootnode set evolves as the network does (empty at
+/// greenfield stage 1), so nodes configured at different times hold
+/// different snapshots; only the manifest and reth genesis must truly match
+/// across the cohort — differing bytes there mean a different network.
+/// Anything derivable from these is derived rather than delivered twice —
+/// e.g. the root-key fetch peers come from `[network].bootnodes`
+/// (`src/peers.rs`), so there is no second list that could skew from it.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct InitConfig {
-    pub domain: DomainConfig,
-    #[serde(default)]
-    pub root_key: RootKeyConfig,
     /// Required: the attestation service reads `network-manifest.json` at startup to
     /// derive `network_id` and bind every attestation to it, and is fatal
     /// without it. A POST that omits `[network]` therefore 400s here rather
     /// than booting a node that crash-loops on the missing file. The deploy
     /// CLI merges the network-wide manifest into the per-node config at POST time.
     pub network: NetworkConfig,
+
+    /// Per-node settings; see [`NodeConfig`].
+    pub node: NodeConfig,
 }
 
 /// DNS name + contact email for the Let's Encrypt cert that fronts this
@@ -27,32 +38,6 @@ pub struct InitConfig {
 pub struct DomainConfig {
     pub email: String,
     pub name: String,
-}
-
-/// Root-key bootstrap config. Fields get converted to env vars under
-/// [`crate::CONF_DIR`]: `genesis_node` to `custodian.env` for
-/// `custodian.service` and `peers` to `attestation.env` for
-/// `attestation.service` (both in seismic-images, loaded via
-/// `EnvironmentFile=`).
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
-pub struct RootKeyConfig {
-    /// True iff this node is the network's genesis node — the one whose
-    /// custodian generates `root_key` locally with OsRng. Every other node
-    /// must leave this `false` (the default) and fetch from peers. Setting
-    /// it on multiple nodes causes a silent network split (each generates
-    /// a different `root_key`; downstream nodes that fetch from one
-    /// can't decrypt state from the other).
-    #[serde(default)]
-    pub genesis_node: bool,
-
-    /// Peer URLs (e.g. `http://10.0.0.1:7878`). When `genesis_node` is
-    /// false, the attestation service fetches `root_key` from one of these
-    /// peers via the `getWrappedRootKey` RPC. Required for non-genesis
-    /// nodes; the attestation service fails fast at startup if this list
-    /// is empty and the local custodian holds no root key.
-    #[serde(default)]
-    pub peers: Vec<String>,
 }
 
 /// The network's identity document, common to genesis and joining nodes.
@@ -79,6 +64,46 @@ pub struct NetworkConfig {
     /// (`src/reth_genesis.rs`) and written verbatim to `reth-genesis.json`
     /// under [`crate::CONF_DIR`].
     pub reth_genesis_base64: String,
+
+    /// Network-wide devp2p bootnodes, as `enode://<128 hex pubkey>@host:port`
+    /// URLs — the single source for the cohort's peer machines. Feeds reth
+    /// verbatim (`reth-p2p.env`'s `RETH_BOOTNODES_FLAG`) and, derived, the
+    /// attestation service's root-key fetch list (`attestation.env`:
+    /// `http://<host>:7878` per bootnode, this node's own entry dropped);
+    /// validation and derivation live in `src/peers.rs`. The field is required,
+    /// but an empty list is valid on the genesis node only — it has no peers
+    /// to dial and mints `root_key` itself; a non-genesis POST with no usable
+    /// bootnode is rejected with `400`.
+    pub bootnodes: Vec<String>,
+}
+
+/// Per-node settings — values that depend on which node receives the config,
+/// unlike `[network]`, whose fields never do.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct NodeConfig {
+    /// The node's public IP address. Azure NICs hold private addresses, so
+    /// reth's NAT autodetection can't be trusted; tdx-init renders this into
+    /// `reth-p2p.env`'s `RETH_NAT_FLAG` as `--nat extip:<ip>` so reth
+    /// advertises the correct external address to peers. Also used to drop
+    /// this node's own enode when deriving root-key fetch peers from
+    /// `[network].bootnodes`. Validated as an `IpAddr` at POST time
+    /// (`src/peers.rs`).
+    pub external_ip: String,
+
+    /// Root-key custody flag: true iff this node is the network's genesis
+    /// node — the one whose custodian generates `root_key` locally with
+    /// OsRng. Every other node must leave this `false` (the default) and
+    /// fetch from a peer derived from `[network].bootnodes`. Setting it on
+    /// multiple nodes causes a silent network split (each generates a
+    /// different `root_key`; downstream nodes that fetch from one can't
+    /// decrypt state from the other). Rendered to `custodian.env` as
+    /// `SEISMIC_CUSTODIAN_GENESIS_NODE`.
+    #[serde(default)]
+    pub genesis_node: bool,
+
+    /// TLS identity for this node's public RPC; see [`DomainConfig`].
+    pub domain: DomainConfig,
 }
 
 #[cfg(test)]
@@ -88,90 +113,107 @@ mod tests {
     #[test]
     fn parses_full_toml_payload() {
         let toml_input = r#"
-[domain]
-name = "node1.example.com"
-email = "ops@example.com"
+[network]
+manifest_base64 = "eyJtYW5pZmVzdF92ZXJzaW9uIjogMX0K"
+reth_genesis_base64 = "eyJjb25maWciOnt9fQ=="
+bootnodes = ["enode://abc@10.0.0.1:30303", "enode://def@10.0.0.2:30303"]
 
-[root_key]
+[node]
+external_ip = "203.0.113.7"
 genesis_node = true
-peers = ["http://10.0.0.1:7878", "http://10.0.0.2:7878"]
 
-[network]
-manifest_base64 = "eyJtYW5pZmVzdF92ZXJzaW9uIjogMX0K"
-reth_genesis_base64 = "eyJjb25maWciOnt9fQ=="
-"#;
-        let cfg: InitConfig = toml::from_str(toml_input).unwrap();
-        assert_eq!(cfg.domain.name, "node1.example.com");
-        assert_eq!(cfg.domain.email, "ops@example.com");
-        assert!(cfg.root_key.genesis_node);
-        assert_eq!(cfg.root_key.peers.len(), 2);
-        assert_eq!(
-            cfg.network.manifest_base64,
-            "eyJtYW5pZmVzdF92ZXJzaW9uIjogMX0K"
-        );
-    }
-
-    #[test]
-    fn parses_network_section() {
-        let toml_input = r#"
-[domain]
+[node.domain]
 name = "node1.example.com"
 email = "ops@example.com"
-
-[network]
-manifest_base64 = "eyJtYW5pZmVzdF92ZXJzaW9uIjogMX0K"
-reth_genesis_base64 = "eyJjb25maWciOnt9fQ=="
 "#;
         let cfg: InitConfig = toml::from_str(toml_input).unwrap();
         assert_eq!(
             cfg.network.manifest_base64,
             "eyJtYW5pZmVzdF92ZXJzaW9uIjogMX0K"
         );
+        assert_eq!(cfg.network.bootnodes.len(), 2);
+        assert_eq!(cfg.node.external_ip, "203.0.113.7");
+        assert!(cfg.node.genesis_node);
+        assert_eq!(cfg.node.domain.name, "node1.example.com");
+        assert_eq!(cfg.node.domain.email, "ops@example.com");
     }
 
     #[test]
-    fn rejects_unknown_field_in_network_section() {
+    fn genesis_node_defaults_to_false() {
+        // Fetching from a peer is the safe default: an accidentally-omitted
+        // flag must never mint a second root_key.
         let toml_input = r#"
-[domain]
+[network]
+manifest_base64 = "eyJtYW5pZmVzdF92ZXJzaW9uIjogMX0K"
+reth_genesis_base64 = "eyJjb25maWciOnt9fQ=="
+bootnodes = []
+
+[node]
+external_ip = "203.0.113.7"
+
+[node.domain]
 name = "node1.example.com"
 email = "ops@example.com"
+"#;
+        let cfg: InitConfig = toml::from_str(toml_input).unwrap();
+        assert!(!cfg.node.genesis_node);
+    }
 
+    #[test]
+    fn accepts_empty_bootnodes() {
+        // The genesis node has no peers to dial: the key is required but an
+        // empty list parses fine (the genesis-only rule lives in src/peers.rs).
+        let toml_input = r#"
 [network]
-manifest_base64 = "eyJ9"
+manifest_base64 = "eyJtYW5pZmVzdF92ZXJzaW9uIjogMX0K"
 reth_genesis_base64 = "eyJjb25maWciOnt9fQ=="
-network_id = "0xabcd"
+bootnodes = []
+
+[node]
+external_ip = "203.0.113.7"
+genesis_node = true
+
+[node.domain]
+name = "node1.example.com"
+email = "ops@example.com"
+"#;
+        let cfg: InitConfig = toml::from_str(toml_input).unwrap();
+        assert!(cfg.network.bootnodes.is_empty());
+    }
+
+    #[test]
+    fn requires_bootnodes_field() {
+        let toml_input = r#"
+[network]
+manifest_base64 = "eyJtYW5pZmVzdF92ZXJzaW9uIjogMX0K"
+reth_genesis_base64 = "eyJjb25maWciOnt9fQ=="
+
+[node]
+external_ip = "203.0.113.7"
+
+[node.domain]
+name = "node1.example.com"
+email = "ops@example.com"
 "#;
         let err = toml::from_str::<InitConfig>(toml_input).unwrap_err();
-        assert!(err.to_string().to_lowercase().contains("unknown"));
-    }
-
-    #[test]
-    fn root_key_section_is_optional_with_defaults() {
-        let toml_input = r#"
-[domain]
-name = "node1.example.com"
-email = "ops@example.com"
-
-[network]
-manifest_base64 = "eyJtYW5pZmVzdF92ZXJzaW9uIjogMX0K"
-reth_genesis_base64 = "eyJjb25maWciOnt9fQ=="
-"#;
-        let cfg: InitConfig = toml::from_str(toml_input).unwrap();
-        assert!(!cfg.root_key.genesis_node);
-        assert!(cfg.root_key.peers.is_empty());
+        assert!(err.to_string().contains("bootnodes"));
     }
 
     #[test]
     fn requires_reth_genesis_field() {
-        // An older deploy CLI that doesn't send the genesis must get a clean
-        // 400 here, not a node whose reth has no chain spec.
+        // A config without the genesis must get a clean 400 here, not a node
+        // whose reth has no chain spec.
         let toml_input = r#"
-[domain]
-name = "node1.example.com"
-email = "ops@example.com"
-
 [network]
 manifest_base64 = "eyJtYW5pZmVzdF92ZXJzaW9uIjogMX0K"
+bootnodes = []
+
+[node]
+external_ip = "203.0.113.7"
+
+[node.domain]
+name = "node1.example.com"
+email = "ops@example.com"
 "#;
         let err = toml::from_str::<InitConfig>(toml_input).unwrap_err();
         assert!(err.to_string().contains("reth_genesis_base64"));
@@ -180,56 +222,107 @@ manifest_base64 = "eyJtYW5pZmVzdF92ZXJzaW9uIjogMX0K"
     #[test]
     fn requires_network_section() {
         let toml_input = r#"
-[domain]
+[node]
+external_ip = "203.0.113.7"
+genesis_node = true
+
+[node.domain]
 name = "node1.example.com"
 email = "ops@example.com"
-
-[root_key]
-genesis_node = true
 "#;
         let err = toml::from_str::<InitConfig>(toml_input).unwrap_err();
         assert!(err.to_string().contains("network"));
     }
 
     #[test]
-    fn rejects_unknown_top_level_section() {
+    fn requires_node_section() {
         let toml_input = r#"
-[domain]
+[network]
+manifest_base64 = "eyJtYW5pZmVzdF92ZXJzaW9uIjogMX0K"
+reth_genesis_base64 = "eyJjb25maWciOnt9fQ=="
+bootnodes = []
+"#;
+        let err = toml::from_str::<InitConfig>(toml_input).unwrap_err();
+        assert!(err.to_string().contains("node"));
+    }
+
+    #[test]
+    fn requires_external_ip_field() {
+        let toml_input = r#"
+[network]
+manifest_base64 = "eyJtYW5pZmVzdF92ZXJzaW9uIjogMX0K"
+reth_genesis_base64 = "eyJjb25maWciOnt9fQ=="
+bootnodes = []
+
+[node]
+[node.domain]
 name = "node1.example.com"
 email = "ops@example.com"
+"#;
+        let err = toml::from_str::<InitConfig>(toml_input).unwrap_err();
+        assert!(err.to_string().contains("external_ip"));
+    }
 
+    #[test]
+    fn requires_domain_in_node_section() {
+        let toml_input = r#"
+[network]
+manifest_base64 = "eyJtYW5pZmVzdF92ZXJzaW9uIjogMX0K"
+reth_genesis_base64 = "eyJjb25maWciOnt9fQ=="
+bootnodes = []
+
+[node]
+external_ip = "203.0.113.7"
+"#;
+        let err = toml::from_str::<InitConfig>(toml_input).unwrap_err();
+        assert!(err.to_string().contains("domain"));
+    }
+
+    #[test]
+    fn rejects_unknown_field_in_network_section() {
+        let toml_input = r#"
 [network]
 manifest_base64 = "eyJ9"
 reth_genesis_base64 = "eyJjb25maWciOnt9fQ=="
+bootnodes = []
+network_id = "0xabcd"
 
-[bogus]
-field = "value"
+[node]
+external_ip = "203.0.113.7"
+
+[node.domain]
+name = "node1.example.com"
+email = "ops@example.com"
 "#;
         let err = toml::from_str::<InitConfig>(toml_input).unwrap_err();
         assert!(err.to_string().to_lowercase().contains("unknown"));
     }
 
     #[test]
-    fn rejects_unknown_field_in_root_key_section() {
+    fn rejects_unknown_field_in_node_section() {
         let toml_input = r#"
-[domain]
-name = "node1.example.com"
-email = "ops@example.com"
-
-[root_key]
-genesis_node = false
-log_level = "trace"
-
 [network]
 manifest_base64 = "eyJ9"
 reth_genesis_base64 = "eyJjb25maWciOnt9fQ=="
+bootnodes = []
+
+[node]
+external_ip = "203.0.113.7"
+internal_ip = "10.0.0.1"
+
+[node.domain]
+name = "node1.example.com"
+email = "ops@example.com"
 "#;
         let err = toml::from_str::<InitConfig>(toml_input).unwrap_err();
         assert!(err.to_string().to_lowercase().contains("unknown"));
     }
 
     #[test]
-    fn requires_domain_section() {
+    fn rejects_removed_root_key_section() {
+        // The old wire schema's [root_key] section (genesis_node + peers)
+        // folded into [node] / derivation: an old deploy CLI must get a clean
+        // 400, not a node silently running with defaults.
         let toml_input = r#"
 [root_key]
 genesis_node = true
@@ -237,8 +330,38 @@ genesis_node = true
 [network]
 manifest_base64 = "eyJ9"
 reth_genesis_base64 = "eyJjb25maWciOnt9fQ=="
+bootnodes = []
+
+[node]
+external_ip = "203.0.113.7"
+
+[node.domain]
+name = "node1.example.com"
+email = "ops@example.com"
 "#;
         let err = toml::from_str::<InitConfig>(toml_input).unwrap_err();
-        assert!(err.to_string().contains("domain"));
+        assert!(err.to_string().to_lowercase().contains("unknown"));
+    }
+
+    #[test]
+    fn rejects_unknown_top_level_section() {
+        let toml_input = r#"
+[network]
+manifest_base64 = "eyJ9"
+reth_genesis_base64 = "eyJjb25maWciOnt9fQ=="
+bootnodes = []
+
+[node]
+external_ip = "203.0.113.7"
+
+[node.domain]
+name = "node1.example.com"
+email = "ops@example.com"
+
+[bogus]
+field = "value"
+"#;
+        let err = toml::from_str::<InitConfig>(toml_input).unwrap_err();
+        assert!(err.to_string().to_lowercase().contains("unknown"));
     }
 }

--- a/bin/tdx-init/src/error.rs
+++ b/bin/tdx-init/src/error.rs
@@ -15,6 +15,9 @@ pub enum TdxInitError {
     #[error("invalid reth genesis: {0}")]
     InvalidRethGenesis(String),
 
+    #[error("invalid peer config: {0}")]
+    InvalidPeers(String),
+
     #[error("Server error: {0}")]
     ServerError(String),
 }
@@ -34,6 +37,10 @@ impl IntoResponse for TdxInitError {
             TdxInitError::InvalidRethGenesis(msg) => (
                 StatusCode::BAD_REQUEST,
                 format!("invalid reth genesis: {msg}"),
+            ),
+            TdxInitError::InvalidPeers(msg) => (
+                StatusCode::BAD_REQUEST,
+                format!("invalid peer config: {msg}"),
             ),
             TdxInitError::Io(_) => (
                 StatusCode::INTERNAL_SERVER_ERROR,

--- a/bin/tdx-init/src/main.rs
+++ b/bin/tdx-init/src/main.rs
@@ -7,6 +7,7 @@ use tracing::info;
 mod config;
 mod error;
 mod manifest;
+mod peers;
 mod reth_genesis;
 mod server;
 mod writer;

--- a/bin/tdx-init/src/peers.rs
+++ b/bin/tdx-init/src/peers.rs
@@ -1,0 +1,293 @@
+//! POST-time validation of the peer inputs and derivation of the root-key
+//! fetch peers.
+//!
+//! `[network].bootnodes` is the single source for the cohort's peer machines.
+//! It feeds two consumers: reth verbatim (rendered into `reth-p2p.env` by the
+//! writer module) and — derived here — the attestation service's root-key
+//! fetch list (`http://<bootnode host>:7878`, this node's own entry dropped).
+//! Bootnodes and root-key peers are the same machines by construction, so
+//! deriving one list from the other makes skew between them unrepresentable,
+//! and the `http://…:7878` convention is rendered in exactly one place.
+//!
+//! Validation is structural, so a malformed enode or IP fails the deploy POST
+//! with `400` rather than surfacing when reth parses its flags at boot and
+//! crash-loops — likewise a non-genesis node left with no usable bootnode,
+//! which would otherwise boot an attestation service with no way to obtain
+//! `root_key`.
+
+use crate::config::NodeConfig;
+use crate::error::{Result, TdxInitError};
+use std::net::IpAddr;
+use tracing::info;
+
+/// Number of hex chars in an enode node id: the 64-byte secp256k1 public key
+/// (uncompressed, without the 0x04 prefix), hex-encoded.
+const ENODE_ID_HEX_LEN: usize = 128;
+
+/// Port the attestation service serves `getWrappedRootKey` on
+/// (`DEFAULT_ENDPOINT_PORT` in `bin/attestation-service`, which is a binary
+/// crate — the constant can't be imported).
+const ROOT_KEY_PEER_PORT: u16 = 7878;
+
+/// Validate the peer inputs from the POSTed config and derive the root-key
+/// fetch peer URLs from the bootnodes: `external_ip` must parse as an IP
+/// address and every bootnode must be a well-formed `enode://` URL. The
+/// node's own enode (host == `external_ip`) is dropped — after the founding
+/// ceremony the persisted bootnode set includes every founding node, this one
+/// included — and a non-genesis node must end up with at least one peer, or
+/// it has no source for `root_key`.
+pub fn validate_and_derive_peers(node: &NodeConfig, bootnodes: &[String]) -> Result<Vec<String>> {
+    let external_ip = parse_external_ip(&node.external_ip)?;
+    let mut peers = Vec::new();
+    for enode in bootnodes {
+        let host = parse_enode_host(enode)?;
+        if is_self(host, external_ip) {
+            continue;
+        }
+        let peer = format!("http://{host}:{ROOT_KEY_PEER_PORT}");
+        if !peers.contains(&peer) {
+            peers.push(peer);
+        }
+    }
+    if !node.genesis_node && peers.is_empty() {
+        return Err(TdxInitError::InvalidPeers(
+            "non-genesis node has no source for root_key: [network].bootnodes \
+             must name at least one machine other than this node"
+                .to_string(),
+        ));
+    }
+    info!(
+        "peer config valid: {} bootnode(s), {} derived root-key peer(s), external_ip={}",
+        bootnodes.len(),
+        peers.len(),
+        node.external_ip,
+    );
+    Ok(peers)
+}
+
+/// Check that `enode` matches `enode://<128 hex pubkey>@host:port` and return
+/// the host. Host shape (IPv4/IPv6/DNS) is left to reth; we only require it
+/// non-empty and the port to parse as a `u16`.
+fn parse_enode_host(enode: &str) -> Result<&str> {
+    let rest = enode.strip_prefix("enode://").ok_or_else(|| {
+        TdxInitError::InvalidPeers(format!("bootnode {enode:?} must start with enode://"))
+    })?;
+    let (id, host_port) = rest.split_once('@').ok_or_else(|| {
+        TdxInitError::InvalidPeers(format!(
+            "bootnode {enode:?} is missing the '@' separating node id from host:port"
+        ))
+    })?;
+    if id.len() != ENODE_ID_HEX_LEN || !id.bytes().all(|b| b.is_ascii_hexdigit()) {
+        return Err(TdxInitError::InvalidPeers(format!(
+            "bootnode {enode:?} pubkey must be {ENODE_ID_HEX_LEN} hex chars"
+        )));
+    }
+    // rsplit so a bracketed IPv6 host ("[::1]:30303") keeps its inner colons.
+    let (host, port) = host_port.rsplit_once(':').ok_or_else(|| {
+        TdxInitError::InvalidPeers(format!("bootnode {enode:?} is missing ':port'"))
+    })?;
+    if host.is_empty() {
+        return Err(TdxInitError::InvalidPeers(format!(
+            "bootnode {enode:?} has an empty host"
+        )));
+    }
+    port.parse::<u16>().map_err(|_| {
+        TdxInitError::InvalidPeers(format!(
+            "bootnode {enode:?} has a non-numeric port {port:?}"
+        ))
+    })?;
+    Ok(host)
+}
+
+/// Check that `external_ip` parses as an IPv4 or IPv6 address.
+fn parse_external_ip(ip: &str) -> Result<IpAddr> {
+    ip.parse::<IpAddr>().map_err(|_| {
+        TdxInitError::InvalidPeers(format!("external_ip {ip:?} is not a valid IP address"))
+    })
+}
+
+/// Whether an enode host names this node itself. Compared as parsed
+/// `IpAddr`s so equivalent textual forms match (`[2001:0db8::1]` vs
+/// `2001:db8::1`); a DNS host never matches — tdx-init does not resolve.
+fn is_self(host: &str, external_ip: IpAddr) -> bool {
+    let bare = host
+        .strip_prefix('[')
+        .and_then(|h| h.strip_suffix(']'))
+        .unwrap_or(host);
+    bare.parse::<IpAddr>() == Ok(external_ip)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::DomainConfig;
+
+    fn node(external_ip: &str, genesis_node: bool) -> NodeConfig {
+        NodeConfig {
+            external_ip: external_ip.to_string(),
+            genesis_node,
+            domain: DomainConfig {
+                email: "ops@example.com".to_string(),
+                name: "node1.example.com".to_string(),
+            },
+        }
+    }
+
+    /// A syntactically valid enode at `host_port` (128-hex pubkey).
+    fn enode(host_port: &str) -> String {
+        format!("enode://{}@{host_port}", "a".repeat(ENODE_ID_HEX_LEN))
+    }
+
+    #[test]
+    fn derives_peers_from_bootnodes() {
+        let peers = validate_and_derive_peers(
+            &node("203.0.113.7", false),
+            &[enode("10.0.0.1:30303"), enode("10.0.0.2:30303")],
+        )
+        .unwrap();
+        assert_eq!(peers, vec!["http://10.0.0.1:7878", "http://10.0.0.2:7878"]);
+    }
+
+    #[test]
+    fn drops_own_enode() {
+        let peers = validate_and_derive_peers(
+            &node("10.0.0.1", false),
+            &[enode("10.0.0.1:30303"), enode("10.0.0.2:30303")],
+        )
+        .unwrap();
+        assert_eq!(peers, vec!["http://10.0.0.2:7878"]);
+    }
+
+    #[test]
+    fn drops_own_enode_by_ip_equality_not_string_equality() {
+        // A non-canonical IPv6 spelling of this node's own address still
+        // counts as self.
+        let peers = validate_and_derive_peers(
+            &node("2001:db8::1", false),
+            &[
+                enode("[2001:0db8:0:0:0:0:0:1]:30303"),
+                enode("10.0.0.2:30303"),
+            ],
+        )
+        .unwrap();
+        assert_eq!(peers, vec!["http://10.0.0.2:7878"]);
+    }
+
+    #[test]
+    fn keeps_bracketed_ipv6_peer_hosts() {
+        let peers =
+            validate_and_derive_peers(&node("10.0.0.1", false), &[enode("[2001:db8::1]:30303")])
+                .unwrap();
+        assert_eq!(peers, vec!["http://[2001:db8::1]:7878"]);
+    }
+
+    #[test]
+    fn keeps_dns_peer_hosts() {
+        let peers = validate_and_derive_peers(
+            &node("10.0.0.1", false),
+            &[enode("node2.example.com:30303")],
+        )
+        .unwrap();
+        assert_eq!(peers, vec!["http://node2.example.com:7878"]);
+    }
+
+    #[test]
+    fn dedupes_repeated_hosts() {
+        let mut second = enode("10.0.0.2:30303");
+        second = second.replacen('a', "b", 1);
+        let peers =
+            validate_and_derive_peers(&node("10.0.0.1", false), &[enode("10.0.0.2:30303"), second])
+                .unwrap();
+        assert_eq!(peers, vec!["http://10.0.0.2:7878"]);
+    }
+
+    #[test]
+    fn genesis_node_may_have_no_bootnodes() {
+        // The greenfield genesis node has no peers to dial and mints
+        // root_key itself.
+        let peers = validate_and_derive_peers(&node("10.0.0.1", true), &[]).unwrap();
+        assert!(peers.is_empty());
+    }
+
+    #[test]
+    fn rejects_joiner_without_bootnodes() {
+        let err = validate_and_derive_peers(&node("10.0.0.1", false), &[]).unwrap_err();
+        assert!(matches!(err, TdxInitError::InvalidPeers(_)));
+        assert!(err.to_string().contains("root_key"), "{err}");
+    }
+
+    #[test]
+    fn rejects_joiner_whose_only_bootnode_is_itself() {
+        let err = validate_and_derive_peers(&node("10.0.0.1", false), &[enode("10.0.0.1:30303")])
+            .unwrap_err();
+        assert!(err.to_string().contains("root_key"), "{err}");
+    }
+
+    #[test]
+    fn accepts_uppercase_hex_node_id() {
+        let id = "AbCdEf".repeat(ENODE_ID_HEX_LEN / 6) + &"0".repeat(ENODE_ID_HEX_LEN % 6);
+        assert_eq!(id.len(), ENODE_ID_HEX_LEN);
+        let enode = format!("enode://{id}@example.com:30303");
+        validate_and_derive_peers(&node("10.0.0.1", false), &[enode]).unwrap();
+    }
+
+    #[test]
+    fn rejects_missing_enode_scheme() {
+        let bad = enode("10.0.0.1:30303").replace("enode://", "");
+        let err = validate_and_derive_peers(&node("10.0.0.1", false), &[bad]).unwrap_err();
+        assert!(matches!(err, TdxInitError::InvalidPeers(_)));
+        assert!(err.to_string().contains("enode://"), "{err}");
+    }
+
+    #[test]
+    fn rejects_short_node_id() {
+        let id = "a".repeat(ENODE_ID_HEX_LEN - 1);
+        let bad = format!("enode://{id}@10.0.0.1:30303");
+        let err = validate_and_derive_peers(&node("10.0.0.1", false), &[bad]).unwrap_err();
+        assert!(err.to_string().contains("hex chars"), "{err}");
+    }
+
+    #[test]
+    fn rejects_non_hex_node_id() {
+        let id = "z".repeat(ENODE_ID_HEX_LEN);
+        let bad = format!("enode://{id}@10.0.0.1:30303");
+        let err = validate_and_derive_peers(&node("10.0.0.1", false), &[bad]).unwrap_err();
+        assert!(err.to_string().contains("hex chars"), "{err}");
+    }
+
+    #[test]
+    fn rejects_missing_at_separator() {
+        let bad = format!("enode://{}", "a".repeat(ENODE_ID_HEX_LEN));
+        let err = validate_and_derive_peers(&node("10.0.0.1", false), &[bad]).unwrap_err();
+        assert!(err.to_string().contains("'@'"), "{err}");
+    }
+
+    #[test]
+    fn rejects_missing_port() {
+        let bad = enode("10.0.0.1");
+        let err = validate_and_derive_peers(&node("10.0.0.1", false), &[bad]).unwrap_err();
+        assert!(err.to_string().contains(":port"), "{err}");
+    }
+
+    #[test]
+    fn rejects_non_numeric_port() {
+        let bad = enode("10.0.0.1:notaport");
+        let err = validate_and_derive_peers(&node("10.0.0.1", false), &[bad]).unwrap_err();
+        assert!(err.to_string().contains("port"), "{err}");
+    }
+
+    #[test]
+    fn rejects_empty_host() {
+        let bad = enode(":30303");
+        let err = validate_and_derive_peers(&node("10.0.0.1", false), &[bad]).unwrap_err();
+        assert!(err.to_string().contains("empty host"), "{err}");
+    }
+
+    #[test]
+    fn rejects_invalid_external_ip() {
+        let err = validate_and_derive_peers(&node("not.an.ip", true), &[enode("10.0.0.1:30303")])
+            .unwrap_err();
+        assert!(matches!(err, TdxInitError::InvalidPeers(_)));
+        assert!(err.to_string().contains("valid IP"), "{err}");
+    }
+}

--- a/bin/tdx-init/src/server.rs
+++ b/bin/tdx-init/src/server.rs
@@ -66,13 +66,15 @@ async fn handle_config(State(state): State<AppState>, body: String) -> Result<Re
     let config: InitConfig = toml::from_str(&body)?;
 
     // Validate the network artifacts while the operator's POST is still
-    // waiting on a response: a bad (or absent) manifest or reth genesis must
-    // 400 the deploy, not fail at boot when the attestation service/reth try to use them.
+    // waiting on a response: a bad (or absent) manifest, reth genesis, or peer
+    // config must 400 the deploy, not fail at boot when the attestation
+    // service/reth try to use them.
     let manifest = crate::manifest::decode_and_validate(&config.network.manifest_base64)?;
     crate::reth_genesis::decode_and_validate(
         &config.network.reth_genesis_base64,
         manifest.chain_id,
     )?;
+    crate::peers::validate_and_derive_peers(&config.node, &config.network.bootnodes)?;
 
     let mut sender_guard = state.config_sender.lock().await;
     match sender_guard.take() {

--- a/bin/tdx-init/src/writer.rs
+++ b/bin/tdx-init/src/writer.rs
@@ -20,9 +20,12 @@ pub const DEFAULT_FILE_MODE: u32 = 0o644;
 /// tdx-init is the schema translator.
 pub async fn write_service_configs(conf_dir: &Path, config: &InitConfig) -> Result<()> {
     fs::create_dir_all(conf_dir).await?;
+    let root_key_peers =
+        crate::peers::validate_and_derive_peers(&config.node, &config.network.bootnodes)?;
     write_domain_env(conf_dir, config).await?;
     write_custodian_env(conf_dir, config).await?;
-    write_attestation_env(conf_dir, config).await?;
+    write_attestation_svc_env(conf_dir, &root_key_peers).await?;
+    write_reth_p2p_env(conf_dir, config).await?;
     let manifest = crate::manifest::decode_and_validate(&config.network.manifest_base64)?;
     let genesis = crate::reth_genesis::decode_and_validate(
         &config.network.reth_genesis_base64,
@@ -63,7 +66,7 @@ async fn write_domain_env(conf_dir: &Path, config: &InitConfig) -> Result<()> {
     let path = conf_dir.join("domain.env");
     let content = format!(
         "DOMAIN_NAME={}\nDOMAIN_EMAIL={}\n",
-        config.domain.name, config.domain.email,
+        config.node.domain.name, config.node.domain.email,
     );
     write_with_mode(&path, &content, DEFAULT_FILE_MODE).await?;
     info!("wrote {}", path.display());
@@ -77,7 +80,7 @@ async fn write_custodian_env(conf_dir: &Path, config: &InitConfig) -> Result<()>
     let path = conf_dir.join("custodian.env");
     let content = format!(
         "SEISMIC_CUSTODIAN_GENESIS_NODE={}\n",
-        config.root_key.genesis_node,
+        config.node.genesis_node,
     );
     write_with_mode(&path, &content, DEFAULT_FILE_MODE).await?;
     info!("wrote {}", path.display());
@@ -86,13 +89,38 @@ async fn write_custodian_env(conf_dir: &Path, config: &InitConfig) -> Result<()>
 
 /// The attestation service's unit loads this via `EnvironmentFile=`; the
 /// binary reads `SEISMIC_ROOT_KEY_PEERS` (where to fetch the root key when the
-/// local custodian starts without one) through clap `env=`.
-async fn write_attestation_env(conf_dir: &Path, config: &InitConfig) -> Result<()> {
+/// local custodian starts without one) through clap `env=`. The peer list is
+/// not a config field: it is derived from `[network].bootnodes` in
+/// `crate::peers`.
+async fn write_attestation_svc_env(conf_dir: &Path, root_key_peers: &[String]) -> Result<()> {
     let path = conf_dir.join("attestation.env");
-    let content = format!(
-        "SEISMIC_ROOT_KEY_PEERS={}\n",
-        config.root_key.peers.join(",")
-    );
+    let content = format!("SEISMIC_ROOT_KEY_PEERS={}\n", root_key_peers.join(","));
+    write_with_mode(&path, &content, DEFAULT_FILE_MODE).await?;
+    info!("wrote {}", path.display());
+    Ok(())
+}
+
+/// reth's unit loads this via `EnvironmentFile=` and puts the *unquoted*
+/// `$RETH_BOOTNODES_FLAG $RETH_NAT_FLAG` on reth's command line. Each var holds
+/// a whole flag: systemd word-splits an unquoted expansion, so a populated var
+/// expands to argv entries while an empty one drops out entirely. Emitting the
+/// flag name inside the var (rather than a bare value) is what lets the genesis
+/// node's empty bootnode list vanish instead of passing `--bootnodes ""`, which
+/// reth rejects. `RETH_NAT_FLAG` is always populated (external_ip is required);
+/// `RETH_BOOTNODES_FLAG` is empty only when there are no bootnodes. Values may
+/// contain a space; systemd EnvironmentFile keeps everything after `=` verbatim
+/// (no quoting needed), matching the other env files here.
+///
+/// Inputs are validated in `crate::peers` at POST time.
+async fn write_reth_p2p_env(conf_dir: &Path, config: &InitConfig) -> Result<()> {
+    let path = conf_dir.join("reth-p2p.env");
+    let bootnodes_flag = if config.network.bootnodes.is_empty() {
+        String::new()
+    } else {
+        format!("--bootnodes {}", config.network.bootnodes.join(","))
+    };
+    let nat_flag = format!("--nat extip:{}", config.node.external_ip);
+    let content = format!("RETH_BOOTNODES_FLAG={bootnodes_flag}\nRETH_NAT_FLAG={nat_flag}\n");
     write_with_mode(&path, &content, DEFAULT_FILE_MODE).await?;
     info!("wrote {}", path.display());
     Ok(())
@@ -109,20 +137,17 @@ async fn write_with_mode(path: &Path, content: impl AsRef<[u8]>, mode: u32) -> R
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::{DomainConfig, NetworkConfig, RootKeyConfig};
+    use crate::config::{DomainConfig, NetworkConfig, NodeConfig};
     use base64::Engine as _;
     use tempfile::TempDir;
 
-    fn sample_config(genesis_node: bool, peers: Vec<&str>) -> InitConfig {
+    /// A syntactically valid enode at `host_port` (128-hex pubkey).
+    fn enode(host_port: &str) -> String {
+        format!("enode://{}@{host_port}", "a".repeat(128))
+    }
+
+    fn sample_config(genesis_node: bool) -> InitConfig {
         InitConfig {
-            domain: DomainConfig {
-                email: "ops@example.com".to_string(),
-                name: "node1.example.com".to_string(),
-            },
-            root_key: RootKeyConfig {
-                genesis_node,
-                peers: peers.into_iter().map(String::from).collect(),
-            },
             network: NetworkConfig {
                 manifest_base64: base64::engine::general_purpose::STANDARD.encode(include_bytes!(
                     "../../../crates/network-manifest/fixtures/network-manifest-v1.json"
@@ -133,6 +158,15 @@ mod tests {
                         crate::reth_genesis::tests::FIXTURE_CHAIN_ID,
                     ),
                 ),
+                bootnodes: vec![],
+            },
+            node: NodeConfig {
+                external_ip: "203.0.113.1".to_string(),
+                genesis_node,
+                domain: DomainConfig {
+                    email: "ops@example.com".to_string(),
+                    name: "node1.example.com".to_string(),
+                },
             },
         }
     }
@@ -140,7 +174,8 @@ mod tests {
     #[tokio::test]
     async fn writes_env_files_with_expected_contents() {
         let tmp = TempDir::new().unwrap();
-        let cfg = sample_config(true, vec!["http://10.0.0.1:7878", "http://10.0.0.2:7878"]);
+        let mut cfg = sample_config(true);
+        cfg.network.bootnodes = vec![enode("10.0.0.1:30303"), enode("10.0.0.2:30303")];
 
         write_service_configs(tmp.path(), &cfg).await.unwrap();
 
@@ -153,6 +188,7 @@ mod tests {
         let custodian = std::fs::read_to_string(tmp.path().join("custodian.env")).unwrap();
         assert_eq!(custodian, "SEISMIC_CUSTODIAN_GENESIS_NODE=true\n");
 
+        // The peer list is derived from the bootnode hosts, not delivered.
         let attestation = std::fs::read_to_string(tmp.path().join("attestation.env")).unwrap();
         assert_eq!(
             attestation,
@@ -161,9 +197,9 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn handles_empty_peers() {
+    async fn genesis_node_without_bootnodes_gets_empty_peers() {
         let tmp = TempDir::new().unwrap();
-        let cfg = sample_config(false, vec![]);
+        let cfg = sample_config(true);
 
         write_service_configs(tmp.path(), &cfg).await.unwrap();
 
@@ -172,9 +208,72 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn drops_own_enode_from_peers_but_not_from_reth_bootnodes() {
+        // The persisted founding bootnode set includes this node's own enode;
+        // reth gets the full set while the root-key fetch skips self.
+        let tmp = TempDir::new().unwrap();
+        let mut cfg = sample_config(false);
+        cfg.network.bootnodes = vec![enode("203.0.113.1:30303"), enode("10.0.0.2:30303")];
+
+        write_service_configs(tmp.path(), &cfg).await.unwrap();
+
+        let attestation = std::fs::read_to_string(tmp.path().join("attestation.env")).unwrap();
+        assert_eq!(attestation, "SEISMIC_ROOT_KEY_PEERS=http://10.0.0.2:7878\n");
+
+        let p2p = std::fs::read_to_string(tmp.path().join("reth-p2p.env")).unwrap();
+        assert!(p2p.contains("203.0.113.1:30303"), "{p2p}");
+        assert!(p2p.contains("10.0.0.2:30303"), "{p2p}");
+    }
+
+    #[tokio::test]
+    async fn rejects_joiner_without_peer_source() {
+        let tmp = TempDir::new().unwrap();
+        let cfg = sample_config(false);
+
+        let err = write_service_configs(tmp.path(), &cfg).await.unwrap_err();
+        assert!(matches!(err, crate::error::TdxInitError::InvalidPeers(_)));
+    }
+
+    #[tokio::test]
+    async fn writes_reth_p2p_env_populated() {
+        let tmp = TempDir::new().unwrap();
+        let mut cfg = sample_config(false);
+        cfg.network.bootnodes = vec![enode("10.0.0.1:30303"), enode("10.0.0.2:30303")];
+        cfg.node.external_ip = "203.0.113.7".to_string();
+
+        write_service_configs(tmp.path(), &cfg).await.unwrap();
+
+        let p2p = std::fs::read_to_string(tmp.path().join("reth-p2p.env")).unwrap();
+        let id = "a".repeat(128);
+        assert_eq!(
+            p2p,
+            format!(
+                "RETH_BOOTNODES_FLAG=--bootnodes enode://{id}@10.0.0.1:30303,enode://{id}@10.0.0.2:30303\nRETH_NAT_FLAG=--nat extip:203.0.113.7\n"
+            )
+        );
+    }
+
+    #[tokio::test]
+    async fn writes_reth_p2p_env_without_bootnodes() {
+        // The genesis node has no bootnodes: RETH_BOOTNODES_FLAG is empty so
+        // reth.service's unquoted expansion drops it, while RETH_NAT_FLAG is
+        // still populated from the (required) external_ip.
+        let tmp = TempDir::new().unwrap();
+        let cfg = sample_config(true);
+
+        write_service_configs(tmp.path(), &cfg).await.unwrap();
+
+        let p2p = std::fs::read_to_string(tmp.path().join("reth-p2p.env")).unwrap();
+        assert_eq!(
+            p2p,
+            "RETH_BOOTNODES_FLAG=\nRETH_NAT_FLAG=--nat extip:203.0.113.1\n"
+        );
+    }
+
+    #[tokio::test]
     async fn writes_network_manifest_verbatim() {
         let tmp = TempDir::new().unwrap();
-        let mut cfg = sample_config(false, vec![]);
+        let mut cfg = sample_config(true);
         // A valid manifest with a non-canonical byte (trailing newline): the
         // written file must be the decoded bytes exactly, not a re-rendering.
         let raw = [
@@ -197,7 +296,7 @@ mod tests {
     #[tokio::test]
     async fn writes_reth_genesis_verbatim() {
         let tmp = TempDir::new().unwrap();
-        let cfg = sample_config(false, vec![]);
+        let cfg = sample_config(true);
 
         write_service_configs(tmp.path(), &cfg).await.unwrap();
 
@@ -210,11 +309,16 @@ mod tests {
     #[tokio::test]
     async fn sets_default_mode() {
         let tmp = TempDir::new().unwrap();
-        let cfg = sample_config(false, vec![]);
+        let cfg = sample_config(true);
 
         write_service_configs(tmp.path(), &cfg).await.unwrap();
 
-        for name in ["domain.env", "custodian.env", "attestation.env"] {
+        for name in [
+            "domain.env",
+            "custodian.env",
+            "attestation.env",
+            "reth-p2p.env",
+        ] {
             let meta = std::fs::metadata(tmp.path().join(name)).unwrap();
             let mode = meta.permissions().mode() & 0o777;
             assert_eq!(mode, DEFAULT_FILE_MODE);


### PR DESCRIPTION
The tdx-init slice of the reth devp2p gossip project, plus the wire-schema cleanup it motivated. The config is now two sections split by provenance: `[network]` is coordinator-produced — a function of the network at POST time, never tailored to the recipient — and `[node]` is this node only:
```
    [network]
    manifest_base64     = "..."
    reth_genesis_base64 = "..."
    bootnodes           = ["enode://<128 hex pubkey>@host:port"]

    [node]
    external_ip  = "203.0.113.7"
    genesis_node = false           # optional, default false

    [node.domain]
    name  = "node1.example.com"
    email = "ops@example.com"
```

- New output `reth-p2p.env` for reth.service (loaded via `EnvironmentFile=`; seismic-images slice lands separately): `RETH_BOOTNODES_FLAG` and `RETH_NAT_FLAG` each hold a whole flag or nothing, so the unit's unquoted expansion drops empty vars — the genesis node boots bootnode-less without tripping reth's `--bootnodes ""` parse error. `--nat extip:` is pinned from `[node].external_ip` because Azure NICs hold private addresses and reth's NAT autodetection can't be trusted.
- `[root_key]` is gone. `genesis_node` moves to `[node]` (still defaulting to false: an omitted flag must never mint a second root_key), and `peers` is no longer a config field at all — the root-key fetch list is derived from `[network].bootnodes` as `http://<host>:7878`, with the node's own enode dropped (IpAddr equality, so non-canonical IPv6 spellings match; DNS hosts never do — tdx-init doesn't resolve). Bootnodes and root-key peers are the same machines by construction, so deriving one list from the other makes skew between them unrepresentable and renders the port convention in exactly one place.
- POST-time validation fails closed (`src/peers.rs`, 400): enode shape, `external_ip` parses as an IP, and a `genesis_node = false` config must end up with at least one derived peer — previously a peerless joiner only surfaced when the attestation service failed at startup. `bootnodes = []` stays valid on the genesis node (nothing to dial; it mints root_key itself).

Breaking for the deploy CLI (old-schema POSTs 400 via deny_unknown_fields, by design): it must send the new shape in the same rollout, and stops assembling `http://ip:7878` peer lists entirely.