### PR TITLE
feat(verify-quote): DCAP-verify a founding node's summit-keys harvest quote

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5074,6 +5074,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "seismic-verify-quote"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "hex",
+ "seismic-attestation",
+ "serde_json",
+ "tempfile",
+ "tokio",
+]
+
+[[package]]
 name = "semver"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,14 @@
 [workspace]
 resolver = "2"
-# The three deployed binaries live under bin/; every crates/ member is a
-# library (some also build a tooling CLI behind their `cli` feature). The dir
-# name is the crate; the arrow is the binary target it builds.
+# The three deployed binaries live under bin/, next to `verify-quote`, which
+# runs off-node in deploy's hands; every crates/ member is a library (some also
+# build a tooling CLI behind their `cli` feature). The dir name is the crate;
+# the arrow is the binary target it builds.
 members = [
     "bin/tdx-init",              # -> tdx-init
     "bin/attestation-service",   # -> seismic-attestation-service
     "bin/custodian-service",     # -> seismic-custodian-service
+    "bin/verify-quote",          # -> verify-quote
 
     "crates/attestation",
     "crates/attestation-rpc",

--- a/README.md
+++ b/README.md
@@ -6,8 +6,9 @@ configuration at boot.
 
 ## Layout
 
-`bin/` holds the three deployed binaries; every crate under `crates/` is a
-library they share.
+`bin/` holds the three deployed binaries plus `verify-quote`, which runs
+off-node in deploy's hands; every crate under `crates/` is a library they
+share.
 
 ### Binaries (`bin/`)
 
@@ -16,6 +17,7 @@ library they share.
 | `tdx-init` | `tdx-init` | Boot-time init: receives node config over HTTP and writes the enclave/reth runtime env, then exits. |
 | `attestation-service` | `seismic-attestation-service` | Network-facing JSON-RPC service (`:7878`): serves attestation evidence and purpose keys. Holds no key material — reaches the custodian over a Unix socket. |
 | `custodian-service` | `seismic-custodian-service` | Standalone service for the RAM-only root-key custodian: no network listener, minimal Unix-socket API, owns the per-boot LUKS keyfile handoff. |
+| `verify-quote` | `verify-quote` | Not deployed to nodes: verification-only CLI that DCAP-verifies one founding node's summit-keys harvest quote against a measurement policy (JSON on stdout, exit 0 ⇔ verified). Shelled out to by deploy's harvest step. |
 
 ### Libraries (`crates/`)
 

--- a/bin/verify-quote/Cargo.toml
+++ b/bin/verify-quote/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "seismic-verify-quote"
+version.workspace = true
+edition.workspace = true
+repository.workspace = true
+homepage.workspace = true
+authors.workspace = true
+license.workspace = true
+readme.workspace = true
+description = "Verification-only CLI that DCAP-verifies a founding-keys harvest quote"
+
+[[bin]]
+name = "verify-quote"
+path = "src/main.rs"
+
+[dependencies]
+seismic-attestation.workspace = true
+
+anyhow.workspace = true
+clap.workspace = true
+hex.workspace = true
+serde_json.workspace = true
+tokio.workspace = true
+
+[dev-dependencies]
+# The error-path tests hand `run` real files, since the failures under test are
+# file-reading and file-parsing failures.
+tempfile = "3.17.1"

--- a/bin/verify-quote/src/main.rs
+++ b/bin/verify-quote/src/main.rs
@@ -1,0 +1,391 @@
+//! `verify-quote` — DCAP-verify one founding node's summit-keys harvest quote.
+//!
+//! Checks that a quote's `report_data` is
+//! `founding_summit_keys_binding(harvest_nonce, node_pk, consensus_pk)` for the
+//! nonce and pubkeys given on the command line, that the quote verifies
+//! cryptographically, and that its measurements satisfy the given measurement
+//! policy. The binding is per node, so one run covers one node's harvest.
+//!
+//! ```text
+//! verify-quote \
+//!   --evidence harvest/box-1.evidence.json \
+//!   --policy build/measurements.json \
+//!   --nonce <64-hex> \
+//!   --node-pubkey <64-hex> \
+//!   --consensus-pubkey <96-hex>
+//! ```
+//!
+//! `--evidence` is a JSON-serialized [`AttestationExchangeMessage`]; `-` reads
+//! it from stdin. Exit 0 plus one JSON object on stdout means verified. Every
+//! failure — bad input, binding mismatch, measurement mismatch, DCAP failure,
+//! non-Azure evidence — is an error on stderr with a nonzero exit and nothing on
+//! stdout.
+//!
+//! Verification-only: this never touches a local TPM, so it runs anywhere Linux
+//! runs. It compiles everywhere, but the `azure` feature gating Azure TDX
+//! verification in the upstream `attestation` crate is enabled through a
+//! Linux-only target block in `crates/attestation/Cargo.toml`, so on macOS
+//! verification fails at runtime — run it in a Linux container there.
+
+use anyhow::Context as _;
+use clap::Parser;
+use seismic_attestation::{
+    AttestationType, SeismicMeasurementPolicy, VerifiedAzureAttestation, VerifyOptions,
+    bindings::{binding64_from_digest32, founding_summit_keys_binding},
+    verify_azure_evidence_with_options,
+};
+use std::{
+    collections::BTreeMap,
+    io::Read as _,
+    path::{Path, PathBuf},
+};
+
+#[derive(Debug, Parser)]
+#[command(
+    name = "verify-quote",
+    version,
+    about = "DCAP-verify one founding node's summit-keys harvest quote against the intended image \
+             measurements",
+    long_about = "DCAP-verify one founding node's summit-keys harvest quote against the intended \
+                  image measurements.\n\n\
+                  Recomputes the report_data the key holder must have quoted over \
+                  (founding_summit_keys_binding of --nonce, --node-pubkey, --consensus-pubkey), \
+                  verifies \
+                  the evidence cryptographically, and enforces --policy on the quoted \
+                  measurements. The policy is required: there is no accept-any mode, because the \
+                  measurement check is the point.\n\n\
+                  Exit 0 with a single JSON object on stdout means verified: \
+                  {\"verified\": true, \"attestation_type\": ..., \"binding\": <128-hex \
+                  report_data>, \"pcrs\": {\"pcr4\": <64-hex>, ...}}. The pcrs map carries every \
+                  register the quote covers, not just the ones the policy pins, so the caller can \
+                  archive it as harvest provenance. Any failure — unreadable or malformed input, \
+                  binding mismatch, measurement mismatch, DCAP failure, non-Azure evidence — \
+                  prints an error to stderr and exits nonzero, with nothing on stdout.\n\n\
+                  Verification-only: this never touches a local TPM, so it runs anywhere Linux \
+                  runs. It compiles on macOS but Azure verification fails there at runtime (the \
+                  upstream `azure` feature is Linux-target-gated), so non-Linux callers run it in \
+                  a Linux container."
+)]
+struct Cli {
+    /// JSON-serialized AttestationExchangeMessage the key holder served
+    /// (`-` reads stdin).
+    #[arg(long, value_name = "PATH")]
+    evidence: PathBuf,
+
+    /// Measurement-policy JSON pinning the intended image measurements, e.g.
+    /// seismic-images' `build/measurements.json`. Required: a quote from an
+    /// unintended image must not pass.
+    #[arg(long, value_name = "PATH")]
+    policy: PathBuf,
+
+    /// The harvest nonce this quote was requested with (32 bytes hex).
+    #[arg(long, value_name = "HEX")]
+    nonce: String,
+
+    /// The ed25519 node pubkey the key holder returned (32 bytes hex).
+    #[arg(long, value_name = "HEX")]
+    node_pubkey: String,
+
+    /// The BLS12-381 MinPk consensus pubkey the key holder returned
+    /// (48 bytes hex).
+    #[arg(long, value_name = "HEX")]
+    consensus_pubkey: String,
+
+    /// Optional PCCS URL for DCAP collateral, instead of the backend default.
+    #[arg(long, value_name = "URL")]
+    pccs_url: Option<String>,
+
+    /// Allow the backend's Azure outdated-TCB override path.
+    #[arg(long)]
+    override_azure_outdated_tcb: bool,
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    // Returning the error from main sends it to stderr with a nonzero exit and
+    // leaves stdout empty, which is exactly deploy's contract.
+    println!("{}", run(Cli::parse()).await?);
+    Ok(())
+}
+
+/// Verify the harvest quote described by `cli` and render the success report.
+///
+/// Separate from `main` so the whole path — including every rejection — is
+/// callable from tests.
+async fn run(cli: Cli) -> anyhow::Result<String> {
+    // Resolve everything that can fail on bad input before any verification:
+    // DCAP costs collateral round-trips, so a mistyped pubkey should not be
+    // discovered on the far side of them.
+    let nonce = decode_hex_arg::<32>("--nonce", &cli.nonce)?;
+    let node_pk = decode_hex_arg::<32>("--node-pubkey", &cli.node_pubkey)?;
+    let consensus_pk = decode_hex_arg::<48>("--consensus-pubkey", &cli.consensus_pubkey)?;
+    let binding = harvest_binding(&nonce, &node_pk, &consensus_pk);
+
+    let evidence_bytes = read_evidence(&cli.evidence).await?;
+    let evidence = serde_json::from_slice(&evidence_bytes)
+        .context("--evidence is not a JSON-serialized AttestationExchangeMessage")?;
+
+    let policy = SeismicMeasurementPolicy::from_file(cli.policy.clone())
+        .await
+        .with_context(|| format!("loading measurement policy {}", cli.policy.display()))?;
+
+    let verified = verify_azure_evidence_with_options(
+        evidence,
+        binding,
+        policy,
+        VerifyOptions {
+            pccs_url: cli.pccs_url,
+            dump_dcap_quotes: false,
+            override_azure_outdated_tcb: cli.override_azure_outdated_tcb,
+        },
+    )
+    .await
+    .context("verifying harvest evidence")?;
+
+    Ok(report(&verified))
+}
+
+/// The 64-byte `report_data` a harvested quote must carry.
+///
+/// Pure and deliberately trivial: deploy calls this instead of deriving the
+/// binding itself, so this one line is the single definition of the check on
+/// both sides.
+fn harvest_binding(nonce: &[u8; 32], node_pk: &[u8; 32], consensus_pk: &[u8; 48]) -> [u8; 64] {
+    binding64_from_digest32(founding_summit_keys_binding(nonce, node_pk, consensus_pk))
+}
+
+/// Decode a fixed-length hex argument, naming the flag in every failure.
+///
+/// The caller is a script assembling five hex strings; an error that does not
+/// say which one it means costs a round of guessing.
+fn decode_hex_arg<const N: usize>(flag: &str, value: &str) -> anyhow::Result<[u8; N]> {
+    let bare = value.strip_prefix("0x").unwrap_or(value);
+    let bytes = hex::decode(bare).with_context(|| format!("{flag} is not valid hex"))?;
+    bytes.try_into().map_err(|bytes: Vec<u8>| {
+        anyhow::anyhow!(
+            "{flag} must be {N} bytes ({} hex chars), got {}",
+            N * 2,
+            bytes.len()
+        )
+    })
+}
+
+/// Read the evidence document from a path, or stdin for `-` (the subprocess
+/// boundary deploy uses to pass exact bytes without a temp file).
+async fn read_evidence(path: &Path) -> anyhow::Result<Vec<u8>> {
+    if path == Path::new("-") {
+        let mut bytes = Vec::new();
+        std::io::stdin()
+            .read_to_end(&mut bytes)
+            .context("reading --evidence from stdin")?;
+        return Ok(bytes);
+    }
+    tokio::fs::read(path)
+        .await
+        .with_context(|| format!("reading --evidence {}", path.display()))
+}
+
+/// The success report: one JSON object, printed only once verification passed.
+///
+/// Registers come out of a `BTreeMap` so the object is assembled in register
+/// order and archived reports diff cleanly across nodes, boots, and builds (the
+/// backend hands back a `HashMap`, whose iteration order is not stable). Every
+/// quoted register is included, not just the policy's, because the caller keeps
+/// this output as harvest provenance.
+fn report(verified: &VerifiedAzureAttestation) -> String {
+    let pcrs: serde_json::Map<String, serde_json::Value> = verified
+        .guest_measurements
+        .pcrs
+        .iter()
+        .map(|(index, value)| (*index, *value))
+        .collect::<BTreeMap<u32, [u8; 32]>>()
+        .into_iter()
+        .map(|(index, value)| (format!("pcr{index}"), hex::encode(value).into()))
+        .collect();
+
+    serde_json::json!({
+        "verified": true,
+        "attestation_type": AttestationType::AzureTdx.as_str(),
+        "binding": hex::encode(verified.binding),
+        "pcrs": pcrs,
+    })
+    .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::CommandFactory as _;
+    use seismic_attestation::AzureGuestMeasurements;
+    use std::collections::HashMap;
+
+    /// A policy that parses. Its measurements never get checked in these tests:
+    /// every case here fails before verification, which is the point — no test
+    /// in this file reaches live DCAP.
+    const VALID_POLICY: &str = r#"[
+      {
+        "attestation_type": "azure-tdx",
+        "measurement_id": "verify-quote-test.vhd",
+        "measurements": {
+          "pcr4": { "expected_any": ["d57063c0669599b885c43a0683436a3463ad49513ddb3996e6fc96040508fd8e"] }
+        }
+      }
+    ]"#;
+
+    const NONCE_HEX: &str = "7777777777777777777777777777777777777777777777777777777777777777";
+    const NODE_PK_HEX: &str = "8888888888888888888888888888888888888888888888888888888888888888";
+    const CONSENSUS_PK_HEX: &str = "999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999";
+
+    fn write_file(dir: &tempfile::TempDir, name: &str, contents: &str) -> PathBuf {
+        let path = dir.path().join(name);
+        std::fs::write(&path, contents).expect("writing test input");
+        path
+    }
+
+    fn cli(evidence: &Path, policy: &Path) -> Cli {
+        Cli::try_parse_from([
+            "verify-quote".as_ref(),
+            "--evidence".as_ref(),
+            evidence.as_os_str(),
+            "--policy".as_ref(),
+            policy.as_os_str(),
+            "--nonce".as_ref(),
+            NONCE_HEX.as_ref(),
+            "--node-pubkey".as_ref(),
+            NODE_PK_HEX.as_ref(),
+            "--consensus-pubkey".as_ref(),
+            CONSENSUS_PK_HEX.as_ref(),
+        ])
+        .expect("well-formed argv")
+    }
+
+    #[test]
+    fn cli_definition_is_valid() {
+        Cli::command().debug_assert();
+    }
+
+    /// The binding is a wire-format commitment shared with the key holder and
+    /// with deploy's assemble-time re-check, so this vector is frozen: it is
+    /// `founding_summit_keys_binding`'s frozen digest, zero-padded to 64 bytes.
+    #[test]
+    fn harvest_binding_matches_frozen_vector() {
+        let binding = harvest_binding(&[0x77; 32], &[0x88; 32], &[0x99; 48]);
+
+        assert_eq!(
+            hex::encode(&binding[..32]),
+            "8973b984dc10f809ebfaacdcad64b8cc5a647cf24e4bc27b3833cc234a9290e5"
+        );
+        assert_eq!(&binding[32..], &[0u8; 32]);
+    }
+
+    /// The hex flags feed the binding, and a wrong one produces a mismatch that
+    /// looks exactly like a bad quote — so they are rejected up front, by name.
+    #[test]
+    fn hex_args_fail_by_flag_name() {
+        let not_hex = decode_hex_arg::<32>("--nonce", "zz77")
+            .unwrap_err()
+            .to_string();
+        assert!(not_hex.contains("--nonce"), "{not_hex}");
+
+        let wrong_length = decode_hex_arg::<48>("--consensus-pubkey", NODE_PK_HEX)
+            .unwrap_err()
+            .to_string();
+        assert!(
+            wrong_length.contains("--consensus-pubkey"),
+            "{wrong_length}"
+        );
+        assert!(wrong_length.contains("48 bytes"), "{wrong_length}");
+
+        assert_eq!(
+            decode_hex_arg::<32>("--node-pubkey", NODE_PK_HEX).unwrap(),
+            [0x88; 32]
+        );
+        // Deploy may hand over 0x-prefixed hex; the two forms mean the same key.
+        assert_eq!(
+            decode_hex_arg::<32>("--node-pubkey", &format!("0x{NODE_PK_HEX}")).unwrap(),
+            [0x88; 32]
+        );
+    }
+
+    #[tokio::test]
+    async fn malformed_evidence_is_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+        let evidence = write_file(&dir, "evidence.json", "{ not evidence");
+        let policy = write_file(&dir, "policy.json", VALID_POLICY);
+
+        let error = run(cli(&evidence, &policy)).await.unwrap_err().to_string();
+        assert!(error.contains("--evidence"), "{error}");
+    }
+
+    #[tokio::test]
+    async fn missing_evidence_file_is_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+        let policy = write_file(&dir, "policy.json", VALID_POLICY);
+
+        let error = run(cli(&dir.path().join("absent.json"), &policy))
+            .await
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("reading --evidence"), "{error}");
+    }
+
+    /// Fail-closed on the policy: this binary has no accept-any path, so an
+    /// unparseable policy must stop the run rather than widen it.
+    #[tokio::test]
+    async fn malformed_policy_is_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+        let evidence = write_file(
+            &dir,
+            "evidence.json",
+            r#"{ "attestation_type": "azure-tdx", "attestation": [1, 2, 3] }"#,
+        );
+        let policy = write_file(&dir, "policy.json", "{ not a policy");
+
+        let error = run(cli(&evidence, &policy)).await.unwrap_err().to_string();
+        assert!(error.contains("measurement policy"), "{error}");
+    }
+
+    /// One job, one binding: a quote from a platform whose measurements this
+    /// policy format cannot pin is rejected without any collateral fetching.
+    #[tokio::test]
+    async fn non_azure_evidence_is_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+        let evidence = write_file(
+            &dir,
+            "evidence.json",
+            r#"{ "attestation_type": "none", "attestation": [] }"#,
+        );
+        let policy = write_file(&dir, "policy.json", VALID_POLICY);
+
+        assert!(run(cli(&evidence, &policy)).await.is_err());
+    }
+
+    #[test]
+    fn report_carries_every_quoted_register() {
+        let verified = VerifiedAzureAttestation {
+            binding: harvest_binding(&[0x77; 32], &[0x88; 32], &[0x99; 48]),
+            guest_measurements: AzureGuestMeasurements {
+                pcrs: HashMap::from([(11, [0xbb; 32]), (4, [0x44; 32]), (9, [0x99; 32])]),
+            },
+        };
+
+        let report: serde_json::Value = serde_json::from_str(&report(&verified)).unwrap();
+
+        assert_eq!(report["verified"], true);
+        assert_eq!(report["attestation_type"], "azure-tdx");
+        assert_eq!(
+            report["binding"],
+            format!(
+                "8973b984dc10f809ebfaacdcad64b8cc5a647cf24e4bc27b3833cc234a9290e5{}",
+                "00".repeat(32)
+            )
+        );
+        // Not just the policy's registers: the caller archives this as harvest
+        // provenance.
+        let pcrs = report["pcrs"].as_object().unwrap();
+        assert_eq!(pcrs.len(), 3);
+        assert_eq!(pcrs["pcr4"], "44".repeat(32));
+        assert_eq!(pcrs["pcr9"], "99".repeat(32));
+        assert_eq!(pcrs["pcr11"], "bb".repeat(32));
+    }
+}


