### PR TITLE
test(measurement-admission): ABI parity for the full registry interface

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,9 +47,9 @@ jobs:
       # the native tpm2-tss libraries; GitHub-hosted runners don't ship them.
       - name: Install TPM build dependencies
         run: sudo apt-get update && sudo apt-get install -y libtss2-dev
-      # Keep the registry client's one-method read interface tied to the
-      # canonical artifact that feeds reth genesis. The artifact remains owned
-      # by the seismic repo; this checkout prevents a second local ABI copy.
+      # Keep the Rust registry interfaces and the registry runtime-code pin tied
+      # to the canonical artifact that feeds reth genesis. The artifact remains
+      # owned by the seismic repo; this checkout prevents a local ABI copy.
       - name: Check out canonical MeasurementRegistry artifact
         uses: actions/checkout@v4
         with:
@@ -72,10 +72,16 @@ jobs:
           cargo test --workspace
           --exclude seismic-attestation-service
           --exclude seismic-measurement-admission
+      # Both parity targets read the same artifact and need no seismic-reth
+      # binary, so they run here rather than in measurement_admission_tests:
+      # the client's runtime read binding, and the admission crate's full
+      # protocol interface plus its registry runtime-code pin.
       - name: Check MeasurementRegistry ABI parity
         env:
           MEASUREMENT_REGISTRY_ARTIFACT: ${{ github.workspace }}/.context/seismic/contracts/artifacts/MeasurementRegistry.json
-        run: cargo test -p seismic-measurement-registry-client --test abi_parity -- --ignored
+        run: >-
+          cargo test -p seismic-measurement-registry-client --test abi_parity -- --ignored
+          && cargo test -p seismic-measurement-admission --test registry_abi -- --ignored
       - name: Run attestation-service unit tests
         run: cargo test -p seismic-attestation-service --lib --bins
 

--- a/crates/measurement-admission/tests/common/mod.rs
+++ b/crates/measurement-admission/tests/common/mod.rs
@@ -1,0 +1,39 @@
+//! Shared `sol!` bindings for the registry test suites.
+//!
+//! `IMeasurementRegistry` mirrors the full protocol surface of the canonical
+//! `MeasurementRegistry` contract — `registry_abi.rs` holds its selector set
+//! equal to the canonical artifact's ABI, so the mutating functions belong here
+//! even though only `reth_registry.rs`'s authority path exercises them.
+//! Enclave *runtime* code reaches the registry through
+//! `seismic-measurement-registry-client`'s narrow read-only binding instead.
+
+#![allow(dead_code)]
+
+use alloy::sol;
+
+sol! {
+    #[sol(rpc)]
+    interface IMeasurementRegistry {
+        function AUTHORITY() external view returns (address);
+        function isAccepted(bytes32 admissionId) external view returns (bool);
+        function statusOf(bytes32 admissionId) external view returns (uint8);
+        function bootstrapPolicyHash() external view returns (bytes32);
+        function activePolicyHash() external view returns (bytes32);
+        function policyRevision() external view returns (uint64);
+        function acceptedCount() external view returns (uint256);
+        function applyPolicyUpdate(
+            bytes32[] calldata accept,
+            bytes32[] calldata deprecate,
+            bytes32 newActivePolicyHash
+        ) external;
+    }
+
+    #[sol(rpc)]
+    interface IMeasurementAuthorityDev {
+        function applyPolicyUpdate(
+            bytes32[] calldata accept,
+            bytes32[] calldata deprecate,
+            bytes32 newActivePolicyHash
+        ) external;
+    }
+}

