### PR TITLE
feat(tdx-init)!: deliver the summit genesis; pin it with summit's config_digest

### DIFF
--- a/bin/tdx-init/README.md
+++ b/bin/tdx-init/README.md
@@ -35,6 +35,7 @@ Unknown top-level sections or fields are rejected — see
 [network]                            # coordinator-produced; a function of the network, not of this node
 manifest_base64 = "eyJib290c3RyYXBfbWVhc3VyZW1lbn..."
 reth_genesis_base64 = "eyJjb25maWciOnsiY2hhaW5JZCI..."
+summit_genesis_base64 = "bmFtZXNwYWNlID0gInNlaXNtaWM..."
 bootnodes = ["enode://<128 hex pubkey>@host:port"]  # the cohort's peers; [] only on the genesis node
 
 [node]                               # this node only
@@ -54,7 +55,12 @@ verbatim to `network-manifest.json`, never parse-and-re-serialize. The
 deploy tool's manifest-assembly step produces the value; the schema's
 authoritative parser is the sibling
 [`seismic-attestation`](../../crates/attestation) crate, kept in lockstep
-with this crate via its shared fixture.
+with this crate via its shared fixture. It is also the document that pins the
+other two `[network]` artifacts — `eth.genesis_hash` commits to
+`reth_genesis_base64`'s bytes and `summit.genesis_config_digest` to
+`summit_genesis_base64`'s — so the three are one assembled set: pairing a
+manifest with a genesis it doesn't pin produces a node that can't join the
+cohort it claims to belong to.
 
 `reth_genesis_base64` carries the reth genesis JSON (chain spec) every
 node's reth boots from. It is network-wide like the manifest, whose
@@ -64,6 +70,21 @@ so POST-time validation is structural: valid JSON whose `config.chainId`
 matches the manifest's `eth.chain_id`. The block-hash commitment is
 enforced deploy-side and at ceremony time; see `src/reth_genesis.rs`.
 Written verbatim to `reth-genesis.json`.
+
+`summit_genesis_base64` carries the summit genesis TOML — the consensus-layer
+genesis every node's summit boots from. It is complete at delivery (the
+founding ceremony harvests the validator set into it before the POST), and the
+manifest's `summit.genesis_config_digest` pins it: summit's own SHA-256 over a
+domain-prefixed SSZ serialization of the genesis, covering the consensus
+parameters and every validator's node/consensus pubkeys and withdrawal
+credentials, but not `ip_address`. tdx-init cannot recompute that digest
+without reimplementing summit's SSZ layout, and doesn't need to — deploy
+verifies it against the manifest pin before POSTing, and summit derives its
+P2P and signing domains from `chain_domain(config_digest)`, so a node fed a
+divergent genesis can't complete a handshake. POST-time validation is
+therefore structural, like the reth half: valid TOML whose `namespace` matches
+the manifest's `summit.namespace` (`src/summit_genesis.rs`). Written verbatim
+to `summit-genesis.toml`.
 
 `[network].bootnodes` is the network-wide devp2p bootnode list — the single
 source for the cohort's peer machines. It feeds reth verbatim (rendered into
@@ -93,6 +114,7 @@ After validation, tdx-init writes:
 | `/run/seismic/conf/attestation.env` | `SEISMIC_ROOT_KEY_PEERS=...` | `attestation.service` (seismic-images) — loaded via `EnvironmentFile=`; [`seismic-attestation-service`](../attestation-service) reads the peer list through clap `env=`. Derived from `[network].bootnodes`, not a config field |
 | `/run/seismic/conf/network-manifest.json` | verbatim manifest bytes | [`seismic-attestation-service`](../attestation-service) — hashes the file itself to derive `network_id` for attestation bindings |
 | `/run/seismic/conf/reth-genesis.json` | verbatim reth genesis bytes | `reth.service` (seismic-images) — passed to `seismic-reth node --chain` |