### PR DESCRIPTION
New workspace member `bin/verify-quote` (`seismic-verify-quote` -> `verify-quote`): a verification-only CLI that checks one founding node's harvested summit keys against the image measurements they must have been generated under.

## What it checks

Given the harvest nonce and the two pubkeys a `summit-key-holder` returned, it recomputes `founding_summit_keys_binding(nonce, node_pk, consensus_pk)` (#229), expands it to the 64-byte attestation input, verifies the evidence cryptographically, and enforces a measurement policy on the quoted registers. The binding is per node, so one run covers one node's harvest and an N-node ceremony runs it N times.

Verified pubkeys are what later get pinned into the summit genesis (#230), and that pin is one-way — consensus signatures are checked offline by future joiners, with no channel context — so a non-TEE pubkey admitted here could vote forever. Hence the fail-closed choices below.

## Contract

    verify-quote --evidence <PATH|-> --policy <PATH> --nonce <64-hex> \
                 --node-pubkey <64-hex> --consensus-pubkey <96-hex> \
                 [--pccs-url <URL>] [--override-azure-outdated-tcb]

Exit 0 plus one JSON object on stdout means verified:

    {"verified":true,"attestation_type":"azure-tdx",
     "binding":"<128-hex>","pcrs":{"pcr4":"…","pcr9":"…"}}

Any failure is an `anyhow` chain on stderr with a nonzero exit and nothing on stdout, so exit status alone is the verdict. `--evidence -` reads stdin, for callers passing exact bytes without a temp file.

Design notes:

- **`--policy` is required and there is no accept-any path.** No `dangerously_accept_any_for_testing` branch exists here and none should be added: the measurement check is the reason the binary exists. A malformed policy stops the run rather than widening it.
- **`verify_azure_evidence_with_options`, not the generic `verify_evidence_with_options`.** The Azure type check then happens before the backend fetches any DCAP collateral, so non-Azure evidence is rejected without network I/O — which is also what lets that rejection be a unit test.
- **All quoted registers in `pcrs`, not just the policy's.** Callers archive this output as harvest provenance. Collected through a `BTreeMap` so the object is built in register order and archived reports diff cleanly (the backend returns a `HashMap`).
- **Hex flags name themselves on failure.** A wrong pubkey yields a binding mismatch indistinguishable from a bad quote, so encoding and lengths are checked up front — before any file or network work — and errors say which flag was wrong.

## Format note

`--evidence` is a JSON-serialized `AttestationExchangeMessage`. That encoding now serves as both the harvest wire format and the archive format, so more than one component depends on it round-tripping; it does, being the same type `seismic-attestation-rpc` already ships over jsonrpsee.

## Platform

Verification-only — never touches a local TPM, so it runs anywhere Linux runs, including a container on a laptop. It compiles everywhere, but the `azure` feature gating Azure TDX verification upstream is enabled through a Linux-only target block in `crates/attestation/Cargo.toml`, so on macOS verification fails at runtime with "Attestation type not supported". Non-Linux callers run it in a Linux container; that image is a separate change.

## Placement

`bin/`, not a `cli`-gated binary inside `crates/attestation`. The `crates/` CLIs (`measurement-admission`, `custodian-ipc`) are libraries first with a CLI attached; nothing links a verify-quote library and there is none. A standalone package also keeps `crates/attestation` thin — a `cli` feature there would add optional `tokio`/`anyhow`/`clap` to the crate every node-side service links.

The root `Cargo.toml` members list and the README binaries table gain the new entry, marked as running off-node rather than deployed.

## Tests

Eight unit tests, no live DCAP: the frozen binding vector from #229, hex flags failing by name (and accepting `0x`), malformed and missing evidence, malformed policy, non-Azure evidence, and the report shape. Live verification is exercised by the founding rehearsal, not CI.