--- a/crates/measurement-admission/tests/registry_abi.rs
+++ b/crates/measurement-admission/tests/registry_abi.rs
@@ -1,0 +1,133 @@
+//! Selector parity between the enclave Rust registry interface and the
+//! canonical Solidity artifact
+//! (https://github.com/SeismicSystems/seismic/blob/main/contracts/artifacts/MeasurementRegistry.json).
+//!
+//! The artifact stays owned by the seismic repo: CI checks it out and points
+//! `MEASUREMENT_REGISTRY_ARTIFACT` at it — the same env var
+//! `seismic-measurement-registry-client`'s `abi_parity` test reads — so no
+//! local ABI copy exists to go stale. Fetching is what makes these checks
+//! meaningful: a committed copy could only show that this crate agrees with
+//! the artifact it last saw, never that it agrees with the canonical one.
+//!
+//! With `reth_registry.rs` tying the genesis template's registry code to
+//! [`REGISTRY_RUNTIME_CODE_HASH`], this closes the chain `genesis template
+//! code <-> REGISTRY_RUNTIME_CODE_HASH <-> canonical artifact`: the ABI checked
+//! here belongs to the exact runtime the chain installs, and an upstream
+//! contract rebuild surfaces as a failure rather than a silent re-pin.
+
+mod common;
+
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    env, fs,
+    path::PathBuf,
+};
+
+use alloy::primitives::keccak256;
+use common::IMeasurementRegistry::IMeasurementRegistryCalls;
+use seismic_measurement_admission::genesis::REGISTRY_RUNTIME_CODE_HASH;
+
+const CANONICAL_ARTIFACT_ENV: &str = "MEASUREMENT_REGISTRY_ARTIFACT";
+
+/// The protocol signatures [`common::IMeasurementRegistry`] is expected to
+/// declare, pinned so that editing the interface fails locally instead of only
+/// once CI supplies the canonical artifact.
+const PINNED_SIGNATURES: [&str; 8] = [
+    "AUTHORITY()",
+    "acceptedCount()",
+    "activePolicyHash()",
+    "applyPolicyUpdate(bytes32[],bytes32[],bytes32)",
+    "bootstrapPolicyHash()",
+    "isAccepted(bytes32)",
+    "policyRevision()",
+    "statusOf(bytes32)",
+];
+
+fn selector_of(signature: &str) -> [u8; 4] {
+    keccak256(signature.as_bytes())[..4]
+        .try_into()
+        .expect("4-byte selector")
+}
+
+fn canonical_artifact() -> serde_json::Value {
+    let path = PathBuf::from(env::var_os(CANONICAL_ARTIFACT_ENV).unwrap_or_else(|| {
+        panic!("{CANONICAL_ARTIFACT_ENV} must point to MeasurementRegistry.json")
+    }));
+    let bytes = fs::read(&path)
+        .unwrap_or_else(|error| panic!("failed to read {}: {error}", path.display()));
+    serde_json::from_slice(&bytes)
+        .unwrap_or_else(|error| panic!("failed to parse {}: {error}", path.display()))
+}
+
+#[test]
+fn interface_selectors_are_pinned() {
+    let pinned: BTreeSet<[u8; 4]> = PINNED_SIGNATURES.iter().copied().map(selector_of).collect();
+    let declared: BTreeSet<[u8; 4]> = IMeasurementRegistryCalls::SELECTORS
+        .iter()
+        .copied()
+        .collect();
+    assert_eq!(
+        pinned, declared,
+        "IMeasurementRegistry no longer declares exactly the pinned protocol signatures"
+    );
+}
+
+/// CI checks out `SeismicSystems/seismic` and points this test at its committed
+/// canonical artifact. It is ignored in an ordinary local run because the
+/// artifact intentionally remains in its owning repository.
+#[test]
+#[ignore = "CI supplies the canonical seismic/contracts artifact"]
+fn runtime_code_pin_matches_canonical_artifact() {
+    let code_hex = canonical_artifact()["deployedBytecode"]["object"]
+        .as_str()
+        .expect("deployedBytecode.object")
+        .to_owned();
+    let code = hex::decode(code_hex.trim_start_matches("0x")).expect("runtime code hex");
+    assert_eq!(
+        keccak256(&code),
+        REGISTRY_RUNTIME_CODE_HASH,
+        "REGISTRY_RUNTIME_CODE_HASH drifted from the canonical registry build; \
+         re-pin it alongside the compiled fixture and the genesis template"
+    );
+}
+
+#[test]
+#[ignore = "CI supplies the canonical seismic/contracts artifact"]
+fn rust_interface_selectors_match_canonical_abi() {
+    let identifiers: BTreeMap<String, String> =
+        serde_json::from_value(canonical_artifact()["methodIdentifiers"].clone())
+            .expect("methodIdentifiers");
+    let mut artifact_selectors: BTreeMap<[u8; 4], String> = BTreeMap::new();
+    for (signature, selector) in identifiers {
+        // Forge's methodIdentifiers are derived from the signature; recompute
+        // rather than trust the artifact's own consistency.
+        let selector: [u8; 4] = hex::decode(&selector)
+            .expect("selector hex")
+            .try_into()
+            .expect("4-byte selector");
+        assert_eq!(
+            selector_of(&signature),
+            selector,
+            "artifact selector for `{signature}` is not the keccak of its signature"
+        );
+        artifact_selectors.insert(selector, signature);
+    }
+
+    for (selector, signature) in &artifact_selectors {
+        assert!(
+            IMeasurementRegistryCalls::SELECTORS.contains(selector),
+            "canonical ABI function `{signature}` is missing from the Rust \
+             IMeasurementRegistry interface"
+        );
+    }
+    let unknown: Vec<String> = IMeasurementRegistryCalls::SELECTORS
+        .iter()
+        .filter(|selector| !artifact_selectors.contains_key(*selector))
+        .map(hex::encode)
+        .collect();
+    assert!(
+        unknown.is_empty(),
+        "Rust IMeasurementRegistry interface declares selectors absent from the \
+         canonical ABI: {unknown:?}"
+    );
+}

--- a/crates/measurement-admission/tests/reth_registry.rs
+++ b/crates/measurement-admission/tests/reth_registry.rs
@@ -29,33 +29,14 @@ use alloy::{
     primitives::{Address, B256, U256, address, keccak256},
     providers::{Provider, ProviderBuilder},
     signers::local::PrivateKeySigner,
-    sol,
 };
 use seismic_measurement_admission::{
     compile_policy,
     genesis::{REGISTRY_RUNTIME_CODE_HASH, registry_genesis_storage},
 };
 