+| `/run/seismic/conf/summit-genesis.toml` | verbatim summit genesis bytes | `summit.service` (seismic-images) — passed to `summit --genesis-path` |
 | `/run/seismic/conf/reth-p2p.env` | `RETH_BOOTNODES_FLAG=...`, `RETH_NAT_FLAG=...` | `reth.service` (seismic-images) — loaded via `EnvironmentFile=`; each var holds a whole flag (`--bootnodes <csv>` / `--nat extip:<ip>`) or is empty, and the unit places the unquoted `$RETH_BOOTNODES_FLAG $RETH_NAT_FLAG` on the command line so empty vars drop out |
 
 Each downstream service reads its own native format (env-var pairs,

--- a/bin/tdx-init/src/config.rs
+++ b/bin/tdx-init/src/config.rs
@@ -9,8 +9,8 @@ use serde::{Deserialize, Serialize};
 /// while `[node]` is this node only. Network-indexed is weaker than
 /// cohort-identical: the bootnode set evolves as the network does (empty at
 /// greenfield stage 1), so nodes configured at different times hold
-/// different snapshots; only the manifest and reth genesis must truly match
-/// across the cohort — differing bytes there mean a different network.
+/// different snapshots; only the manifest and the two genesis files must truly
+/// match across the cohort — differing bytes there mean a different network.
 /// Anything derivable from these is derived rather than delivered twice —
 /// e.g. the root-key fetch peers come from `[network].bootnodes`
 /// (`src/peers.rs`), so there is no second list that could skew from it.
@@ -53,6 +53,20 @@ pub struct DomainConfig {
 pub struct NetworkConfig {
     /// base64 (standard alphabet) of the network-manifest.json bytes, as
     /// emitted by the deploy tool's manifest assembly step.
+    ///
+    /// This document is also what pins the other two `[network]` artifacts:
+    /// `eth.genesis_hash` commits to the reth genesis carried in
+    /// `reth_genesis_base64`, and `summit.genesis_config_digest` to the summit
+    /// genesis in `summit_genesis_base64`. The three fields are therefore one
+    /// assembled set rather than three independent values — pairing a manifest
+    /// with a genesis it doesn't pin yields a node that can't join the cohort
+    /// it claims to belong to (a reth genesis block hash its peers reject, or a
+    /// summit `chain_domain` no handshake matches). tdx-init doesn't recompute
+    /// either commitment in-process — that would need reth's own chain-spec
+    /// parse path and summit's SSZ implementation — so it enforces the cheap
+    /// fields the manifest duplicates for exactly this purpose (`eth.chain_id`,
+    /// `summit.namespace`) and leaves the hashes to deploy, which verifies both
+    /// before POSTing.
     pub manifest_base64: String,
 
     /// base64 encoding of the reth genesis JSON — the chain spec
@@ -64,6 +78,19 @@ pub struct NetworkConfig {
     /// (`src/reth_genesis.rs`) and written verbatim to `reth-genesis.json`
     /// under [`crate::CONF_DIR`].
     pub reth_genesis_base64: String,
+
+    /// base64 encoding of the summit genesis TOML — the consensus-layer
+    /// genesis every node's summit boots from
+    /// (`--genesis-path /run/seismic/conf/summit-genesis.toml`). Network-wide
+    /// like the reth genesis, and complete at delivery: the founding ceremony
+    /// harvests the validator set into it before the POST, and the manifest's
+    /// `summit.genesis_config_digest` pins the result. Required because a node
+    /// booted without it has no consensus genesis and its summit blocks
+    /// forever — late joiners need it just as much as the founders do.
+    /// Validated structurally at POST time against the manifest's
+    /// `summit.namespace` (`src/summit_genesis.rs`) and written verbatim to
+    /// `summit-genesis.toml` under [`crate::CONF_DIR`].
+    pub summit_genesis_base64: String,
 
     /// Network-wide devp2p bootnodes, as `enode://<128 hex pubkey>@host:port`
     /// URLs — the single source for the cohort's peer machines. Feeds reth
@@ -116,6 +143,7 @@ mod tests {
 [network]
 manifest_base64 = "eyJtYW5pZmVzdF92ZXJzaW9uIjogMX0K"
 reth_genesis_base64 = "eyJjb25maWciOnt9fQ=="
+summit_genesis_base64 = "bmFtZXNwYWNlID0gIl9TVU1NSVQiCg=="
 bootnodes = ["enode://abc@10.0.0.1:30303", "enode://def@10.0.0.2:30303"]
 
 [node]
@@ -146,6 +174,7 @@ email = "ops@example.com"
 [network]
 manifest_base64 = "eyJtYW5pZmVzdF92ZXJzaW9uIjogMX0K"
 reth_genesis_base64 = "eyJjb25maWciOnt9fQ=="
+summit_genesis_base64 = "bmFtZXNwYWNlID0gIl9TVU1NSVQiCg=="
 bootnodes = []
 
 [node]
@@ -167,6 +196,7 @@ email = "ops@example.com"
 [network]
 manifest_base64 = "eyJtYW5pZmVzdF92ZXJzaW9uIjogMX0K"
 reth_genesis_base64 = "eyJjb25maWciOnt9fQ=="
+summit_genesis_base64 = "bmFtZXNwYWNlID0gIl9TVU1NSVQiCg=="
 bootnodes = []
 
 [node]
@@ -187,6 +217,7 @@ email = "ops@example.com"
 [network]
 manifest_base64 = "eyJtYW5pZmVzdF92ZXJzaW9uIjogMX0K"
 reth_genesis_base64 = "eyJjb25maWciOnt9fQ=="
+summit_genesis_base64 = "bmFtZXNwYWNlID0gIl9TVU1NSVQiCg=="
 
 [node]
 external_ip = "203.0.113.7"
@@ -206,6 +237,7 @@ email = "ops@example.com"
         let toml_input = r#"
 [network]
 manifest_base64 = "eyJtYW5pZmVzdF92ZXJzaW9uIjogMX0K"
+summit_genesis_base64 = "bmFtZXNwYWNlID0gIl9TVU1NSVQiCg=="
 bootnodes = []
 
 [node]
@@ -217,6 +249,28 @@ email = "ops@example.com"
 "#;
         let err = toml::from_str::<InitConfig>(toml_input).unwrap_err();
         assert!(err.to_string().contains("reth_genesis_base64"));
+    }
+
+    #[test]
+    fn requires_summit_genesis_field() {
+        // Same rule as the reth half: without the consensus genesis the POST
+        // must 400, not produce a node whose summit blocks forever waiting
+        // for a genesis file that never arrives.
+        let toml_input = r#"
+[network]
+manifest_base64 = "eyJtYW5pZmVzdF92ZXJzaW9uIjogMX0K"
+reth_genesis_base64 = "eyJjb25maWciOnt9fQ=="
+bootnodes = []
+
+[node]
+external_ip = "203.0.113.7"
+
+[node.domain]
+name = "node1.example.com"
+email = "ops@example.com"
+"#;
+        let err = toml::from_str::<InitConfig>(toml_input).unwrap_err();
+        assert!(err.to_string().contains("summit_genesis_base64"));
     }
 
     #[test]
@@ -240,6 +294,7 @@ email = "ops@example.com"
 [network]
 manifest_base64 = "eyJtYW5pZmVzdF92ZXJzaW9uIjogMX0K"
 reth_genesis_base64 = "eyJjb25maWciOnt9fQ=="
+summit_genesis_base64 = "bmFtZXNwYWNlID0gIl9TVU1NSVQiCg=="
 bootnodes = []
 "#;
         let err = toml::from_str::<InitConfig>(toml_input).unwrap_err();
@@ -252,6 +307,7 @@ bootnodes = []
 [network]
 manifest_base64 = "eyJtYW5pZmVzdF92ZXJzaW9uIjogMX0K"
 reth_genesis_base64 = "eyJjb25maWciOnt9fQ=="
+summit_genesis_base64 = "bmFtZXNwYWNlID0gIl9TVU1NSVQiCg=="
 bootnodes = []
 
 [node]
@@ -269,6 +325,7 @@ email = "ops@example.com"
 [network]
 manifest_base64 = "eyJtYW5pZmVzdF92ZXJzaW9uIjogMX0K"
 reth_genesis_base64 = "eyJjb25maWciOnt9fQ=="
+summit_genesis_base64 = "bmFtZXNwYWNlID0gIl9TVU1NSVQiCg=="
 bootnodes = []
 
 [node]
@@ -284,6 +341,7 @@ external_ip = "203.0.113.7"
 [network]
 manifest_base64 = "eyJ9"
 reth_genesis_base64 = "eyJjb25maWciOnt9fQ=="
+summit_genesis_base64 = "bmFtZXNwYWNlID0gIl9TVU1NSVQiCg=="
 bootnodes = []
 network_id = "0xabcd"
 
@@ -304,6 +362,7 @@ email = "ops@example.com"
 [network]
 manifest_base64 = "eyJ9"
 reth_genesis_base64 = "eyJjb25maWciOnt9fQ=="
+summit_genesis_base64 = "bmFtZXNwYWNlID0gIl9TVU1NSVQiCg=="
 bootnodes = []
 
 [node]
@@ -330,6 +389,7 @@ genesis_node = true
 [network]
 manifest_base64 = "eyJ9"
 reth_genesis_base64 = "eyJjb25maWciOnt9fQ=="
+summit_genesis_base64 = "bmFtZXNwYWNlID0gIl9TVU1NSVQiCg=="
 bootnodes = []
 
 [node]
@@ -349,6 +409,7 @@ email = "ops@example.com"
 [network]
 manifest_base64 = "eyJ9"
 reth_genesis_base64 = "eyJjb25maWciOnt9fQ=="
+summit_genesis_base64 = "bmFtZXNwYWNlID0gIl9TVU1NSVQiCg=="
 bootnodes = []
 
 [node]

--- a/bin/tdx-init/src/error.rs
+++ b/bin/tdx-init/src/error.rs
@@ -15,6 +15,9 @@ pub enum TdxInitError {
     #[error("invalid reth genesis: {0}")]
     InvalidRethGenesis(String),
 
+    #[error("invalid summit genesis: {0}")]
+    InvalidSummitGenesis(String),
+
     #[error("invalid peer config: {0}")]
     InvalidPeers(String),
 
@@ -37,6 +40,10 @@ impl IntoResponse for TdxInitError {
             TdxInitError::InvalidRethGenesis(msg) => (
                 StatusCode::BAD_REQUEST,
                 format!("invalid reth genesis: {msg}"),
+            ),
+            TdxInitError::InvalidSummitGenesis(msg) => (
+                StatusCode::BAD_REQUEST,
+                format!("invalid summit genesis: {msg}"),
             ),
             TdxInitError::InvalidPeers(msg) => (
                 StatusCode::BAD_REQUEST,

--- a/bin/tdx-init/src/main.rs
+++ b/bin/tdx-init/src/main.rs
@@ -10,6 +10,7 @@ mod manifest;
 mod peers;
 mod reth_genesis;
 mod server;
+mod summit_genesis;
 mod writer;
 
 /// Per-service env file drop-zone. Lives on tmpfs (cleared each boot),

--- a/bin/tdx-init/src/manifest.rs
+++ b/bin/tdx-init/src/manifest.rs
@@ -24,6 +24,7 @@ use tracing::info;
 pub struct ValidatedManifest {
     pub bytes: Vec<u8>,
     pub chain_id: u64,
+    pub namespace: String,
 }
 
 /// Decode the `[network].manifest_base64` embed and strictly validate it.
@@ -53,6 +54,7 @@ pub fn decode_and_validate(manifest_base64: &str) -> Result<ValidatedManifest> {
     Ok(ValidatedManifest {
         bytes,
         chain_id: manifest.eth.chain_id,
+        namespace: manifest.summit.namespace,
     })
 }
 
@@ -73,7 +75,7 @@ mod tests {
     const FIXTURE: &[u8] =
         include_bytes!("../../../crates/network-manifest/fixtures/network-manifest-v1.json");
     const FIXTURE_NETWORK_ID: &str =
-        "0xc4d4721b2e287df26022e6d27c8cf772841a872b6be08b1938cbc76d88703747";
+        "0x8ef142e3f2bf15f8b201c4d8cda7848a9e846222c62b5615d4d36c7fccd98a24";
 
     fn b64(bytes: &[u8]) -> String {
         base64::engine::general_purpose::STANDARD.encode(bytes)
@@ -85,6 +87,7 @@ mod tests {
         assert_eq!(manifest.bytes, FIXTURE, "decoded bytes must be verbatim");
         assert_eq!(network_id_hex(&manifest.bytes), FIXTURE_NETWORK_ID);
         assert_eq!(manifest.chain_id, 5124);
+        assert_eq!(manifest.namespace, "seismic-devnet-3");
     }
 
     #[test]

--- a/bin/tdx-init/src/reth_genesis.rs
+++ b/bin/tdx-init/src/reth_genesis.rs
@@ -6,8 +6,8 @@
 //! network. The manifest's `eth.genesis_hash = keccak(rlp(header))` pins the
 //! file's genesis *block* — the header and, through the state root, the
 //! alloc — but not its `config` section (fork schedule), which lies outside
-//! the header. tdx-init also cannot recompute that hash (it would need
-//! reth's own chain-spec parse path), so POST-time validation here is
+//! the header. tdx-init also does not recompute that hash in-process (it
+//! would need reth's own chain-spec parse path), so POST-time validation here is
 //! structural: valid JSON whose `config.chainId` matches the manifest's
 //! `eth.chain_id`. The block-hash commitment is enforced deploy-side
 //! (`manifest assemble` shells out to `seismic-reth genesis-hash`) and again
@@ -37,6 +37,12 @@ struct GenesisConfigProbe {
 /// Decode the `[network].reth_genesis_base64` embed and validate it against
 /// the validated manifest's `eth.chain_id`. Returns the exact genesis bytes
 /// to write — callers must not transform them further.
+///
+/// Deliberately unchecked: `eth.genesis_hash`. Verifying it here is possible —
+/// shell out to `seismic-reth genesis-hash`, or link reth's chain-spec stack —
+/// but both add a dependency this boot-time translator doesn't otherwise carry
+/// (the image's binary layout, or reth's crates). The module docs cover why the
+/// structural check suffices.
 pub fn decode_and_validate(reth_genesis_base64: &str, manifest_chain_id: u64) -> Result<Vec<u8>> {
     // Be forgiving about transport-layer line wrapping (PEM-style); this
     // changes nothing about the decoded bytes.

--- a/bin/tdx-init/src/server.rs
+++ b/bin/tdx-init/src/server.rs
@@ -66,13 +66,17 @@ async fn handle_config(State(state): State<AppState>, body: String) -> Result<Re
     let config: InitConfig = toml::from_str(&body)?;
 
     // Validate the network artifacts while the operator's POST is still
-    // waiting on a response: a bad (or absent) manifest, reth genesis, or peer
-    // config must 400 the deploy, not fail at boot when the attestation
-    // service/reth try to use them.
+    // waiting on a response: a bad (or absent) manifest, reth genesis, summit
+    // genesis, or peer config must 400 the deploy, not fail at boot when the
+    // attestation service/reth/summit try to use them.
     let manifest = crate::manifest::decode_and_validate(&config.network.manifest_base64)?;
     crate::reth_genesis::decode_and_validate(
         &config.network.reth_genesis_base64,
         manifest.chain_id,
+    )?;
+    crate::summit_genesis::decode_and_validate(
+        &config.network.summit_genesis_base64,
+        &manifest.namespace,
     )?;
     crate::peers::validate_and_derive_peers(&config.node, &config.network.bootnodes)?;
 

--- a/bin/tdx-init/src/summit_genesis.rs
+++ b/bin/tdx-init/src/summit_genesis.rs
@@ -1,0 +1,154 @@
+//! summit-genesis validation at POST time.
+//!
+//! The summit genesis TOML is the consensus-layer genesis every node's summit
+//! boots from (`--genesis-path /run/seismic/conf/summit-genesis.toml`). Unlike
+//! a template, it is complete at delivery: the founding ceremony harvests the
+//! validator set into it before the config POST, so it is identical on every
+//! node of a network and re-POSTed verbatim on every boot, exactly like
+//! `reth-genesis.json`.
+//!
+//! The manifest's `summit.genesis_config_digest` pins the file — but tdx-init
+//! deliberately does *not* recompute it. That digest is SHA-256 over summit's
+//! own domain-prefixed SSZ serialization, so recomputing it in-process here
+//! would mean reimplementing summit's SSZ layout, and a divergence between the two
+//! implementations would reject valid deployments. It isn't needed either:
+//! deploy verifies the digest against the manifest pin before POSTing, and
+//! summit derives its P2P and signing domains from
+//! `chain_domain(config_digest)`, so a node fed a divergent genesis cannot
+//! complete a handshake with the cohort. POST-time validation here is
+//! structural, exactly like the reth half (which cannot recompute
+//! `keccak(rlp(header))` either): valid TOML whose `namespace` matches the
+//! manifest's `summit.namespace`.
+//!
+//! Like the manifest, the file travels base64-encoded and is written
+//! verbatim — summit parses it itself, so tdx-init must not re-render it.
+
+use crate::error::{Result, TdxInitError};
+use base64::Engine;
+use serde::Deserialize;
+use tracing::info;
+
+/// Minimal probe: only the cross-checked field is parsed. The genesis
+/// schema belongs to summit — it is not re-validated here.
+#[derive(Deserialize)]
+struct GenesisProbe {
+    namespace: String,
+}
+
+/// Decode the `[network].summit_genesis_base64` embed and validate it against
+/// the validated manifest's `summit.namespace`. Returns the exact genesis bytes
+/// to write — callers must not transform them further.
+///
+/// Deliberately unchecked: `summit.genesis_config_digest`. Verifying it here is
+/// possible — shell out to the summit binary, or link its SSZ serialization —
+/// but both add a dependency this boot-time translator doesn't otherwise carry
+/// (the image's binary layout, or summit's crates). The module docs cover why
+/// the structural check suffices.
+pub fn decode_and_validate(
+    summit_genesis_base64: &str,
+    manifest_namespace: &str,
+) -> Result<Vec<u8>> {
+    // Be forgiving about transport-layer line wrapping (PEM-style); this
+    // changes nothing about the decoded bytes.
+    let stripped: String = summit_genesis_base64
+        .chars()
+        .filter(|c| !c.is_ascii_whitespace())
+        .collect();
+    let bytes = base64::engine::general_purpose::STANDARD
+        .decode(stripped)
+        .map_err(|e| {
+            TdxInitError::InvalidSummitGenesis(format!(
+                "summit_genesis_base64 is not valid base64: {e}"
+            ))
+        })?;
+
+    let text = std::str::from_utf8(&bytes).map_err(|e| {
+        TdxInitError::InvalidSummitGenesis(format!(
+            "not a summit genesis TOML document: bytes are not valid UTF-8: {e}"
+        ))
+    })?;
+    let genesis: GenesisProbe = toml::from_str(text).map_err(|e| {
+        TdxInitError::InvalidSummitGenesis(format!(
+            "not a summit genesis TOML document with a string namespace: {e}"
+        ))
+    })?;
+    if genesis.namespace != manifest_namespace {
+        return Err(TdxInitError::InvalidSummitGenesis(format!(
+            "namespace {:?} does not match the manifest's summit.namespace {:?}",
+            genesis.namespace, manifest_namespace
+        )));
+    }
+
+    info!(
+        "summit genesis valid: namespace={} ({} bytes)",
+        genesis.namespace,
+        bytes.len(),
+    );
+    Ok(bytes)
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use super::*;
+
+    /// Namespace matching the shared manifest fixture's `summit.namespace`.
+    pub(crate) const FIXTURE_NAMESPACE: &str = "seismic-devnet-3";
+
+    pub(crate) fn genesis_toml(namespace: &str) -> Vec<u8> {
+        format!(
+            "namespace = \"{namespace}\"\nchain_id = 5124\n\n[[validators]]\nbls_pubkey = \"0xab\"\n"
+        )
+        .into_bytes()
+    }
+
+    fn b64(bytes: &[u8]) -> String {
+        base64::engine::general_purpose::STANDARD.encode(bytes)
+    }
+
+    #[test]
+    fn decodes_and_validates_matching_namespace() {
+        let raw = genesis_toml(FIXTURE_NAMESPACE);
+        let bytes = decode_and_validate(&b64(&raw), FIXTURE_NAMESPACE).unwrap();
+        assert_eq!(bytes, raw, "decoded bytes must be verbatim");
+    }
+
+    #[test]
+    fn tolerates_wrapped_base64_without_changing_bytes() {
+        let raw = genesis_toml(FIXTURE_NAMESPACE);
+        let mut wrapped = b64(&raw);
+        wrapped.insert(10, '\n');
+        wrapped.insert(20, ' ');
+        let bytes = decode_and_validate(&wrapped, FIXTURE_NAMESPACE).unwrap();
+        assert_eq!(bytes, raw);
+    }
+
+    #[test]
+    fn rejects_invalid_base64() {
+        let err = decode_and_validate("not-base64!!!", FIXTURE_NAMESPACE).unwrap_err();
+        assert!(err.to_string().contains("base64"), "{err}");
+    }
+
+    #[test]
+    fn rejects_non_toml_bytes() {
+        let err =
+            decode_and_validate(&b64(b"{\"namespace\": \"x\""), FIXTURE_NAMESPACE).unwrap_err();
+        assert!(err.to_string().contains("summit genesis TOML"), "{err}");
+    }
+
+    #[test]
+    fn rejects_toml_without_namespace() {
+        let err = decode_and_validate(&b64(b"chain_id = 5124\n"), FIXTURE_NAMESPACE).unwrap_err();
+        assert!(err.to_string().contains("namespace"), "{err}");
+    }
+
+    #[test]
+    fn rejects_namespace_mismatch() {
+        let raw = genesis_toml("seismic-devnet-4");
+        let err = decode_and_validate(&b64(&raw), FIXTURE_NAMESPACE).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("seismic-devnet-4") && msg.contains("seismic-devnet-3"),
+            "{msg}"
+        );
+    }
+}

--- a/bin/tdx-init/src/writer.rs
+++ b/bin/tdx-init/src/writer.rs
@@ -31,8 +31,13 @@ pub async fn write_service_configs(conf_dir: &Path, config: &InitConfig) -> Resu
         &config.network.reth_genesis_base64,
         manifest.chain_id,
     )?;
+    let summit_genesis = crate::summit_genesis::decode_and_validate(
+        &config.network.summit_genesis_base64,
+        &manifest.namespace,
+    )?;
     write_network_manifest(conf_dir, &manifest).await?;
     write_reth_genesis(conf_dir, &genesis).await?;
+    write_summit_genesis(conf_dir, &summit_genesis).await?;
     Ok(())
 }
 
@@ -57,6 +62,15 @@ async fn write_network_manifest(
 /// itself (`--chain`), so tdx-init never re-renders it.
 async fn write_reth_genesis(conf_dir: &Path, genesis_bytes: &[u8]) -> Result<()> {
     let path = conf_dir.join("reth-genesis.json");
+    write_with_mode(&path, genesis_bytes, DEFAULT_FILE_MODE).await?;
+    info!("wrote {}", path.display());
+    Ok(())
+}
+
+/// Write the validated summit genesis bytes verbatim: summit parses the file
+/// itself (`--genesis-path`), so tdx-init never re-renders it.
+async fn write_summit_genesis(conf_dir: &Path, genesis_bytes: &[u8]) -> Result<()> {
+    let path = conf_dir.join("summit-genesis.toml");
     write_with_mode(&path, genesis_bytes, DEFAULT_FILE_MODE).await?;
     info!("wrote {}", path.display());
     Ok(())
@@ -156,6 +170,12 @@ mod tests {
                 reth_genesis_base64: base64::engine::general_purpose::STANDARD.encode(
                     crate::reth_genesis::tests::genesis_json(
                         crate::reth_genesis::tests::FIXTURE_CHAIN_ID,
+                    ),
+                ),
+                // A summit genesis whose namespace matches the fixture manifest's.
+                summit_genesis_base64: base64::engine::general_purpose::STANDARD.encode(
+                    crate::summit_genesis::tests::genesis_toml(
+                        crate::summit_genesis::tests::FIXTURE_NAMESPACE,
                     ),
                 ),
                 bootnodes: vec![],
@@ -303,6 +323,20 @@ mod tests {
         let written = std::fs::read(tmp.path().join("reth-genesis.json")).unwrap();
         let expected =
             crate::reth_genesis::tests::genesis_json(crate::reth_genesis::tests::FIXTURE_CHAIN_ID);
+        assert_eq!(written, expected);
+    }
+
+    #[tokio::test]
+    async fn writes_summit_genesis_verbatim() {
+        let tmp = TempDir::new().unwrap();
+        let cfg = sample_config(true);
+
+        write_service_configs(tmp.path(), &cfg).await.unwrap();
+
+        let written = std::fs::read(tmp.path().join("summit-genesis.toml")).unwrap();
+        let expected = crate::summit_genesis::tests::genesis_toml(
+            crate::summit_genesis::tests::FIXTURE_NAMESPACE,
+        );
         assert_eq!(written, expected);
     }
 

--- a/crates/network-manifest/fixtures/network-manifest-v1.json
+++ b/crates/network-manifest/fixtures/network-manifest-v1.json
@@ -3,7 +3,6 @@
     "chain_id": 5124,
     "genesis_hash": "0x78ab9057bb67f95a6182969c5d755ac02802c98c0d2f0d8daeb52f4bddc60be5"
   },
-  "genesis_nonce": "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
   "manifest_version": 1,
   "measurements": {
     "bootstrap_policy_hash": "0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
@@ -14,7 +13,7 @@
   },
   "name": "seismic-devnet-3",
   "summit": {
-    "genesis_template_hash": "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    "genesis_config_digest": "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
     "namespace": "seismic-devnet-3"
   }
 }

--- a/crates/network-manifest/src/lib.rs
+++ b/crates/network-manifest/src/lib.rs
@@ -69,16 +69,19 @@ impl fmt::Debug for NetworkId {
 ///
 /// - `eth.chain_id` — kills transaction replay (EIP-155): a tx signed for one
 ///   network is invalid on another.
-/// - `genesis_nonce` (via `network_id`) — kills attestation-transcript
-///   replay: quotes and root-key handshake bindings from one network can't
-///   verify on a clone deployment.
+/// - `summit.genesis_config_digest` (via `network_id`) — kills
+///   attestation-transcript replay: quotes and root-key handshake bindings
+///   from one network can't verify on a clone deployment. The digest covers
+///   the validator pubkeys harvested during that founding, so two foundings
+///   cannot share one — distinct deployments get distinct `network_id`s by
+///   construction, with no authored nonce needed.
 /// - `summit.namespace` — kills BLS consensus-signature replay: without a
 ///   distinct signing domain, a validator key active on two chains (cloned
 ///   devnets, a fork) produces votes valid on both — manufactured
 ///   equivocation.
 ///
-/// Only `genesis_nonce` is guaranteed to differ between clone deployments;
-/// operators must vary `eth.chain_id` and `summit.namespace` too for the
+/// Only `summit.genesis_config_digest` differs between clone deployments for
+/// free; operators must vary `eth.chain_id` and `summit.namespace` too for the
 /// other two layers to hold.
 ///
 /// Parsing is strict: unknown keys are rejected, so two verifiers can never
@@ -92,9 +95,6 @@ pub struct NetworkManifestV1 {
     pub manifest_version: u64,
     /// Human label; intentionally part of the hash (intent is identity).
     pub name: String,
-    /// Fresh per deployment ceremony; the clone-deployment uniquifier.
-    #[serde(deserialize_with = "hex_32")]
-    pub genesis_nonce: [u8; 32],
     pub eth: EthManifest,
     pub summit: SummitManifest,
     pub measurements: MeasurementsManifest,
@@ -120,11 +120,18 @@ pub struct EthManifest {
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct SummitManifest {
-    /// SHA-256 of the summit network-params template file bytes (the
-    /// pre-`fill-genesis-template` artifact, no `[[validators]]`).
+    /// Summit's own `config_digest` of the complete founding `genesis.toml`:
+    /// SHA-256 over summit's domain-prefixed SSZ serialization, computed by
+    /// `summit genesis digest <file>`. Covers the consensus parameters plus
+    /// every validator's ed25519 node pubkey, BLS consensus pubkey, and
+    /// withdrawal credentials; excludes `ip_address` (summit annotates it
+    /// "network topology, not consensus identity"), so refreshing a
+    /// delivered IP never changes `network_id`. It is also the value summit
+    /// derives `chain_domain` from, so live nodes already enforce agreement
+    /// on everything it covers.
     #[serde(deserialize_with = "hex_32")]
-    pub genesis_template_hash: [u8; 32],
-    /// BLS signature domain separator; duplicated from the template so
+    pub genesis_config_digest: [u8; 32],
+    /// BLS signature domain separator; duplicated from the genesis so
     /// verifiers don't need to parse TOML.
     pub namespace: String,
 }
@@ -256,13 +263,12 @@ mod tests {
 
         assert_eq!(manifest.manifest_version, 1);
         assert_eq!(manifest.name, "seismic-devnet-3");
-        assert_eq!(manifest.genesis_nonce, [0xAA; 32]);
         assert_eq!(manifest.eth.chain_id, 5124);
         assert_eq!(
             hex::encode(manifest.eth.genesis_hash),
             "78ab9057bb67f95a6182969c5d755ac02802c98c0d2f0d8daeb52f4bddc60be5"
         );
-        assert_eq!(manifest.summit.genesis_template_hash, [0xBB; 32]);
+        assert_eq!(manifest.summit.genesis_config_digest, [0xBB; 32]);
         assert_eq!(manifest.summit.namespace, "seismic-devnet-3");
         assert_eq!(manifest.measurements.bootstrap_policy_hash, [0xCC; 32]);
         assert_eq!(
@@ -279,7 +285,7 @@ mod tests {
         let network_id = NetworkId::from_manifest_bytes(FIXTURE);
         assert_eq!(
             network_id.to_string(),
-            "0xc4d4721b2e287df26022e6d27c8cf772841a872b6be08b1938cbc76d88703747"
+            "0x8ef142e3f2bf15f8b201c4d8cda7848a9e846222c62b5615d4d36c7fccd98a24"
         );
     }
 
@@ -331,8 +337,9 @@ mod tests {
     #[test]
     fn rejects_malformed_hex_fields() {
         // wrong length for a 32-byte field
-        let result =
-            parse_mutated(|v| v["genesis_nonce"] = format!("0x{}", "aa".repeat(31)).into());
+        let result = parse_mutated(|v| {
+            v["summit"]["genesis_config_digest"] = format!("0x{}", "bb".repeat(31)).into()
+        });
         assert!(matches!(result, Err(ManifestError::Json(_))));
 
         // missing 0x prefix


### PR DESCRIPTION
# tdx-init `summit_genesis_base64` + manifest summit-genesis pin

Two independent halves: the manifest's summit pin changes shape, and tdx-init
gains a third network-wide artifact to fan out.

## Part A — `crates/network-manifest`: summit pin + nonce retirement

- `SummitManifest.genesis_template_hash` → **`genesis_config_digest`**. The
  old field hashed the summit network-params *template* — the
  pre-`fill-genesis-template` artifact that ends at `validators = []`, so it
  committed to none of the validator identities. The new field is summit's own
  `config_digest`: SHA-256 over its domain-prefixed SSZ serialization of the
  *complete* founding genesis, covering the consensus parameters plus every
  validator's ed25519 node pubkey, BLS consensus pubkey, and withdrawal
  credentials, and deliberately excluding `ip_address` (topology, not consensus
  identity), so refreshing a delivered IP never changes `network_id`. Deploy
  computes it via the summit CLI's `genesis digest` subcommand.

- **`genesis_nonce` retires.** Its only job was clone-deployment uniqueness:
  because `network_id = SHA-256(manifest bytes)`, two networks built from
  otherwise-identical inputs would produce byte-identical manifests and share an
  identity, letting a quote or root-key binding from one verify on the other.
  That was load-bearing only because nothing else in the manifest was
  per-founding-fresh — the old template hash was a static authored artifact.
  `genesis_config_digest` covers validator keys generated inside each node's TEE
  during the founding, so two foundings cannot share one, and distinct
  deployments get distinct `network_id`s by construction. This also replaces
  uniqueness-by-operator-discipline (an authored nonce can be silently
  wrong — copied manifest, fixed or all-zero value, and nothing notices) with
  uniqueness enforced at runtime, since summit derives `chain_domain` from that
  same digest.

  Scope note: the nonce only ever covered the attestation-transcript layer.
  Operators must still vary `eth.chain_id` (tx replay, EIP-155) and
  `summit.namespace` (BLS consensus-signature replay) themselves. The struct doc
  preserves that caveat.

- **Still `manifest_version = 1`, still `NetworkManifestV1`.** The schema is
  edited in place rather than bumped to v2 — the project is pre-release and no
  deployed network parses v1, so carrying a dual-version parser or a second
  fixture would be dead weight. `fixtures/network-manifest-v1.json` is updated
  in place; there is exactly one fixture, as before.

- Pinned `network_id` re-derived: **`0x8ef142e3f2bf15f8b201c4d8cda7848a9e846222c62b5615d4d36c7fccd98a24`**
  (`shasum -a 256` of the fixture), asserted in both `lib.rs` and
  `bin/tdx-init/src/manifest.rs`. Fixture verified byte-exact against the deploy
  emitter's format (`json.dumps(indent=2, sort_keys=True) + "\n"`); key sorting
  survives the rename since `genesis_config_digest` < `namespace`.

## Part B — `bin/tdx-init`: `summit_genesis_base64`

Mirrors the `reth_genesis_base64` pattern end to end.

- `NetworkConfig.summit_genesis_base64: String` — required, no `Option`, no
  default. Every fresh node needs the summit genesis, founder or late joiner
  alike; a config without it must 400 at POST time rather than produce a node
  whose summit blocks forever.
- New `src/summit_genesis.rs`: strip ASCII whitespace → base64 STANDARD decode →
  probe-parse as TOML with a one-field `GenesisProbe { namespace }` (no
  `deny_unknown_fields` — the genesis schema belongs to summit) → cross-check
  against the manifest's `summit.namespace`. Returns the exact bytes.
- `InvalidSummitGenesis(String)` → 400, `ValidatedManifest.namespace` so the
  check never re-parses the manifest schema, wired into both `handle_config` and
  `write_service_configs`, and `write_summit_genesis` writing
  `summit-genesis.toml` verbatim at `DEFAULT_FILE_MODE`.
- Summit's `--genesis-path` is repointed at that file by the images repo (not
  this PR); summit's `acquire_genesis` already short-circuits on a valid present
  file, so no summit change is needed.

## Wire break (lockstep with deploy)

`deny_unknown_fields` plus the required field make this a hard break in both
directions, intentionally — same precedent as the `[root_key]` section removal:

- old deploy CLI → new image: `400 missing field summit_genesis_base64`
- new deploy CLI → old image: `400 unknown field`

Deploy must land, together: `summit_genesis_base64` in
`build_config`/`render_network_section`, plus the manifest emitter dropping
`genesis_nonce` and renaming the summit key. Since the fixture is edited in place
rather than added alongside a v1 copy, deploy's
`test_render_matches_enclave_fixture_bytes` (which live-fetches the fixture from
this repo's `seismic` branch) goes red the moment this merges and green again when
deploy's side lands — worth sequencing the two closely.

## Follow-up (not in this PR): verify both hash pins in-enclave

POST-time validation here is *structural* — `config.chainId` against
`eth.chain_id`, `namespace` against `summit.namespace` — and deliberately does
not check `eth.genesis_hash` or `summit.genesis_config_digest`. Not because it
can't: the image ships both `seismic-reth` and the summit binary, and
`seismic-reth genesis-hash` / `summit genesis digest` are pure functions of a
file (deploy's `manifest assemble` already shells out to the former). tdx-init
could shell out to both.

What that would buy is **diagnostics, not security**. Both artifacts already have
a runtime backstop — reth's P2P handshake rejects peers on genesis-hash mismatch,
and summit derives its P2P/signing domains from `chain_domain(config_digest)` so
a divergent genesis can't handshake. Shelling out yields the same verdict those
would, seconds earlier and with an error that names the problem instead of
manifesting as "node never peers." It adds no security: the manifest and both
genesis files arrive in the *same* POST from the *same* party, so a
self-consistency check between them catches nothing. What actually protects
external verifiers is that `network_id` is derived over the manifest bytes they
independently hold.

Costs to settle before doing it:

1. **It inverts validate-before-write.** The CLIs take a file, but
   `handle_config` deliberately touches no filesystem — a rejected POST leaves no
   trace and the 409 second-POST path never writes. Either a tempfile in the
   server path, or move the check into `write_service_configs` where the bytes
   already land (cleaner, but by then the POST has returned 200).
2. **New brick risk at the earliest boot step.** tdx-init currently has zero
   runtime dependencies on other components. A future image whose
   `summit genesis digest` output format shifts would 400 every POST — an
   undeployable node needing an image rebuild, with the error pointing at the
   config step rather than at summit.
3. **The summit CLI's `genesis digest` subcommand doesn't exist yet** — it is
   in-flight in the summit repo.

If we do it, do both hashes together for symmetry, and say plainly in the
docstrings that it's a diagnostic so nobody later mistakes it for the security
boundary. Both `decode_and_validate` functions carry a short comment noting the
option and its dependency cost.