-sol! {
-    #[sol(rpc)]
-    interface IMeasurementRegistry {
-        function isAccepted(bytes32 admissionId) external view returns (bool);
-        function statusOf(bytes32 admissionId) external view returns (uint8);
-        function bootstrapPolicyHash() external view returns (bytes32);
-        function activePolicyHash() external view returns (bytes32);
-        function policyRevision() external view returns (uint64);
-        function acceptedCount() external view returns (uint256);
-    }
-
-    #[sol(rpc)]
-    interface IMeasurementAuthorityDev {
-        function applyPolicyUpdate(
-            bytes32[] calldata accept,
-            bytes32[] calldata deprecate,
-            bytes32 newActivePolicyHash
-        ) external;
-    }
-}
+mod common;
+use common::{IMeasurementAuthorityDev, IMeasurementRegistry};
 
 const REGISTRY: Address = address!("0x1000000000000000000000000000000000000001");
 const AUTHORITY: Address = address!("0x1000000000000000000000000000000000000002");


### PR DESCRIPTION
Share one `sol!` interface between the two registry test suites and hold its
selector set equal to the canonical `MeasurementRegistry` ABI, so the Rust view
of the contract cannot drift from the build the chain installs.

## What changed

- `tests/common/mod.rs` carries the full eight-function protocol interface,
  replacing the two inline interfaces in `reth_registry.rs`. Parity is asserted
  as set equality, so the mutating functions belong there; enclave runtime code
  still reaches the registry through the narrow read-only binding in
  `seismic-measurement-registry-client`.
- `tests/registry_abi.rs` reads the canonical artifact from
  `MEASUREMENT_REGISTRY_ARTIFACT` — the `SeismicSystems/seismic` sparse checkout
  already present in the `tests` job — so the enclave keeps no local ABI copy. A
  committed copy could only show agreement with the artifact it last saw, never
  with the canonical one.
- It recomputes each `methodIdentifiers` entry from its signature rather than
  trusting the artifact's own consistency, requires that selector set to equal
  the interface's, and ties `REGISTRY_RUNTIME_CODE_HASH` to the artifact's
  `deployedBytecode`. That last assertion gives the enclave its own detector for
  an upstream contract rebuild; previously only the monorepo's
  `MeasurementRegistry.t.sol` caught one.
- A non-ignored companion pins the eight signatures, so editing the interface
  fails on a plain `cargo test` without needing the artifact.
- CI runs both parity targets from the existing checkout step. Neither needs a
  `seismic-reth` binary, so they stay in the `tests` job.

## Follow-ups / suggestions

Not settled — worth discussing before anyone acts on it. Nothing here blocks
this PR; the checks are correct as they stand.

The tests in `registry_abi.rs` are two different kinds of check sharing one
file, separated only by `#[ignore]`:

|  | operands | property |
|---|---|---|
| signature pin ↔ `sol!` selectors; committed genesis-template code ↔ `REGISTRY_RUNTIME_CODE_HASH` | both in-tree | reproducible, bisectable, no network; a failure means someone edited *this* repo |
| pins ↔ canonical artifact | one out-of-tree, at a moving ref | time-dependent — the same commit can pass today and fail tomorrow; a failure usually means someone edited the *other* repo |

Possible cleanup, roughly in order of confidence:

1. **Move the template-code assertion out of `reth_registry.rs`.** "Committed
   genesis template matches the runtime pin" has nothing to do with booting a
   node, and as an inline assert inside `launch_seeded_node` it only runs when a
   `seismic-reth` binary is present. As a standalone test in `registry_abi.rs` it
   would run unconditionally — a strict coverage gain.
2. **Consider splitting the per-PR gate from a scheduled canary.** The
   artifact-backed assertions follow the monorepo's default branch, so making
   them a PR gate means an unrelated enclave PR can go red for a change in
   another repo. Note the monorepo's own `MeasurementRegistry.t.sol` already
   catches a rebuild at the rebuild site, on the PR that causes it — so these
   assertions are redundancy with worse attribution, which argues for a nightly
   canary rather than a gate.
3. **Reconsider how the artifact is located.** `#[ignore]` currently does double
   duty as "needs an external input" and "isn't really a gate", and it means the
   check silently stops running if the CI step is ever renamed or dropped. Having
   the test find or fetch the artifact itself would fix that and remove the
   YAML-owned input, but it trades against reproducibility: a fetch has to name a
   ref, and pinning a SHA proves the same thing as vendoring the bytes while
   adding a network dependency. A hardcoded sibling-checkout path is not the
   answer either — it bakes a machine layout assumption into source.
4. **`seismic-measurement-registry-client`'s `abi_parity` has the same shape**
   and would want whatever treatment lands here.
