### PR TITLE
feat(summit-key-holder): pre-manifest holder for summit keys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -180,7 +180,7 @@ dependencies = [
  "itoa",
  "serde",
  "serde_json",
- "winnow",
+ "winnow 0.7.15",
 ]
 
 [[package]]
@@ -237,7 +237,7 @@ dependencies = [
  "either",
  "serde",
  "serde_with",
- "sha2",
+ "sha2 0.10.9",
  "thiserror 2.0.18",
 ]
 
@@ -344,9 +344,9 @@ dependencies = [
  "cfg-if",
  "const-hex",
  "derive_more 2.1.1",
- "foldhash",
+ "foldhash 0.1.5",
  "hashbrown 0.15.5",
- "indexmap 2.10.0",
+ "indexmap 2.14.0",
  "itoa",
  "k256",
  "keccak-asm",
@@ -371,9 +371,9 @@ dependencies = [
  "cfg-if",
  "const-hex",
  "derive_more 2.1.1",
- "foldhash",
+ "foldhash 0.1.5",
  "hashbrown 0.15.5",
- "indexmap 2.10.0",
+ "indexmap 2.14.0",
  "itoa",
  "k256",
  "keccak-asm",
@@ -594,7 +594,7 @@ dependencies = [
  "alloy-sol-macro-input 0.8.26",
  "const-hex",
  "heck",
- "indexmap 2.10.0",
+ "indexmap 2.14.0",
  "proc-macro-error2",
  "proc-macro2",
  "quote",
@@ -613,7 +613,7 @@ dependencies = [
  "alloy-sol-macro-input 1.3.0",
  "const-hex",
  "heck",
- "indexmap 2.10.0",
+ "indexmap 2.14.0",
  "proc-macro-error2",
  "proc-macro2",
  "quote",
@@ -663,7 +663,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c13fc168b97411e04465f03e632f31ef94cad1c7c8951bf799237fd7870d535"
 dependencies = [
  "serde",
- "winnow",
+ "winnow 0.7.15",
 ]
 
 [[package]]
@@ -673,7 +673,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52db32fbd35a9c0c0e538b58b81ebbae08a51be029e7ad60e08b60481c2ec6c3"
 dependencies = [
  "serde",
- "winnow",
+ "winnow 0.7.15",
 ]
 
 [[package]]
@@ -970,6 +970,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 dependencies = [
  "serde",
+ "zeroize",
 ]
 
 [[package]]
@@ -1146,6 +1147,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4342d8937fc7e5dd9b1c60292261c0670c882a2cd1719cfc11b1af41731e32ad"
+dependencies = [
+ "aws-lc-sys",
+ "untrusted 0.7.1",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d9ceb1da931507a12f4fccea479dccd00da1943e1b4ae72d8e502d707361444"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "pkg-config",
+]
+
+[[package]]
 name = "axum"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1211,7 +1236,7 @@ dependencies = [
  "serde-big-array",
  "serde_json",
  "sev",
- "sha2",
+ "sha2 0.10.9",
  "thiserror 2.0.18",
  "tss-esapi",
  "zerocopy",
@@ -1383,6 +1408,16 @@ dependencies = [
  "cfg-if",
  "constant_time_eq",
  "cpufeatures 0.3.0",
+ "zeroize",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -1474,10 +1509,13 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.32"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2352e5597e9c544d5e6d9c95190d5d27738ade584fa8db0a16e130e5c2b5296e"
+checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
 dependencies = [
+ "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -1495,7 +1533,7 @@ dependencies = [
  "serde",
  "serde-human-bytes",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -1515,6 +1553,30 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chacha20"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "chacha20poly1305"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
+dependencies = [
+ "aead",
+ "chacha20",
+ "cipher",
+ "poly1305",
+ "zeroize",
+]
 
 [[package]]
 name = "chrono"
@@ -1565,6 +1627,7 @@ checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common",
  "inout",
+ "zeroize",
 ]
 
 [[package]]
@@ -1608,6 +1671,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "cmov"
+version = "0.5.0-pre.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5417da527aa9bf6a1e10a781231effd1edd3ee82f27d5f8529ac9b279babce96"
+
+[[package]]
 name = "codicon"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1630,16 +1708,138 @@ dependencies = [
 ]
 
 [[package]]
-name = "const-hex"
-version = "1.14.1"
+name = "commonware-codec"
+version = "2026.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83e22e0ed40b96a48d3db274f72fd365bd78f67af39b6bbd47e8a15e1c6207ff"
+checksum = "f06e32817f35fb517ceb6102d984f9a85fde85666c96f053638e323b8597f2f7"
+dependencies = [
+ "bytes",
+ "cfg-if",
+ "commonware-macros",
+ "paste",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "commonware-cryptography"
+version = "2026.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f09b55dd5510c3b7613a573606a41961c2788709ffde053d4e644bec0bff2c"
+dependencies = [
+ "anyhow",
+ "aws-lc-rs",
+ "blake3",
+ "blst",
+ "bytes",
+ "cfg-if",
+ "chacha20poly1305",
+ "commonware-codec",
+ "commonware-macros",
+ "commonware-math",
+ "commonware-parallel",
+ "commonware-utils",
+ "crc-fast",
+ "ctutils",
+ "ecdsa",
+ "ed25519-consensus",
+ "getrandom 0.2.16",
+ "num-rational",
+ "num-traits",
+ "p256",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+ "sha2 0.10.9",
+ "thiserror 2.0.18",
+ "x25519-dalek",
+ "zeroize",
+]
+
+[[package]]
+name = "commonware-macros"
+version = "2026.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5419e6eb2c4c9e56517cfc07062a984b882dabf573d53191a73b98358cd9782a"
+dependencies = [
+ "commonware-macros-impl",
+ "tokio",
+]
+
+[[package]]
+name = "commonware-macros-impl"
+version = "2026.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82dd7062336fc7d2107e9a63312ef1b9811d06bfe56dfd56f97e6ce5d4aa0565"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+ "toml 0.9.12+spec-1.1.0",
+]
+
+[[package]]
+name = "commonware-math"
+version = "2026.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5d834ed8bf601e113b9cd2ba284dd0e95adf558933dc727f52f8879434cb286"
+dependencies = [
+ "bytes",
+ "commonware-codec",
+ "commonware-macros",
+ "commonware-parallel",
+ "commonware-utils",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "commonware-parallel"
+version = "2026.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d6a412b4c868174963b38ff2dad6686c573ec56834d9b39d20b73437c6d9726"
+dependencies = [
+ "cfg-if",
+ "commonware-macros",
+ "rayon",
+]
+
+[[package]]
+name = "commonware-utils"
+version = "2026.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf66d7b5c89489d71b0669bda2e014e7c9ffcdf65629ae31886efe5361b1179"
+dependencies = [
+ "bytes",
+ "cfg-if",
+ "commonware-codec",
+ "commonware-macros",
+ "futures",
+ "getrandom 0.2.16",
+ "hashbrown 0.16.1",
+ "num-bigint",
+ "num-integer",
+ "num-rational",
+ "num-traits",
+ "parking_lot",
+ "pin-project",
+ "rand 0.8.5",
+ "thiserror 2.0.18",
+ "tokio",
+ "zeroize",
+]
+
+[[package]]
+name = "const-hex"
+version = "1.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33e2a781ebdf4467d1428dc4593067825fb646f6871475098d8577421af73558"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "hex",
  "proptest",
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1733,6 +1933,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
 
 [[package]]
+name = "crc-fast"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e75b2483e97a5a7da73ac68a05b629f9c53cff58d8ed1c77866079e18b00dba5"
+dependencies = [
+ "digest 0.10.7",
+ "spin 0.10.0",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1753,6 +1963,16 @@ version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
 dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
+dependencies = [
+ "crossbeam-epoch",
  "crossbeam-utils",
 ]
 
@@ -1810,6 +2030,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctutils"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "758e5ed90be3c8abff7f9a6f37ab7f6d8c59c2210d448b81f3f508134aec84e4"
+dependencies = [
+ "cmov",
+]
+
+[[package]]
 name = "curve25519-dalek"
 version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1834,6 +2063,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.104",
+]
+
+[[package]]
+name = "curve25519-dalek-ng"
+version = "4.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c359b7249347e46fb28804470d071c921156ad62b3eef5d34e2ba867533dec8"
+dependencies = [
+ "byteorder",
+ "digest 0.9.0",
+ "rand_core 0.6.4",
+ "subtle-ng",
+ "zeroize",
 ]
 
 [[package]]
@@ -1955,7 +2197,7 @@ dependencies = [
  "serde",
  "serde-human-bytes",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "signature",
  "tracing",
  "urlencoding",
@@ -1976,9 +2218,9 @@ dependencies = [
  "ring",
  "rsa",
  "rustls-pki-types",
- "sha2",
+ "sha2 0.10.9",
  "signature",
- "untrusted",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -1993,7 +2235,7 @@ dependencies = [
  "p256",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "sha3",
  "time",
  "x509-parser 0.15.1",
@@ -2130,7 +2372,7 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.10.4",
  "const-oid",
  "crypto-common",
  "subtle",
@@ -2205,6 +2447,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ed25519-consensus"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c8465edc8ee7436ffea81d21a019b16676ee3db267aa8d5a8d729581ecf998b"
+dependencies = [
+ "curve25519-dalek-ng",
+ "hex",
+ "rand_core 0.6.4",
+ "sha2 0.9.9",
+ "thiserror 1.0.69",
+ "zeroize",
+]
+
+[[package]]
 name = "ed25519-dalek"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2212,7 +2468,7 @@ checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
- "sha2",
+ "sha2 0.10.9",
  "subtle",
 ]
 
@@ -2305,7 +2561,7 @@ dependencies = [
  "digest 0.10.7",
  "md-5",
  "sha1",
- "sha2",
+ "sha2 0.10.9",
  "sha3",
 ]
 
@@ -2354,6 +2610,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
 name = "fixed-hash"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2394,6 +2656,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
 name = "foreign-types"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2425,6 +2693,12 @@ checksum = "73fde052dbfc920003cfd2c8e2c6e6d4cc7c1091538c3a24226cec0665ab08c0"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "funty"
@@ -2570,9 +2844,20 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasi 0.14.2+wasi-0.2.4",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
 ]
 
 [[package]]
@@ -2670,7 +2955,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap 2.10.0",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -2708,9 +2993,24 @@ checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.1.5",
  "serde",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "foldhash 0.2.0",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
@@ -2729,9 +3029,6 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "hex-conservative"
@@ -3091,13 +3388,14 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.10.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.5",
+ "hashbrown 0.17.1",
  "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -3185,6 +3483,16 @@ name = "jni-sys"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+
+[[package]]
+name = "jobserver"
+version = "0.1.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
+dependencies = [
+ "getrandom 0.4.3",
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
@@ -3398,7 +3706,7 @@ dependencies = [
  "elliptic-curve",
  "once_cell",
  "serdect",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -3426,7 +3734,7 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
- "spin",
+ "spin 0.9.8",
 ]
 
 [[package]]
@@ -3465,11 +3773,10 @@ checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
 
 [[package]]
 name = "lock_api"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
 dependencies = [
- "autocfg",
  "scopeguard",
 ]
 
@@ -3713,6 +4020,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3884,7 +4202,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -3896,7 +4214,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -3929,9 +4247,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.12.4"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -3939,15 +4257,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.11"
+version = "0.9.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets 0.52.6",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -4105,6 +4423,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
+name = "poly1305"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+dependencies = [
+ "cpufeatures 0.2.17",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
 name = "polyval"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4168,11 +4497,11 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.3.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edce586971a4dfaa28950c6f18ed55e0406c1ab88bbce2c6f6293a7aaba73d35"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit",
+ "toml_edit 0.25.13+spec-1.1.0",
 ]
 
 [[package]]
@@ -4303,6 +4632,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "radium"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4377,6 +4712,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
  "rand_core 0.9.3",
+]
+
+[[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -4525,7 +4880,7 @@ dependencies = [
  "cfg-if",
  "getrandom 0.2.16",
  "libc",
- "untrusted",
+ "untrusted 0.9.0",
  "windows-sys 0.52.0",
 ]
 
@@ -4559,7 +4914,7 @@ dependencies = [
  "pkcs1",
  "pkcs8",
  "rand_core 0.6.4",
- "sha2",
+ "sha2 0.10.9",
  "signature",
  "spki",
  "subtle",
@@ -4723,7 +5078,7 @@ checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",
- "untrusted",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -4842,7 +5197,7 @@ dependencies = [
  "rand_core 0.6.4",
  "serde",
  "serde_bytes",
- "sha2",
+ "sha2 0.10.9",
  "subtle",
  "zeroize",
 ]
@@ -4932,7 +5287,7 @@ dependencies = [
  "seismic-network-manifest",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "thiserror 2.0.18",
  "tokio",
 ]
@@ -4983,7 +5338,7 @@ dependencies = [
  "schnorrkel",
  "secp256k1",
  "serde",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -4997,7 +5352,7 @@ dependencies = [
  "schnorrkel",
  "secp256k1",
  "seismic-crypto",
- "sha2",
+ "sha2 0.10.9",
  "zeroize",
 ]
 
@@ -5012,7 +5367,7 @@ dependencies = [
  "libc",
  "serde",
  "serde_bytes",
- "sha2",
+ "sha2 0.10.9",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -5047,7 +5402,7 @@ dependencies = [
  "hex",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "thiserror 2.0.18",
  "tokio",
 ]
@@ -5069,8 +5424,33 @@ dependencies = [
  "hex",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "seismic-summit-key-holder"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "axum",
+ "clap",
+ "commonware-codec",
+ "commonware-cryptography",
+ "commonware-math",
+ "commonware-utils",
+ "hex",
+ "http-body-util",
+ "rand 0.8.5",
+ "seismic-attestation",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+ "tower",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -5181,7 +5561,7 @@ version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
- "indexmap 2.10.0",
+ "indexmap 2.14.0",
  "itoa",
  "memchr",
  "serde",
@@ -5210,6 +5590,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5231,7 +5620,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.10.0",
+ "indexmap 2.14.0",
  "schemars 0.9.0",
  "schemars 1.0.4",
  "serde",
@@ -5327,6 +5716,19 @@ dependencies = [
 
 [[package]]
 name = "sha2"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
+dependencies = [
+ "block-buffer 0.9.0",
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest 0.9.0",
+ "opaque-debug",
+]
+
+[[package]]
+name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
@@ -5367,9 +5769,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook-registry"
@@ -5444,6 +5846,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
+name = "spin"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
+
+[[package]]
 name = "spki"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5497,6 +5905,12 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "subtle-ng"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "734676eb262c623cec13c3155096e08d1f8f29adce39ba17948b18dad1e54142"
 
 [[package]]
 name = "syn"
@@ -5608,7 +6022,7 @@ dependencies = [
  "serde",
  "serde-human-bytes",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "thiserror 2.0.18",
  "vsock",
 ]
@@ -5626,7 +6040,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
- "toml",
+ "toml 0.8.23",
  "tracing",
  "tracing-subscriber",
 ]
@@ -5838,9 +6252,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
- "serde_spanned",
- "toml_datetime",
- "toml_edit",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
+ "toml_edit 0.22.27",
+]
+
+[[package]]
+name = "toml"
+version = "0.9.12+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
+dependencies = [
+ "indexmap 2.14.0",
+ "serde_core",
+ "serde_spanned 1.1.1",
+ "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 0.7.15",
 ]
 
 [[package]]
@@ -5853,17 +6282,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "0.7.5+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "toml_edit"
 version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap 2.10.0",
+ "indexmap 2.14.0",
  "serde",
- "serde_spanned",
- "toml_datetime",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
  "toml_write",
- "winnow",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.13+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
+dependencies = [
+ "indexmap 2.14.0",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "winnow 1.0.4",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.3+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
+dependencies = [
+ "winnow 1.0.4",
 ]
 
 [[package]]
@@ -5871,6 +6339,12 @@ name = "toml_write"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
+name = "toml_writer"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tower"
@@ -6089,6 +6563,12 @@ dependencies = [
  "crypto-common",
  "subtle",
 ]
+
+[[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "untrusted"
@@ -6693,9 +7173,18 @@ checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"
-version = "0.7.12"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3edebf492c8125044983378ecb5766203ad3b4c2f7a922bd7dd207f6d443e95"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 dependencies = [
  "memchr",
 ]
@@ -6722,6 +7211,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
+]
+
+[[package]]
+name = "x25519-dalek"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
+dependencies = [
+ "curve25519-dalek",
+ "rand_core 0.6.4",
+ "serde",
+ "zeroize",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-# The three deployed binaries live under bin/, next to `verify-quote`, which
+# The four deployed binaries live under bin/, next to `verify-quote`, which
 # runs off-node in deploy's hands; every crates/ member is a library (some also
 # build a tooling CLI behind their `cli` feature). The dir name is the crate;
 # the arrow is the binary target it builds.
@@ -8,6 +8,7 @@ members = [
     "bin/tdx-init",              # -> tdx-init
     "bin/attestation-service",   # -> seismic-attestation-service
     "bin/custodian-service",     # -> seismic-custodian-service
+    "bin/summit-key-holder",     # -> summit-key-holder
     "bin/verify-quote",          # -> verify-quote
 
     "crates/attestation",
@@ -51,6 +52,7 @@ anyhow = "1.0"
 attestation = { git = "https://github.com/flashbots/attested-tls", rev = "05a79a3f16a6d074bc10ce7aa29a3cd804fdc613" }
 az-cvm-vtpm = { version = "0.7.4", default-features = false }
 az-tdx-vtpm = "0.7.4"
+axum = "0.8.6"
 bincode = "1.3.3"
 ciborium = "0.2"
 clap = { version = "4.5.51", features = ["derive", "env"] }

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ configuration at boot.
 
 ## Layout
 
-`bin/` holds the three deployed binaries plus `verify-quote`, which runs
+`bin/` holds the four deployed binaries plus `verify-quote`, which runs
 off-node in deploy's hands; every crate under `crates/` is a library they
 share.
 
@@ -17,6 +17,7 @@ share.
 | `tdx-init` | `tdx-init` | Boot-time init: receives node config over HTTP and writes the enclave/reth runtime env, then exits. |
 | `attestation-service` | `seismic-attestation-service` | Network-facing JSON-RPC service (`:7878`): serves attestation evidence and purpose keys. Holds no key material — reaches the custodian over a Unix socket. |
 | `custodian-service` | `seismic-custodian-service` | Standalone service for the RAM-only root-key custodian: no network listener, minimal Unix-socket API, owns the per-boot LUKS keyfile handoff. |
+| `summit-key-holder` | `summit-key-holder` | Pre-manifest holder of a node's summit consensus keys: generates them in RAM at boot, serves `{pubkeys, quote}` over HTTP (`:7879`) for deploy's founding harvest, persists them into summit's keystore once LUKS opens. |
 | `verify-quote` | `verify-quote` | Not deployed to nodes: verification-only CLI that DCAP-verifies one founding node's summit-keys harvest quote against a measurement policy (JSON on stdout, exit 0 ⇔ verified). Shelled out to by deploy's harvest step. |
 
 ### Libraries (`crates/`)
@@ -32,6 +33,64 @@ share.
 | `measurement-admission` | Admission-ID derivation and measurement-policy compiler for the on-chain `MeasurementRegistry` (plus the policy-compiler CLI behind the `cli` feature). |
 | `network-manifest` | Network-manifest schema (`NetworkManifestV1`) and `network_id` derivation. |
 | `measurement-registry-client` | Read-only Alloy client for the on-chain `MeasurementRegistry`. |
+
+## Boot chain
+
+How the deployed binaries relate across one node boot. Every boot runs
+the same sequence; the founding harvest is the only founding-specific
+step (see [network-founding.md](https://github.com/SeismicSystems/seismic/blob/main/docs/tee/network-founding.md)).
+Unit ordering and the LUKS setup script live in seismic-images; deploy
+drives the node from off-box.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant D as deploy (off-node)
+    participant TI as tdx-init<br/>:8080
+    participant KH as summit-key-holder<br/>:7879 + control.sock
+    participant CU as custodian-service<br/>custodian.sock
+    participant AT as attestation-service<br/>:7878
+    participant LU as setup-persistent-luks<br/>(seismic-images)
+    participant SU as summit
+    participant RE as seismic-reth
+
+    Note over TI,KH: start at network-online, before any config exists
+    KH->>KH: generate summit keys in RAM
+    opt founding harvest — only while no manifest exists
+        D->>KH: GET /v1/quote?nonce=…
+        KH-->>D: {pubkeys, evidence}
+        Note over D: DCAP-verified off-node via verify-quote
+    end
+    D->>TI: POST node config
+    TI->>TI: validate, write /run/seismic/conf/*, exit
+    Note over KH: manifest present → /v1/quote answers 410<br/>(/v1/keys keeps serving, for life)
+    CU->>CU: start (after tdx-init):<br/>genesis node mints root_key, joiner awaits it
+    AT->>CU: connect custodian.sock
+    opt joining node
+        AT->>AT: attested root-key exchange with a peer's :7878
+        AT->>CU: install wrapped root_key
+    end
+    CU->>LU: root_key held → write per-boot LUKS keyfile
+    AT->>AT: bind :7878 (deploy's readiness signal)
+    LU->>LU: open /persistent
+    SU->>KH: ExecStartPre persist-wait →<br/>control.sock: persist
+    KH->>KH: write keystore (first boot) or confirm it (reboot),<br/>drop RAM keys
+    KH-->>SU: persisted / confirmed
+    SU->>SU: start from the keystore +<br/>/run/seismic/conf/summit-genesis.toml
+    RE->>CU: purpose keys over custodian.sock<br/>(per-UID ACL: reth gets tx-io + rng)
+```
+
+The same boot as a timeline — bars are process lifespans, labeled
+vertical lines are the boot-chain events. The red bar is the
+founding-fragility window: the summit keys exist only in one process's
+RAM until `/persistent` exists, and `/persistent` only exists
+*downstream of tdx-init's exit* (conf gates the custodian, the
+custodian's root_key gates the LUKS keyfile, the keyfile gates the
+mount). tdx-init is the only exits-after-boot binary; the holder and
+the custodian are both key-custodian services that do their critical
+work in the first seconds and then stay up serving it.
+
+![One node boot — event-ordered timeline](docs/boot-timeline.svg)
 
 ## Building
 

--- a/bin/summit-key-holder/Cargo.toml
+++ b/bin/summit-key-holder/Cargo.toml
@@ -1,0 +1,58 @@
+[package]
+name = "seismic-summit-key-holder"
+version.workspace = true
+edition.workspace = true
+repository.workspace = true
+homepage.workspace = true
+authors.workspace = true
+license.workspace = true
+readme.workspace = true
+description = "Pre-manifest holder of a node's summit consensus keys: RAM keygen at boot, {pubkeys, quote} over HTTP, keystore persist at LUKS-open"
+
+[lib]
+name = "seismic_summit_key_holder"
+path = "src/lib.rs"
+
+[[bin]]
+name = "summit-key-holder"
+path = "src/main.rs"
+
+[dependencies]
+seismic-attestation.workspace = true
+
+# Summit's exact commonware pin (summit Cargo.toml, plain crates.io, no
+# [patch]): the keystore this binary writes is read back by summit's
+# `KeyPaths`, so the key encoding must be commonware's, at summit's version.
+# `=` because commonware's calendar versioning makes 2026.5.0 "compatible"
+# to cargo while moving APIs. When summit bumps commonware, bump these with
+# it; the golden-vector test in keys.rs is what actually catches drift.
+#
+# TODO(summit-keystore): we should extract a small keystore crate in summit
+# (filenames + read/write + re-exported key types), and depend on that instead.
+# Caveat: a git dep does not inherit summit's Cargo.lock, so exact commonware pins (there or
+# here) and the golden-vector test stay necessary either way.
+#
+# The `rand` 0.8 line exists only because commonware's keygen takes a
+# rand_core 0.6 `CryptoRngCore`; the workspace `rand` is 0.9.
+commonware-codec = "=2026.4.0"
+commonware-cryptography = "=2026.4.0"
+commonware-math = "=2026.4.0"
+commonware-utils = "=2026.4.0"
+rand_08 = { package = "rand", version = "0.8.5" }
+
+anyhow.workspace = true
+axum.workspace = true
+clap.workspace = true
+hex.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+thiserror.workspace = true
+tokio.workspace = true
+tracing.workspace = true
+tracing-subscriber.workspace = true
+
+[dev-dependencies]
+# Router tests drive handlers through tower's `oneshot` without a socket.
+http-body-util = "0.1"
+tempfile = "3.17"
+tower = { version = "0.5", features = ["util"] }

--- a/bin/summit-key-holder/README.md
+++ b/bin/summit-key-holder/README.md
@@ -1,0 +1,79 @@
+# summit-key-holder
+
+Pre-manifest holder of a node's summit consensus keys. The network
+manifest pins every founding validator's pubkeys, so the keys must
+exist before the manifest does — before the config POST, before
+admission, before LUKS. This service generates the
+summit keypairs (ed25519 node identity + BLS12-381 MinPk consensus) in
+RAM at boot, serves `{pubkeys, quote}` over HTTP for deploy's founding
+harvest, and persists them into summit's keystore once LUKS has opened
+`/persistent`. Design:
+[network-founding.md](https://github.com/SeismicSystems/seismic/blob/main/docs/tee/network-founding.md).
+
+## Usage
+
+```sh
+# The long-running service (summit-key-holder.service, User=summit):
+summit-key-holder serve \
+    [--listen 0.0.0.0:7879] \
+    [--keystore-dir /persistent/summit/keys] \
+    [--control-socket /run/summit-key-holder/control.sock] \
+    [--network-manifest /run/seismic/conf/network-manifest.json]
+
+# summit.service's ExecStartPre — blocks until the keystore is written
+# (first boot) or confirmed (reboot):
+summit-key-holder persist-wait [--control-socket ...]
+```
+
+## HTTP API (`:7879`, plain HTTP)
+
+| Endpoint | Response |
+|---|---|
+| `GET /v1/keys` | `{node_public_key, consensus_public_key}` — bare lowercase hex (64 / 96 chars), exactly as summit renders them. Served for life; post-persist it reads the keystore and feeds deploy's launch-time continuity assertion. |
+| `GET /v1/quote?nonce=<64-hex>` | The keys plus `evidence`, a JSON-serialized `AttestationExchangeMessage` with `report_data = founding_summit_keys_binding(nonce, node_pk, consensus_pk)` — the exact bytes `verify-quote --evidence` consumes and deploy's harvest archives verbatim. `410 Gone` once the network manifest exists. |
+
+Quote generation opens the raw TPM (`/dev/tpm0`, exclusive) and costs
+seconds per call; requests are serialized in-process. Once the manifest
+lands, attestation-service owns the TPM quote path and this service
+refuses to quote — per boot, not permanently: the conf dir is tmpfs, so
+the window reopens on every boot until the config re-POST. That is why
+the port's NSG restriction to `operator_ip_cidr` is permanent.
+
+## Persist flow
+
+`persist` is one operation on the Unix control socket (never the
+network listener): write the keystore if absent, confirm it decodes if
+present, discard the RAM keys either way. A half-written keystore is
+finished on retry only if its one existing file provably holds this
+boot's own RAM key (an interrupted persist — each file lands
+atomically); any other partial keystore is refused, since overwriting
+it would silently mint keys the manifest never pinned. The retry path
+matters because production images have no shell: rebooting a founder
+burns its pinned keys, so a transient write failure that couldn't heal
+through systemd's restart of summit.service would force a full
+re-found. `persist-wait` retries while
+the holder is unreachable and exits nonzero on a definitive failure, so
+summit's start fails loudly rather than coming up without its pinned
+keys.
+
+The keystore is summit's wire format byte-for-byte (`node_key.pem` /
+`consensus_key.pem`, hex of the commonware-codec encoding, 0600 in a
+0700 dir), pinned by a golden-vector test against a keystore summit's
+own `keys generate` emitted. The commonware dependency is pinned `=` to
+summit's exact version for the same reason.
+
+## Security
+
+- The HTTP listener is up at the most exposed moment of the node's life
+  (pre-manifest, pre-admission). It holds the private keys in-process —
+  the accepted v1 trade; the control socket is the boundary along which
+  a custody split would happen — but never serves them: only pubkeys
+  and quotes leave the process.
+- A harvested key is trustworthy only if the same box later accepts the
+  real configure cleanly; any anomaly burns the whole harvest
+  (deploy-side procedure, nothing here enforces it).
+- RAM keys that never persist die with the process; both commonware
+  private-key types zeroize on drop. A reboot inside the founding
+  window therefore produces fresh keys — the launch-time continuity
+  assertion, not this service, is what catches the resulting pin
+  mismatch.

--- a/bin/summit-key-holder/src/control.rs
+++ b/bin/summit-key-holder/src/control.rs
@@ -1,0 +1,329 @@
+//! The persist control socket — deliberately not the network listener.
+//!
+//! One operation, `persist`: write the keystore if absent, confirm it if
+//! present, discard the RAM keys either way. summit.service's
+//! `ExecStartPre=summit-key-holder persist-wait` blocks on it — this is
+//! the sole provisioner of summit's keystore, so summit never starts
+//! before the pinned keys are on disk.
+//!
+//! This socket is the future custody-split boundary: if the holder is ever
+//! split into a socket-only custody process plus a secret-free HTTP front,
+//! the protocol here — and its `persist-wait` client — does not change.
+//!
+//! Wire format is one JSON line per direction over a per-request
+//! connection. No secret ever crosses this socket (responses carry public
+//! keys only), so the custodian's length-prefixed-CBOR/zeroize transport
+//! discipline would buy nothing here; a debuggable text protocol wins.
+//! systemd-tmpfiles creates the socket directory; both ends run as the
+//! `summit` user, so the socket itself is 0600.
+
+use std::io::ErrorKind;
+use std::path::Path;
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::Context as _;
+use serde::{Deserialize, Serialize};
+use tokio::io::{AsyncBufReadExt as _, AsyncReadExt as _, AsyncWriteExt as _, BufReader};
+use tokio::net::{UnixListener, UnixStream};
+use tracing::{debug, info, warn};
+
+use crate::state::{Holder, PersistOutcome};
+
+/// Default control socket path. The `/run/summit-key-holder` tmpfs
+/// directory is created by systemd-tmpfiles from a snippet in
+/// seismic-images; `bind` also creates it as a fallback for local runs.
+pub const DEFAULT_CONTROL_SOCKET_PATH: &str = "/run/summit-key-holder/control.sock";
+
+/// A request line must fit comfortably in one read; anything longer is not
+/// this protocol.
+const MAX_REQUEST_LINE: u64 = 1024;
+
+/// How long `persist-wait` sleeps between connection attempts while the
+/// holder is not up yet.
+const PERSIST_WAIT_RETRY: Duration = Duration::from_millis(500);
+
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(tag = "op", rename_all = "kebab-case")]
+pub enum ControlRequest {
+    Persist,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(tag = "result", rename_all = "kebab-case")]
+pub enum ControlResponse {
+    /// First boot: keystore written from this boot's RAM keys.
+    Persisted {
+        node_public_key: String,
+        consensus_public_key: String,
+    },
+    /// Reboot: existing keystore decoded cleanly; RAM keys discarded.
+    Confirmed {
+        node_public_key: String,
+        consensus_public_key: String,
+    },
+    /// Definitive failure (partial keystore, unwritable dir, …). The
+    /// client must exit nonzero, failing summit's start loudly.
+    Failed { error: String },
+}
+
+impl From<Result<PersistOutcome, crate::error::HolderError>> for ControlResponse {
+    fn from(result: Result<PersistOutcome, crate::error::HolderError>) -> Self {
+        match result {
+            Ok(outcome) => {
+                let keys = outcome.public_keys();
+                let (node_public_key, consensus_public_key) =
+                    (keys.node_hex(), keys.consensus_hex());
+                match outcome {
+                    PersistOutcome::Persisted(_) => ControlResponse::Persisted {
+                        node_public_key,
+                        consensus_public_key,
+                    },
+                    PersistOutcome::Confirmed(_) => ControlResponse::Confirmed {
+                        node_public_key,
+                        consensus_public_key,
+                    },
+                }
+            }
+            Err(e) => ControlResponse::Failed {
+                error: e.to_string(),
+            },
+        }
+    }
+}
+
+/// Bind the control socket, clearing a previous run's stale inode (same
+/// rationale as the custodian socket's bind).
+pub fn bind(path: &Path) -> std::io::Result<UnixListener> {
+    if let Some(dir) = path.parent() {
+        std::fs::create_dir_all(dir)?;
+    }
+    match std::fs::remove_file(path) {
+        Ok(()) => {}
+        Err(e) if e.kind() == ErrorKind::NotFound => {}
+        Err(e) => return Err(e),
+    }
+    let listener = UnixListener::bind(path)?;
+    // 0600: the only legitimate client is persist-wait running as the same
+    // (summit) user from summit.service's ExecStartPre.
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))?;
+    }
+    info!("control socket listening on {}", path.display());
+    Ok(listener)
+}
+
+/// Accept loop: one request line per connection, one response line back.
+/// Never returns.
+pub async fn serve(listener: UnixListener, holder: Arc<Holder>) {
+    loop {
+        let stream = match listener.accept().await {
+            Ok((stream, _)) => stream,
+            Err(e) => {
+                warn!("control socket accept failed: {e}");
+                continue;
+            }
+        };
+        let holder = Arc::clone(&holder);
+        tokio::spawn(async move {
+            if let Err(e) = handle_connection(stream, holder).await {
+                warn!("control connection failed: {e}");
+            }
+        });
+    }
+}
+
+/// Generic over the stream so the protocol is testable over an in-memory
+/// duplex; only [`serve`] touches real sockets (the custodian-ipc split).
+async fn handle_connection<S>(stream: S, holder: Arc<Holder>) -> anyhow::Result<()>
+where
+    S: tokio::io::AsyncRead + tokio::io::AsyncWrite,
+{
+    let (read_half, mut write_half) = tokio::io::split(stream);
+    let mut line = String::new();
+    BufReader::new(read_half.take(MAX_REQUEST_LINE))
+        .read_line(&mut line)
+        .await
+        .context("reading request line")?;
+
+    let response = match serde_json::from_str::<ControlRequest>(&line) {
+        Ok(ControlRequest::Persist) => {
+            // Keystore writes hit the persistent disk (sync_all); keep them
+            // off the async runtime.
+            let response: ControlResponse = tokio::task::spawn_blocking(move || holder.persist())
+                .await
+                .context("persist task panicked")?
+                .into();
+            if let ControlResponse::Failed { error } = &response {
+                warn!("persist failed: {error}");
+            } else {
+                info!("persist: {response:?}");
+            }
+            response
+        }
+        Err(e) => ControlResponse::Failed {
+            error: format!("unrecognized request: {e}"),
+        },
+    };
+
+    let mut bytes = serde_json::to_vec(&response).context("encoding response")?;
+    bytes.push(b'\n');
+    write_half
+        .write_all(&bytes)
+        .await
+        .context("writing response line")?;
+    Ok(())
+}
+
+/// The `persist-wait` client: block until the holder reports the keystore
+/// written (first boot) or confirmed (reboot); exit nonzero on a definitive
+/// failure. Connection errors mean the holder is not up yet and are
+/// retried forever — systemd's start timeout is the backstop.
+pub async fn persist_wait(path: &Path) -> anyhow::Result<ControlResponse> {
+    loop {
+        let stream = match UnixStream::connect(path).await {
+            Ok(stream) => stream,
+            Err(e) => {
+                debug!("holder not reachable at {} ({e}); retrying", path.display());
+                tokio::time::sleep(PERSIST_WAIT_RETRY).await;
+                continue;
+            }
+        };
+        // Past this point errors are protocol failures, not "not up yet":
+        // fail loudly rather than mask a broken holder by retrying.
+        return persist_once(stream).await;
+    }
+}
+
+async fn persist_once<S>(stream: S) -> anyhow::Result<ControlResponse>
+where
+    S: tokio::io::AsyncRead + tokio::io::AsyncWrite,
+{
+    let (read_half, mut write_half) = tokio::io::split(stream);
+    let mut request = serde_json::to_vec(&ControlRequest::Persist)?;
+    request.push(b'\n');
+    write_half
+        .write_all(&request)
+        .await
+        .context("sending persist request")?;
+
+    let mut line = String::new();
+    BufReader::new(read_half)
+        .read_line(&mut line)
+        .await
+        .context("reading persist response")?;
+    let response: ControlResponse =
+        serde_json::from_str(&line).context("decoding persist response")?;
+    match &response {
+        ControlResponse::Failed { error } => anyhow::bail!("holder refused persist: {error}"),
+        _ => Ok(response),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_holder(dir: &Path) -> Arc<Holder> {
+        Arc::new(Holder::new(
+            dir.join("keys"),
+            dir.join("network-manifest.json"),
+        ))
+    }
+
+    /// Drive one client request against `handle_connection` over an
+    /// in-memory duplex — the protocol without a real socket.
+    async fn persist_over_duplex(holder: &Arc<Holder>) -> anyhow::Result<ControlResponse> {
+        let (client, server) = tokio::io::duplex(4096);
+        let server_holder = Arc::clone(holder);
+        let server_task = tokio::spawn(handle_connection(server, server_holder));
+        let response = persist_once(client).await;
+        server_task.await.unwrap().unwrap();
+        response
+    }
+
+    #[tokio::test]
+    async fn persist_protocol_round_trips_first_boot_and_reboot() {
+        let dir = tempfile::tempdir().unwrap();
+        let holder = test_holder(dir.path());
+
+        let expected = holder.public_keys().unwrap();
+        match persist_over_duplex(&holder).await.unwrap() {
+            ControlResponse::Persisted {
+                node_public_key,
+                consensus_public_key,
+            } => {
+                assert_eq!(node_public_key, expected.node_hex());
+                assert_eq!(consensus_public_key, expected.consensus_hex());
+            }
+            other => panic!("expected Persisted, got {other:?}"),
+        }
+
+        // Second persist over the same keystore confirms.
+        match persist_over_duplex(&holder).await.unwrap() {
+            ControlResponse::Confirmed {
+                node_public_key, ..
+            } => {
+                assert_eq!(node_public_key, expected.node_hex());
+            }
+            other => panic!("expected Confirmed, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn persist_fails_loudly_on_a_partial_keystore() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("keys")).unwrap();
+        std::fs::write(dir.path().join("keys/node_key.pem"), "00").unwrap();
+        let holder = test_holder(dir.path());
+
+        let err = persist_over_duplex(&holder).await.unwrap_err().to_string();
+        assert!(err.contains("partial keystore"), "got: {err}");
+    }
+
+    #[tokio::test]
+    async fn garbage_requests_get_a_failed_response_not_a_hang() {
+        let dir = tempfile::tempdir().unwrap();
+        let holder = test_holder(dir.path());
+
+        let (client, server) = tokio::io::duplex(4096);
+        let server_task = tokio::spawn(handle_connection(server, holder));
+        let (read_half, mut write_half) = tokio::io::split(client);
+        write_half
+            .write_all(b"{\"op\":\"launch-missiles\"}\n")
+            .await
+            .unwrap();
+        let mut line = String::new();
+        BufReader::new(read_half)
+            .read_line(&mut line)
+            .await
+            .unwrap();
+        let response: ControlResponse = serde_json::from_str(&line).unwrap();
+        assert!(matches!(response, ControlResponse::Failed { .. }));
+        server_task.await.unwrap().unwrap();
+    }
+
+    /// End-to-end over a real socket: bind, serve, persist-wait. Requires
+    /// an environment that permits AF_UNIX binds (CI does; some sandboxes
+    /// don't — the duplex tests above cover the protocol there).
+    #[tokio::test(flavor = "multi_thread")]
+    async fn persist_wait_round_trips_over_a_real_socket() {
+        let dir = tempfile::tempdir().unwrap();
+        let socket = dir.path().join("control.sock");
+        let holder = test_holder(dir.path());
+        let listener = bind(&socket).unwrap();
+        tokio::spawn(serve(listener, Arc::clone(&holder)));
+
+        let expected = holder.public_keys().unwrap();
+        match persist_wait(&socket).await.unwrap() {
+            ControlResponse::Persisted {
+                node_public_key, ..
+            } => {
+                assert_eq!(node_public_key, expected.node_hex());
+            }
+            other => panic!("expected Persisted, got {other:?}"),
+        }
+    }
+}

--- a/bin/summit-key-holder/src/error.rs
+++ b/bin/summit-key-holder/src/error.rs
@@ -1,0 +1,83 @@
+//! Error type and its HTTP mapping.
+//!
+//! The HTTP listener is the node's most exposed surface (pre-manifest,
+//! pre-admission), so the mapping follows the attestation-service rule:
+//! caller mistakes surface their detail (400/410), server-side failures are
+//! logged in full and flattened to a fixed string on the wire.
+
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum HolderError {
+    /// The request's nonce was not 32 bytes of hex.
+    #[error("invalid nonce: {0}")]
+    InvalidNonce(String),
+
+    /// The network manifest exists, so the quote window has closed for this
+    /// boot: attestation-service owns the TPM quote path from the config
+    /// POST onward.
+    #[error("quote serving stopped: network manifest present")]
+    QuoteWindowClosed,
+
+    /// Keystore I/O or decode failure — includes the `Partial` state, where
+    /// exactly one key file exists and neither writing nor vouching is safe.
+    #[error("keystore: {0}")]
+    Keystore(String),
+
+    /// Evidence generation failed (TPM/IMDS path, or a non-TDX host).
+    #[error("evidence generation: {0}")]
+    Attestation(String),
+
+    /// RAM keys already discarded and no keystore present. Unreachable in
+    /// the designed lifecycle; loud if the impossible happens.
+    #[error("no keys held: RAM keys discarded and keystore absent")]
+    NoKeys,
+}
+
+impl IntoResponse for HolderError {
+    fn into_response(self) -> Response {
+        let (status, message) = match &self {
+            HolderError::InvalidNonce(detail) => {
+                (StatusCode::BAD_REQUEST, format!("invalid nonce: {detail}"))
+            }
+            HolderError::QuoteWindowClosed => (StatusCode::GONE, self.to_string()),
+            HolderError::Keystore(_) | HolderError::Attestation(_) | HolderError::NoKeys => {
+                tracing::error!(error = %self, "internal error serving holder request");
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "internal error".to_string(),
+                )
+            }
+        };
+        (status, message).into_response()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn internal_errors_do_not_leak_detail_on_the_wire() {
+        let response =
+            HolderError::Keystore("reading /persistent/summit/keys/node_key.pem: EACCES".into())
+                .into_response();
+        assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    }
+
+    #[test]
+    fn caller_mistakes_map_to_400_and_410() {
+        assert_eq!(
+            HolderError::InvalidNonce("expected 64 hex chars".into())
+                .into_response()
+                .status(),
+            StatusCode::BAD_REQUEST
+        );
+        assert_eq!(
+            HolderError::QuoteWindowClosed.into_response().status(),
+            StatusCode::GONE
+        );
+    }
+}

--- a/bin/summit-key-holder/src/http.rs
+++ b/bin/summit-key-holder/src/http.rs
@@ -1,0 +1,188 @@
+//! The network-facing HTTP surface (plain HTTP; nginx and certbot exist
+//! only post-POST, and deploy already polls raw ports pre-manifest).
+//!
+//! Two GETs, per the founding-harvest wire contract:
+//!
+//! - `GET /v1/keys` → `{node_public_key, consensus_public_key}` — served
+//!   for life; post-persist this feeds deploy's launch-time continuity
+//!   assertion (live pubkeys == pinned pubkeys).
+//! - `GET /v1/quote?nonce=<64-hex>` → the keys plus attestation evidence
+//!   whose `report_data` is `founding_summit_keys_binding(nonce, node_pk,
+//!   consensus_pk)` — the exact JSON `verify-quote --evidence` consumes and
+//!   deploy's harvest archives verbatim. Refuses 410 once the network
+//!   manifest exists: attestation-service owns the TPM from the config POST
+//!   onward.
+//!
+//! This listener is reachable pre-admission; the node NSG restricts the
+//! port to `operator_ip_cidr`, permanently — the conf dir is tmpfs, so the
+//! quote window reopens on every boot.
+
+use std::sync::Arc;
+
+use axum::Router;
+use axum::extract::{Query, State};
+use axum::response::Json;
+use axum::routing::get;
+use seismic_attestation::bindings::{binding64_from_digest32, founding_summit_keys_binding};
+use seismic_attestation::{AttestationExchangeMessage, AttestationType, generate_evidence};
+use serde::{Deserialize, Serialize};
+
+use crate::error::HolderError;
+use crate::state::Holder;
+
+/// Attestation type this build mints evidence for. Azure TDX + vTPM is the
+/// only supported surface today (mirrors attestation-service).
+const ATTESTATION_TYPE: AttestationType = AttestationType::AzureTdx;
+
+#[derive(Serialize, Deserialize)]
+pub struct KeysResponse {
+    pub node_public_key: String,
+    pub consensus_public_key: String,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct QuoteResponse {
+    pub node_public_key: String,
+    pub consensus_public_key: String,
+    /// The harvest wire *and* archive format: deploy stores these bytes
+    /// verbatim and hands them to `verify-quote --evidence`.
+    pub evidence: AttestationExchangeMessage,
+}
+
+#[derive(Deserialize)]
+struct QuoteParams {
+    nonce: String,
+}
+
+pub fn router(holder: Arc<Holder>) -> Router {
+    Router::new()
+        .route("/v1/keys", get(get_keys))
+        .route("/v1/quote", get(get_quote))
+        .with_state(holder)
+}
+
+async fn get_keys(State(holder): State<Arc<Holder>>) -> Result<Json<KeysResponse>, HolderError> {
+    let keys = holder.public_keys()?;
+    Ok(Json(KeysResponse {
+        node_public_key: keys.node_hex(),
+        consensus_public_key: keys.consensus_hex(),
+    }))
+}
+
+async fn get_quote(
+    State(holder): State<Arc<Holder>>,
+    Query(params): Query<QuoteParams>,
+) -> Result<Json<QuoteResponse>, HolderError> {
+    if !holder.quote_window_open() {
+        return Err(HolderError::QuoteWindowClosed);
+    }
+    let nonce = parse_nonce(&params.nonce)?;
+    let keys = holder.public_keys()?;
+    let binding = binding64_from_digest32(founding_summit_keys_binding(
+        &nonce,
+        &keys.node,
+        &keys.consensus,
+    ));
+
+    // Evidence generation blocks for seconds (NV write, fixed 3 s sleep,
+    // IMDS round-trip) and must not overlap itself, so gate it and push it
+    // off the async runtime.
+    let _gate = holder.quote_gate.lock().await;
+    let evidence =
+        tokio::task::spawn_blocking(move || generate_evidence(ATTESTATION_TYPE, binding))
+            .await
+            .map_err(|e| HolderError::Attestation(format!("evidence task panicked: {e}")))?
+            .map_err(|e| HolderError::Attestation(e.to_string()))?;
+
+    Ok(Json(QuoteResponse {
+        node_public_key: keys.node_hex(),
+        consensus_public_key: keys.consensus_hex(),
+        evidence,
+    }))
+}
+
+/// Parse a harvest nonce: 32 bytes of hex, `0x` optional (the same leniency
+/// as `verify-quote`'s hex arguments).
+fn parse_nonce(value: &str) -> Result<[u8; 32], HolderError> {
+    let stripped = value.strip_prefix("0x").unwrap_or(value);
+    let bytes =
+        hex::decode(stripped).map_err(|e| HolderError::InvalidNonce(format!("not hex: {e}")))?;
+    bytes
+        .try_into()
+        .map_err(|_| HolderError::InvalidNonce("expected 32 bytes (64 hex chars)".to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use http_body_util::BodyExt as _;
+    use std::fs;
+    use std::path::Path;
+    use tower::ServiceExt as _;
+
+    fn holder(dir: &Path) -> Arc<Holder> {
+        Arc::new(Holder::new(
+            dir.join("keys"),
+            dir.join("network-manifest.json"),
+        ))
+    }
+
+    async fn get(router: Router, uri: &str) -> (StatusCode, Vec<u8>) {
+        let response = router
+            .oneshot(Request::builder().uri(uri).body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        let status = response.status();
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        (status, body.to_vec())
+    }
+
+    #[tokio::test]
+    async fn keys_endpoint_serves_summit_shaped_hex() {
+        let dir = tempfile::tempdir().unwrap();
+        let (status, body) = get(router(holder(dir.path())), "/v1/keys").await;
+        assert_eq!(status, StatusCode::OK);
+        let keys: KeysResponse = serde_json::from_slice(&body).unwrap();
+        assert_eq!(keys.node_public_key.len(), 64);
+        assert_eq!(keys.consensus_public_key.len(), 96);
+        assert!(!keys.node_public_key.starts_with("0x"));
+    }
+
+    #[tokio::test]
+    async fn quote_refuses_410_once_manifest_exists() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join("network-manifest.json"), "{}").unwrap();
+        let (status, _) = get(
+            router(holder(dir.path())),
+            &format!("/v1/quote?nonce={}", "11".repeat(32)),
+        )
+        .await;
+        assert_eq!(status, StatusCode::GONE);
+    }
+
+    #[tokio::test]
+    async fn quote_rejects_bad_nonces_before_touching_the_tpm() {
+        let dir = tempfile::tempdir().unwrap();
+        let router = router(holder(dir.path()));
+        for uri in [
+            "/v1/quote",                                     // missing param
+            "/v1/quote?nonce=zz",                            // not hex
+            "/v1/quote?nonce=1122",                          // too short
+            &format!("/v1/quote?nonce={}", "11".repeat(33)), // too long
+        ] {
+            let (status, _) = get(router.clone(), uri).await;
+            assert_eq!(status, StatusCode::BAD_REQUEST, "uri: {uri}");
+        }
+    }
+
+    #[test]
+    fn nonce_parsing_accepts_optional_0x() {
+        let hex64 = "aa".repeat(32);
+        assert_eq!(
+            parse_nonce(&hex64).unwrap(),
+            parse_nonce(&format!("0x{hex64}")).unwrap()
+        );
+    }
+}

--- a/bin/summit-key-holder/src/keys.rs
+++ b/bin/summit-key-holder/src/keys.rs
@@ -1,0 +1,379 @@
+//! Summit keypair generation and keystore I/O.
+//!
+//! The keystore written here is read back by summit's `KeyPaths`
+//! (`types/src/key_paths.rs`), so the wire format is summit's, byte for
+//! byte: `node_key.pem` and `consensus_key.pem`, each the bare lowercase
+//! hex of the commonware-codec key encoding (64 chars — both private keys
+//! are 32-byte scalars), no `0x`, no trailing newline, file mode 0600 in a
+//! 0700 directory. Summit's reader is lenient (`from_hex_formatted`), but
+//! its own writer emits exactly this, and the golden-vector test below pins
+//! us to a keystore summit's `keys generate` produced.
+//!
+//! Private keys never leave this module as raw bytes: [`HeldKeys`] hands
+//! out only public material, and both commonware key types zeroize on drop.
+
+use std::fs;
+use std::io::Write as _;
+use std::path::{Path, PathBuf};
+
+use commonware_codec::Encode as _;
+use commonware_cryptography::Signer as _;
+use commonware_cryptography::{bls12381, ed25519};
+use commonware_math::algebra::Random as _;
+
+use crate::error::HolderError;
+
+/// Summit's node-identity key filename (`KeyPaths::node_key_path_str`).
+pub const NODE_KEY_FILE: &str = "node_key.pem";
+/// Summit's consensus key filename (`KeyPaths::consensus_key_path_str`).
+pub const CONSENSUS_KEY_FILE: &str = "consensus_key.pem";
+
+/// The summit keypairs, held in RAM between boot and persist.
+///
+/// Deliberately not `Clone`: exactly one copy per process, dropped (and
+/// zeroized — both commonware private key types wrap their scalar in a
+/// zeroizing `Secret`) at persist or with the process.
+pub struct HeldKeys {
+    node: ed25519::PrivateKey,
+    consensus: bls12381::PrivateKey,
+}
+
+impl HeldKeys {
+    /// Generate a fresh keypair set from the OS RNG.
+    pub fn generate() -> Self {
+        Self {
+            node: ed25519::PrivateKey::random(&mut rand_08::rngs::OsRng),
+            consensus: bls12381::PrivateKey::random(&mut rand_08::rngs::OsRng),
+        }
+    }
+
+    pub fn public_keys(&self) -> PublicKeys {
+        PublicKeys::derive(&self.node, &self.consensus)
+    }
+}
+
+/// Public halves of a summit keypair set, as the fixed-size raw bytes the
+/// founding binding hashes. Hex rendering matches summit's (`Display` on
+/// commonware public keys): bare lowercase, no `0x`.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PublicKeys {
+    pub node: [u8; 32],
+    pub consensus: [u8; 48],
+}
+
+impl PublicKeys {
+    fn derive(node: &ed25519::PrivateKey, consensus: &bls12381::PrivateKey) -> Self {
+        let node = node
+            .public_key()
+            .encode()
+            .as_ref()
+            .try_into()
+            .expect("ed25519 public keys encode to 32 bytes");
+        let consensus = consensus
+            .public_key()
+            .encode()
+            .as_ref()
+            .try_into()
+            .expect("BLS12-381 MinPk public keys encode to 48 bytes");
+        Self { node, consensus }
+    }
+
+    pub fn node_hex(&self) -> String {
+        commonware_utils::hex(&self.node)
+    }
+
+    pub fn consensus_hex(&self) -> String {
+        commonware_utils::hex(&self.consensus)
+    }
+}
+
+/// What exists at a keystore path. `Partial` is an error to act on —
+/// writing would clobber half a keystore, confirming would vouch for one —
+/// unless [`partial_matches_held`] proves it is this boot's own interrupted
+/// persist, which finishing converges.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum KeystoreStatus {
+    Absent,
+    Partial,
+    Present,
+}
+
+/// Report which of the two key files exist under `dir`.
+///
+/// A missing directory is `Absent`, not an error: pre-LUKS the keystore's
+/// mount point does not exist yet, and the uniform serving rule ("keystore
+/// if present, else RAM") relies on that reading.
+pub fn keystore_status(dir: &Path) -> KeystoreStatus {
+    let node = dir.join(NODE_KEY_FILE).is_file();
+    let consensus = dir.join(CONSENSUS_KEY_FILE).is_file();
+    match (node, consensus) {
+        (true, true) => KeystoreStatus::Present,
+        (false, false) => KeystoreStatus::Absent,
+        _ => KeystoreStatus::Partial,
+    }
+}
+
+/// Whether every key file that *does* exist under `dir` holds exactly the
+/// keys in `keys`.
+///
+/// This is what makes a `Partial` keystore safe to finish: each file lands
+/// atomically (temp + rename), so a half-written keystore's one file is a
+/// complete key — if it decodes to the held RAM key, the partial state is
+/// this boot's own interrupted persist and rewriting converges on the
+/// keystore that persist was building. Foreign or undecodable content is
+/// `false`: overwriting it would silently mint keys the manifest never
+/// pinned.
+pub fn partial_matches_held(dir: &Path, keys: &HeldKeys) -> bool {
+    let file_matches = |file: &str, held_encoding: &[u8]| {
+        let path = dir.join(file);
+        !path.is_file()
+            || fs::read_to_string(&path)
+                .ok()
+                .and_then(|encoded| commonware_utils::from_hex_formatted(&encoded))
+                .is_some_and(|raw| raw.as_slice() == held_encoding)
+    };
+    file_matches(NODE_KEY_FILE, keys.node.encode().as_ref())
+        && file_matches(CONSENSUS_KEY_FILE, keys.consensus.encode().as_ref())
+}
+
+/// Write `keys` into `dir` in summit's keystore format.
+///
+/// The directory is created 0700 like summit's `create_keystore_dir`; each
+/// file lands via a same-directory temp file (`create_new`, mode 0600,
+/// `sync_all`) renamed into place, so a reader polling for the exact path
+/// never observes a partially-written key — the same discipline as the
+/// custodian's LUKS keyfile.
+pub fn write_keystore(dir: &Path, keys: &HeldKeys) -> Result<(), HolderError> {
+    create_keystore_dir(dir).map_err(|e| {
+        HolderError::Keystore(format!("creating keystore dir {}: {e}", dir.display()))
+    })?;
+    write_key_file(
+        &dir.join(NODE_KEY_FILE),
+        &commonware_utils::hex(&keys.node.encode()),
+    )?;
+    write_key_file(
+        &dir.join(CONSENSUS_KEY_FILE),
+        &commonware_utils::hex(&keys.consensus.encode()),
+    )?;
+    Ok(())
+}
+
+/// Read both key files from `dir` and derive their public halves.
+///
+/// Decoding the privates (rather than stat-ing the files) is the point:
+/// `Confirmed` from the persist op and every post-persist `/v1/keys`
+/// response vouch for a keystore summit will actually be able to load.
+pub fn read_keystore_public_keys(dir: &Path) -> Result<PublicKeys, HolderError> {
+    let node: ed25519::PrivateKey = read_key_file(&dir.join(NODE_KEY_FILE))?;
+    let consensus: bls12381::PrivateKey = read_key_file(&dir.join(CONSENSUS_KEY_FILE))?;
+    Ok(PublicKeys::derive(&node, &consensus))
+}
+
+fn read_key_file<K: commonware_codec::DecodeExt<()>>(path: &Path) -> Result<K, HolderError> {
+    let encoded = fs::read_to_string(path)
+        .map_err(|e| HolderError::Keystore(format!("reading {}: {e}", path.display())))?;
+    let raw = commonware_utils::from_hex_formatted(&encoded)
+        .ok_or_else(|| HolderError::Keystore(format!("{} is not hex", path.display())))?;
+    K::decode(raw.as_ref())
+        .map_err(|e| HolderError::Keystore(format!("decoding {}: {e}", path.display())))
+}
+
+/// Create the keystore directory 0700, exactly like summit's
+/// `create_keystore_dir` — private keys land here, so a permissive umask
+/// must not leak into the directory mode.
+fn create_keystore_dir(dir: &Path) -> std::io::Result<()> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::DirBuilderExt as _;
+        fs::DirBuilder::new()
+            .recursive(true)
+            .mode(0o700)
+            .create(dir)
+    }
+    #[cfg(not(unix))]
+    {
+        fs::create_dir_all(dir)
+    }
+}
+
+fn write_key_file(path: &Path, contents: &str) -> Result<(), HolderError> {
+    let tmp = tmp_path(path);
+    let write = || -> std::io::Result<()> {
+        // A crash between temp-create and rename strands a temp file on the
+        // persistent disk, and `create_new` would then fail every later
+        // persist; clear it first. `create_new` still closes the race window
+        // between two live writers.
+        match fs::remove_file(&tmp) {
+            Ok(()) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => return Err(e),
+        }
+        let mut open = fs::OpenOptions::new();
+        open.write(true).create_new(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt as _;
+            open.mode(0o600);
+        }
+        let mut file = open.open(&tmp)?;
+        file.write_all(contents.as_bytes())?;
+        file.sync_all()?;
+        fs::rename(&tmp, path)
+    };
+    write().map_err(|e| {
+        // Best-effort cleanup so a failed write doesn't strand a temp file
+        // that fails the next attempt's `create_new`.
+        let _ = fs::remove_file(&tmp);
+        HolderError::Keystore(format!("writing {}: {e}", path.display()))
+    })
+}
+
+fn tmp_path(path: &Path) -> PathBuf {
+    let mut name = path
+        .file_name()
+        .expect("key paths have filenames")
+        .to_owned();
+    name.push(".tmp");
+    path.with_file_name(name)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use commonware_codec::DecodeExt as _;
+
+    /// Golden vectors: a keystore emitted by summit's `keys generate`
+    /// (summit `testnet/node0`, committed at
+    /// <https://github.com/SeismicSystems/summit/tree/main/testnet/node0>),
+    /// whose public keys are independently pinned as the first validator of
+    /// summit's `example_genesis.toml`.
+    const SUMMIT_NODE_KEY_FILE: &str =
+        "19887e80c3ebb397ef2167b52beb89eab9208699f918dfb311c9a44cb52f8b25";
+    const SUMMIT_CONSENSUS_KEY_FILE: &str =
+        "0097b3521bf678203a7fb449b3d5e4870ce56cac94c837b6a116a78f902a891f";
+    const SUMMIT_NODE_PUBKEY: &str =
+        "1be3cb06d7cc347602421fb73838534e4b54934e28959de98906d120d0799ef2";
+    const SUMMIT_CONSENSUS_PUBKEY: &str = "a6f61154ae7be4fd38cd43cf69adfd4896c57473cacb389702bb83f8adf923eecf4854c745e064c0a2db79db5674332b";
+
+    fn summit_keystore(dir: &Path) {
+        fs::write(dir.join(NODE_KEY_FILE), SUMMIT_NODE_KEY_FILE).unwrap();
+        fs::write(dir.join(CONSENSUS_KEY_FILE), SUMMIT_CONSENSUS_KEY_FILE).unwrap();
+    }
+
+    #[test]
+    fn golden_vector_reads_summit_keystore() {
+        let dir = tempfile::tempdir().unwrap();
+        summit_keystore(dir.path());
+        let keys = read_keystore_public_keys(dir.path()).unwrap();
+        assert_eq!(keys.node_hex(), SUMMIT_NODE_PUBKEY);
+        assert_eq!(keys.consensus_hex(), SUMMIT_CONSENSUS_PUBKEY);
+    }
+
+    #[test]
+    fn golden_vector_write_matches_summit_bytes() {
+        // Decode the summit-emitted privates, write them through our writer,
+        // and require the exact file bytes back: this is the byte-parity pin
+        // on the wire format (bare lowercase hex, no 0x, no newline).
+        let node = ed25519::PrivateKey::decode(
+            commonware_utils::from_hex(SUMMIT_NODE_KEY_FILE)
+                .unwrap()
+                .as_ref(),
+        )
+        .unwrap();
+        let consensus = bls12381::PrivateKey::decode(
+            commonware_utils::from_hex(SUMMIT_CONSENSUS_KEY_FILE)
+                .unwrap()
+                .as_ref(),
+        )
+        .unwrap();
+        let keys = HeldKeys { node, consensus };
+
+        let dir = tempfile::tempdir().unwrap();
+        let store = dir.path().join("keys");
+        write_keystore(&store, &keys).unwrap();
+
+        let node_bytes = fs::read(store.join(NODE_KEY_FILE)).unwrap();
+        let consensus_bytes = fs::read(store.join(CONSENSUS_KEY_FILE)).unwrap();
+        assert_eq!(node_bytes, SUMMIT_NODE_KEY_FILE.as_bytes());
+        assert_eq!(consensus_bytes, SUMMIT_CONSENSUS_KEY_FILE.as_bytes());
+
+        let read_back = read_keystore_public_keys(&store).unwrap();
+        assert_eq!(read_back.node_hex(), SUMMIT_NODE_PUBKEY);
+        assert_eq!(read_back.consensus_hex(), SUMMIT_CONSENSUS_PUBKEY);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn keystore_permissions_match_summit() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let dir = tempfile::tempdir().unwrap();
+        let store = dir.path().join("keys");
+        write_keystore(&store, &HeldKeys::generate()).unwrap();
+
+        let mode = |p: &Path| fs::metadata(p).unwrap().permissions().mode() & 0o7777;
+        assert_eq!(mode(&store), 0o700);
+        assert_eq!(mode(&store.join(NODE_KEY_FILE)), 0o600);
+        assert_eq!(mode(&store.join(CONSENSUS_KEY_FILE)), 0o600);
+    }
+
+    #[test]
+    fn generate_write_read_round_trips() {
+        let keys = HeldKeys::generate();
+        let expected = keys.public_keys();
+        assert_eq!(expected.node_hex().len(), 64);
+        assert_eq!(expected.consensus_hex().len(), 96);
+
+        let dir = tempfile::tempdir().unwrap();
+        write_keystore(dir.path(), &keys).unwrap();
+        assert_eq!(read_keystore_public_keys(dir.path()).unwrap(), expected);
+    }
+
+    #[test]
+    fn status_distinguishes_absent_partial_present() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = dir.path().join("nonexistent");
+        assert_eq!(keystore_status(&store), KeystoreStatus::Absent);
+
+        assert_eq!(keystore_status(dir.path()), KeystoreStatus::Absent);
+        fs::write(dir.path().join(NODE_KEY_FILE), SUMMIT_NODE_KEY_FILE).unwrap();
+        assert_eq!(keystore_status(dir.path()), KeystoreStatus::Partial);
+        fs::write(
+            dir.path().join(CONSENSUS_KEY_FILE),
+            SUMMIT_CONSENSUS_KEY_FILE,
+        )
+        .unwrap();
+        assert_eq!(keystore_status(dir.path()), KeystoreStatus::Present);
+    }
+
+    #[test]
+    fn partial_matches_held_distinguishes_own_write_from_foreign() {
+        let keys = HeldKeys::generate();
+        let dir = tempfile::tempdir().unwrap();
+
+        // Our own interrupted write: one file, holding the held node key.
+        write_keystore(dir.path(), &keys).unwrap();
+        fs::remove_file(dir.path().join(CONSENSUS_KEY_FILE)).unwrap();
+        assert!(partial_matches_held(dir.path(), &keys));
+
+        // The same file holding someone else's key, or garbage: foreign.
+        fs::write(dir.path().join(NODE_KEY_FILE), SUMMIT_NODE_KEY_FILE).unwrap();
+        assert!(!partial_matches_held(dir.path(), &keys));
+        fs::write(dir.path().join(NODE_KEY_FILE), "not hex").unwrap();
+        assert!(!partial_matches_held(dir.path(), &keys));
+    }
+
+    #[test]
+    fn stale_temp_file_does_not_block_a_later_write() {
+        // A crash between temp-create and rename must not wedge every later
+        // persist attempt: the writer clears its own stale temp file first.
+        let keys = HeldKeys::generate();
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join(format!("{NODE_KEY_FILE}.tmp")), "stale").unwrap();
+        write_keystore(dir.path(), &keys).unwrap();
+        assert_eq!(
+            read_keystore_public_keys(dir.path()).unwrap(),
+            keys.public_keys()
+        );
+    }
+}

--- a/bin/summit-key-holder/src/lib.rs
+++ b/bin/summit-key-holder/src/lib.rs
@@ -1,0 +1,46 @@
+//! Pre-manifest holder of a node's summit consensus keys.
+//!
+//! The network manifest pins every founding validator's pubkeys, so the
+//! keys must exist *before* the manifest does — before the config POST,
+//! before admission, before LUKS. This service is
+//! where they live in that window: it generates the summit keypairs
+//! (ed25519 node identity + BLS12-381 MinPk consensus) in RAM at boot,
+//! serves `{pubkeys, quote}` over plain HTTP for deploy's founding harvest,
+//! and persists them into summit's keystore once LUKS has opened
+//! `/persistent`. See
+//! <https://github.com/SeismicSystems/seismic/blob/main/docs/tee/network-founding.md>.
+//!
+//! Boundary rules:
+//!
+//! - **Never the custodian.** These are per-VM identity keys, not
+//!   `root_key`-shared secrets, and the custodian's design is *no network
+//!   listener, ever* — while this service must serve HTTP to the outside
+//!   pre-manifest, the most exposed moment in the node's life. Hosting the
+//!   keys there would undo the custodian split.
+//! - **Same user as summit.** The keystore is written as the `summit` user
+//!   into summit's own key directory: summit's keys live under summit's own
+//!   user/ownership even though keygen happens in this binary, and serving
+//!   pubkeys never grants another user read access to key material.
+//! - **Keygen/persist vs serve are separable modules** ([`keys`] and
+//!   [`state`] vs [`http`]), and the persist trigger is a Unix control
+//!   socket ([`control`]) rather than the network listener. The socket is
+//!   the future custody-split boundary: if the single-process holder is
+//!   ever split (privates in a socket-only process, a secret-free HTTP
+//!   front), the client side of that socket does not change.
+//!
+//! Lifecycle per boot: generate RAM keys → serve `{pubkeys, quote}` until
+//! `/run/seismic/conf/network-manifest.json` appears (the quote window;
+//! reopens every boot since the conf dir is tmpfs) → `persist` over the
+//! control socket writes the keystore on first boot or confirms it on
+//! reboot, discarding the RAM keys either way → pubkey serving continues
+//! for life from the keystore, feeding the launch-time continuity
+//! assertion. RAM keys that never persist die with the process (dropping a
+//! commonware private key zeroizes it); a reboot in the founding window
+//! therefore burns the harvested key, which the launch assertion is
+//! designed to catch.
+
+pub mod control;
+pub mod error;
+pub mod http;
+pub mod keys;
+pub mod state;

--- a/bin/summit-key-holder/src/main.rs
+++ b/bin/summit-key-holder/src/main.rs
@@ -1,0 +1,122 @@
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use clap::{Parser, Subcommand};
+use seismic_summit_key_holder::control::{self, DEFAULT_CONTROL_SOCKET_PATH};
+use seismic_summit_key_holder::http;
+use seismic_summit_key_holder::state::Holder;
+use tracing::info;
+use tracing_subscriber::EnvFilter;
+
+/// Where the holder serves `{pubkeys, quote}`. `0.0.0.0`: deploy's harvest
+/// dials in from outside; the node NSG restricts the port to
+/// `operator_ip_cidr`, permanently (the quote window reopens every boot).
+const DEFAULT_LISTEN_ADDR: &str = "0.0.0.0:7879";
+
+/// Summit's keystore, on the LUKS-backed persistent volume
+/// (`/persistent/summit` is 0700 summit:summit per seismic-images'
+/// tmpfiles-persistent.conf). Does not exist until LUKS opens; the holder
+/// serves RAM keys until then.
+const DEFAULT_KEYSTORE_DIR: &str = "/persistent/summit/keys";
+
+/// Where tdx-init drops the verbatim manifest. Mirrors tdx-init's
+/// `CONF_DIR`/`network-manifest.json`; its presence closes the quote
+/// window for this boot.
+const NETWORK_MANIFEST_PATH: &str = "/run/seismic/conf/network-manifest.json";
+
+#[derive(Parser)]
+#[command(author, version, about, long_about = None)]
+struct Args {
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Subcommand)]
+enum Command {
+    /// Generate summit keys in RAM and serve them: `{pubkeys, quote}` over
+    /// HTTP for deploy's founding harvest, plus the persist control socket.
+    Serve {
+        /// HTTP listen address.
+        #[arg(long, default_value = DEFAULT_LISTEN_ADDR)]
+        listen: String,
+        /// Summit keystore directory the persist op writes into.
+        #[arg(long, default_value = DEFAULT_KEYSTORE_DIR)]
+        keystore_dir: PathBuf,
+        /// Persist control socket path.
+        #[arg(long, default_value = DEFAULT_CONTROL_SOCKET_PATH)]
+        control_socket: PathBuf,
+        /// Network manifest path whose presence closes the quote window.
+        #[arg(long, default_value = NETWORK_MANIFEST_PATH)]
+        network_manifest: PathBuf,
+    },
+    /// Block until the holder has written the keystore (first boot) or
+    /// confirmed it already exists (reboot). summit.service's
+    /// ExecStartPre — the sole provisioner of summit's keystore, so a
+    /// definitive failure exits nonzero and fails summit's start loudly
+    /// rather than letting it run on keys the manifest never pinned.
+    PersistWait {
+        /// Persist control socket path.
+        #[arg(long, default_value = DEFAULT_CONTROL_SOCKET_PATH)]
+        control_socket: PathBuf,
+    },
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
+    tracing_subscriber::fmt().with_env_filter(filter).init();
+
+    match Args::parse().command {
+        Command::Serve {
+            listen,
+            keystore_dir,
+            control_socket,
+            network_manifest,
+        } => serve(listen, keystore_dir, control_socket, network_manifest).await,
+        Command::PersistWait { control_socket } => {
+            let response = control::persist_wait(&control_socket).await?;
+            info!("persist complete: {response:?}");
+            Ok(())
+        }
+    }
+}
+
+async fn serve(
+    listen: String,
+    keystore_dir: PathBuf,
+    control_socket: PathBuf,
+    network_manifest: PathBuf,
+) -> anyhow::Result<()> {
+    let holder = Arc::new(Holder::new(keystore_dir, network_manifest));
+    let keys = holder.public_keys()?;
+    info!(
+        node_public_key = %keys.node_hex(),
+        consensus_public_key = %keys.consensus_hex(),
+        "summit keys held"
+    );
+
+    let control_listener = control::bind(&control_socket)?;
+    let http_listener = tokio::net::TcpListener::bind(&listen).await?;
+    info!("HTTP listening on {listen}");
+
+    tokio::select! {
+        result = axum::serve(http_listener, http::router(Arc::clone(&holder))) => {
+            result?;
+            anyhow::bail!("HTTP server exited unexpectedly");
+        }
+        _ = control::serve(control_listener, holder) => {
+            unreachable!("the control accept loop never returns");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::CommandFactory as _;
+
+    #[test]
+    fn args_parse() {
+        Args::command().debug_assert();
+    }
+}

--- a/bin/summit-key-holder/src/state.rs
+++ b/bin/summit-key-holder/src/state.rs
@@ -1,0 +1,275 @@
+//! The holder's key state machine.
+//!
+//! One rule decides what every surface serves: **keystore if present, else
+//! RAM**. At boot the keystore's mount point does not even exist (LUKS has
+//! not opened `/persistent`), so fresh RAM keys serve; after `persist`, the
+//! keystore serves — for life, feeding the launch-time pubkey-continuity
+//! assertion. The uniform rule also makes the per-boot rewind harmless: a
+//! rebooted node regenerates RAM keys and serves them until `persist`
+//! discards them in favor of the keystore it confirms.
+
+use std::path::PathBuf;
+use std::sync::Mutex;
+
+use crate::error::HolderError;
+use crate::keys::{
+    HeldKeys, KeystoreStatus, PublicKeys, keystore_status, partial_matches_held,
+    read_keystore_public_keys, write_keystore,
+};
+
+/// What a `persist` request did.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum PersistOutcome {
+    /// First boot: the RAM keys were written into the keystore.
+    Persisted(PublicKeys),
+    /// Reboot: the keystore already existed and decoded cleanly; this
+    /// boot's RAM keys were discarded.
+    Confirmed(PublicKeys),
+}
+
+impl PersistOutcome {
+    pub fn public_keys(&self) -> &PublicKeys {
+        match self {
+            PersistOutcome::Persisted(keys) | PersistOutcome::Confirmed(keys) => keys,
+        }
+    }
+}
+
+pub struct Holder {
+    /// RAM keys, present from boot until `persist` drops them (dropping a
+    /// commonware private key zeroizes it). The mutex also serializes
+    /// concurrent `persist` requests.
+    ram: Mutex<Option<HeldKeys>>,
+    keystore_dir: PathBuf,
+    manifest_path: PathBuf,
+    /// Serializes evidence generation within this process: the vTPM quote
+    /// path is exclusive-open on `/dev/tpm0` and takes seconds per call.
+    /// (Cross-process serialization is by design: this service stops
+    /// quoting once the manifest exists, before attestation-service — the
+    /// TPM's owner from then on — starts.)
+    pub quote_gate: tokio::sync::Mutex<()>,
+}
+
+impl Holder {
+    /// Generate fresh RAM keys and stand up the state machine.
+    pub fn new(keystore_dir: PathBuf, manifest_path: PathBuf) -> Self {
+        Self::with_keys(HeldKeys::generate(), keystore_dir, manifest_path)
+    }
+
+    /// Stand up the state machine over known keys — tests plant these on
+    /// disk to fabricate an "own interrupted write" partial keystore.
+    pub(crate) fn with_keys(keys: HeldKeys, keystore_dir: PathBuf, manifest_path: PathBuf) -> Self {
+        Self {
+            ram: Mutex::new(Some(keys)),
+            keystore_dir,
+            manifest_path,
+            quote_gate: tokio::sync::Mutex::new(()),
+        }
+    }
+
+    /// The uniform serving rule: keystore if present, else RAM keys.
+    pub fn public_keys(&self) -> Result<PublicKeys, HolderError> {
+        match keystore_status(&self.keystore_dir) {
+            KeystoreStatus::Present => read_keystore_public_keys(&self.keystore_dir),
+            KeystoreStatus::Partial => Err(self.partial_keystore_error()),
+            KeystoreStatus::Absent => self
+                .ram
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .as_ref()
+                .map(HeldKeys::public_keys)
+                .ok_or(HolderError::NoKeys),
+        }
+    }
+
+    /// Quotes are served only until the network manifest lands: from the
+    /// config POST onward, attestation-service owns the TPM quote path.
+    /// A per-request stat of the tmpfs path is the freshest possible check.
+    pub fn quote_window_open(&self) -> bool {
+        !self.manifest_path.exists()
+    }
+
+    /// The control socket's one operation: write the keystore if absent,
+    /// confirm it if present, discard the RAM keys either way.
+    ///
+    /// Holding the RAM lock across the whole operation serializes
+    /// concurrent `persist` requests, so exactly one writer ever runs.
+    pub fn persist(&self) -> Result<PersistOutcome, HolderError> {
+        let mut ram = self
+            .ram
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        match keystore_status(&self.keystore_dir) {
+            KeystoreStatus::Present => {
+                // Decode before vouching: `Confirmed` must mean summit can
+                // load these files, not merely that they exist.
+                let keys = read_keystore_public_keys(&self.keystore_dir)?;
+                // This boot's RAM keys were never pinned; the launch
+                // continuity assertion is what surfaces a mismatch between
+                // the confirmed keystore and the manifest.
+                *ram = None;
+                Ok(PersistOutcome::Confirmed(keys))
+            }
+            KeystoreStatus::Partial => {
+                // A partial keystore that provably holds this boot's own RAM
+                // keys is an interrupted persist (each file lands atomically,
+                // so the one that exists is a complete key): finishing the
+                // write converges on the keystore that attempt was building.
+                // Anything else — a prior boot's remnant, foreign content —
+                // is refused: overwriting would silently mint keys the
+                // manifest never pinned.
+                let held = ram.as_ref().ok_or_else(|| self.partial_keystore_error())?;
+                if !partial_matches_held(&self.keystore_dir, held) {
+                    return Err(self.partial_keystore_error());
+                }
+                write_keystore(&self.keystore_dir, held)?;
+                let keys = held.public_keys();
+                *ram = None;
+                Ok(PersistOutcome::Persisted(keys))
+            }
+            KeystoreStatus::Absent => {
+                let held = ram.as_ref().ok_or(HolderError::NoKeys)?;
+                write_keystore(&self.keystore_dir, held)?;
+                let keys = held.public_keys();
+                *ram = None;
+                Ok(PersistOutcome::Persisted(keys))
+            }
+        }
+    }
+
+    fn partial_keystore_error(&self) -> HolderError {
+        HolderError::Keystore(format!(
+            "partial keystore at {}: exactly one of node_key.pem/consensus_key.pem exists; \
+             refusing to write over or vouch for it",
+            self.keystore_dir.display()
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::path::Path;
+
+    fn holder(dir: &Path) -> Holder {
+        Holder::new(dir.join("keys"), dir.join("network-manifest.json"))
+    }
+
+    #[test]
+    fn serves_ram_keys_until_persist_then_keystore() {
+        let dir = tempfile::tempdir().unwrap();
+        let holder = holder(dir.path());
+
+        let ram_keys = holder.public_keys().unwrap();
+        let outcome = holder.persist().unwrap();
+        assert_eq!(outcome, PersistOutcome::Persisted(ram_keys.clone()));
+
+        // Post-persist the keystore serves, and it holds the same keys.
+        assert_eq!(holder.public_keys().unwrap(), ram_keys);
+    }
+
+    #[test]
+    fn persist_on_existing_keystore_confirms_and_discards_ram_keys() {
+        let dir = tempfile::tempdir().unwrap();
+        let first_boot = holder(dir.path());
+        let pinned = match first_boot.persist().unwrap() {
+            PersistOutcome::Persisted(keys) => keys,
+            other => panic!("expected Persisted, got {other:?}"),
+        };
+
+        // A "reboot": a fresh holder with fresh RAM keys over the same dir.
+        let rebooted = holder(dir.path());
+        assert_eq!(
+            rebooted.persist().unwrap(),
+            PersistOutcome::Confirmed(pinned.clone())
+        );
+        // The fresh RAM keys are gone; the pinned keystore serves.
+        assert_eq!(rebooted.public_keys().unwrap(), pinned);
+    }
+
+    #[test]
+    fn keystore_wins_over_ram_keys_before_persist() {
+        // Uniform rule: a rebooted node with an already-opened keystore
+        // serves the pinned keys even before its persist confirms them.
+        let dir = tempfile::tempdir().unwrap();
+        let first_boot = holder(dir.path());
+        let pinned = first_boot.persist().unwrap().public_keys().clone();
+
+        let rebooted = holder(dir.path());
+        assert_eq!(rebooted.public_keys().unwrap(), pinned);
+    }
+
+    #[test]
+    fn persist_finishes_its_own_interrupted_write() {
+        // Simulate a persist that crashed between the two file writes: one
+        // complete key file holding this boot's own RAM key. The retry must
+        // finish the keystore rather than wedge on Partial.
+        let dir = tempfile::tempdir().unwrap();
+        let store = dir.path().join("keys");
+        let keys = HeldKeys::generate();
+        write_keystore(&store, &keys).unwrap();
+        fs::remove_file(store.join(crate::keys::CONSENSUS_KEY_FILE)).unwrap();
+
+        let holder = Holder::with_keys(keys, store, dir.path().join("network-manifest.json"));
+        // Serving still refuses the Partial state; only persist repairs it.
+        assert!(matches!(
+            holder.public_keys(),
+            Err(HolderError::Keystore(_))
+        ));
+
+        let outcome = holder.persist().unwrap();
+        let pinned = match outcome {
+            PersistOutcome::Persisted(keys) => keys,
+            other => panic!("expected Persisted, got {other:?}"),
+        };
+        assert_eq!(holder.public_keys().unwrap(), pinned);
+    }
+
+    #[test]
+    fn persist_refuses_a_foreign_partial_keystore() {
+        // A prior boot's remnant: a valid key file that is NOT this boot's
+        // RAM key. Overwriting would mint unpinned keys — refuse loudly.
+        let dir = tempfile::tempdir().unwrap();
+        let store = dir.path().join("keys");
+        write_keystore(&store, &HeldKeys::generate()).unwrap();
+        fs::remove_file(store.join(crate::keys::CONSENSUS_KEY_FILE)).unwrap();
+
+        let holder = Holder::new(store, dir.path().join("network-manifest.json"));
+        let err = holder.persist().unwrap_err();
+        assert!(matches!(err, HolderError::Keystore(_)));
+    }
+
+    #[test]
+    fn partial_keystore_is_refused_everywhere() {
+        let dir = tempfile::tempdir().unwrap();
+        let holder = holder(dir.path());
+        fs::create_dir_all(dir.path().join("keys")).unwrap();
+        fs::write(dir.path().join("keys/node_key.pem"), "00").unwrap();
+
+        assert!(matches!(
+            holder.public_keys(),
+            Err(HolderError::Keystore(_))
+        ));
+        assert!(matches!(holder.persist(), Err(HolderError::Keystore(_))));
+    }
+
+    #[test]
+    fn persist_after_persist_confirms() {
+        // summit.service restarts re-run persist-wait; the second persist
+        // must confirm rather than fail on the discarded RAM keys.
+        let dir = tempfile::tempdir().unwrap();
+        let holder = holder(dir.path());
+        let pinned = holder.persist().unwrap().public_keys().clone();
+        assert_eq!(holder.persist().unwrap(), PersistOutcome::Confirmed(pinned));
+    }
+
+    #[test]
+    fn quote_window_tracks_manifest_presence() {
+        let dir = tempfile::tempdir().unwrap();
+        let holder = holder(dir.path());
+        assert!(holder.quote_window_open());
+        fs::write(dir.path().join("network-manifest.json"), "{}").unwrap();
+        assert!(!holder.quote_window_open());
+    }
+}

--- a/bin/tdx-init/Cargo.toml
+++ b/bin/tdx-init/Cargo.toml
@@ -12,7 +12,7 @@ description = "Boot-time node initialization: receives node config over HTTP and
 [dependencies]
 seismic-network-manifest.workspace = true
 
-axum = { version = "0.8.6" }
+axum.workspace = true
 base64 = "0.22"
 clap = { version = "4.5.51", features = ["derive"] }
 serde = { version = "1.0.228", features = ["derive"] }

--- a/docs/boot-timeline.svg
+++ b/docs/boot-timeline.svg
@@ -1,0 +1,80 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 470" font-family="ui-sans-serif, system-ui, -apple-system, sans-serif" font-size="12">
+  <!-- One node boot, event-ordered. Time not to scale. -->
+  <!-- Event verticals -->
+  <g stroke="#8b949e" stroke-dasharray="4 4" opacity="0.65">
+    <line x1="200" y1="58" x2="200" y2="425"/>
+    <line x1="390" y1="58" x2="390" y2="425"/>
+    <line x1="490" y1="58" x2="490" y2="425"/>
+    <line x1="630" y1="58" x2="630" y2="425"/>
+    <line x1="740" y1="58" x2="740" y2="425"/>
+  </g>
+  <!-- Event labels, staggered; the x=390 event is one instant with three
+       consequences (tdx-init handles the POST synchronously), so its label
+       stacks over a single vertical. -->
+  <g fill="#8b949e" text-anchor="middle">
+    <text x="200" y="30">boot</text>
+    <text x="390" y="14">config POSTed</text>
+    <text x="390" y="30">conf written</text>
+    <text x="390" y="46">tdx-init exits</text>
+    <text x="490" y="30">root_key held</text>
+    <text x="630" y="48">/persistent opens</text>
+    <text x="740" y="30">keys land in /persistent</text>
+  </g>
+
+  <!-- Row labels -->
+  <g fill="#8b949e" text-anchor="end">
+    <text x="185" y="86">deploy (off-node)</text>
+    <text x="185" y="126">tdx-init</text>
+    <text x="185" y="186">summit-key-holder</text>
+    <text x="185" y="251">custodian-service</text>
+    <text x="185" y="291">attestation-service</text>
+    <text x="185" y="331">setup-persistent-luks</text>
+    <text x="185" y="371">summit</text>
+    <text x="185" y="411">seismic-reth</text>
+  </g>
+
+  <!-- deploy (off-node) -->
+  <rect x="205" y="75" width="173" height="14" rx="3" fill="#5a6470"/>
+  <text x="212" y="86" fill="#ffffff" font-size="10.5">harvest /v1/quote (founding)</text>
+  <path d="M 390 75 L 397 82 L 390 89 L 383 82 Z" fill="#8b949e"/>
+  <path d="M 900 75 L 907 82 L 900 89 L 893 82 Z" fill="#8b949e"/>
+  <text x="890" y="103" fill="#8b949e" font-size="10.5" text-anchor="middle">launch assertions: /v1/keys vs pin</text>
+
+  <!-- tdx-init -->
+  <rect x="200" y="115" width="190" height="14" rx="3" fill="#5a6470"/>
+  <text x="207" y="126" fill="#ffffff" font-size="10.5">await the POST on :8080</text>
+
+  <!-- summit-key-holder -->
+  <rect x="200" y="155" width="540" height="14" rx="3" fill="#e5534b"/>
+  <text x="207" y="166" fill="#ffffff" font-size="10.5">summit keys exist only in this process's RAM</text>
+  <rect x="200" y="175" width="190" height="14" rx="3" fill="#946300"/>
+  <text x="207" y="186" fill="#ffffff" font-size="10.5">quote window (/v1/quote)</text>
+  <rect x="200" y="195" width="750" height="14" rx="3" fill="#5a6470"/>
+  <text x="207" y="206" fill="#ffffff" font-size="10.5">serve /v1/keys + the control.sock persist op</text>
+
+  <!-- custodian-service -->
+  <rect x="400" y="240" width="550" height="14" rx="3" fill="#5a6470"/>
+  <text x="407" y="251" fill="#ffffff" font-size="10.5">starts once conf exists — hold root_key in RAM; write the LUKS keyfile once held</text>
+
+  <!-- attestation-service -->
+  <rect x="410" y="280" width="540" height="14" rx="3" fill="#5a6470"/>
+  <text x="417" y="291" fill="#ffffff" font-size="10.5">starts once conf exists — binds :7878 once the custodian holds root_key</text>
+
+  <!-- setup-persistent-luks -->
+  <text x="493" y="331" fill="#8b949e" font-size="10.5" text-anchor="end">starts on the LUKS keyfile</text>
+  <rect x="500" y="320" width="130" height="14" rx="3" fill="#5a6470"/>
+  <text x="507" y="331" fill="#ffffff" font-size="10.5">open /persistent</text>
+
+  <!-- summit -->
+  <rect x="650" y="360" width="90" height="14" rx="3" fill="#5a6470"/>
+  <text x="657" y="371" fill="#ffffff" font-size="10.5">persist-wait</text>
+  <rect x="740" y="360" width="210" height="14" rx="3" fill="#5a6470"/>
+  <text x="747" y="371" fill="#ffffff" font-size="10.5">run from the keystore</text>
+
+  <!-- seismic-reth -->
+  <rect x="640" y="400" width="310" height="14" rx="3" fill="#5a6470"/>
+  <text x="647" y="411" fill="#ffffff" font-size="10.5">run — purpose keys via custodian.sock</text>
+
+  <!-- caption -->
+  <text x="200" y="452" fill="#8b949e" font-style="italic" font-size="11">time not to scale — each bar starts at the dashed event that unblocks it; bars reaching the right edge run for the life of the node</text>
+</svg>


### PR DESCRIPTION
The network manifest pins every founding validator's pubkeys, so the keys must exist before the manifest does — before the config POST, before admission, before LUKS. bin/summit-key-holder is where they live in that window:

- Generates the summit keypairs (ed25519 node + BLS12-381 MinPk consensus) in RAM at boot and serves them over plain HTTP on :7879: GET /v1/keys for life (feeds deploy's launch-time continuity assertion), GET /v1/quote?nonce= for deploy's founding harvest — the evidence is a JSON-serialized AttestationExchangeMessage with report_data = founding_summit_keys_binding(nonce, node_pk, bls_pk), refused 410 once tdx-init drops the network manifest. The conf dir is tmpfs, so the quote window reopens every boot until the config re-POST.

- Persists the keys into summit's keystore once LUKS opens /persistent, via a single `persist` op on a Unix control socket — deliberately not the network listener; the socket is the future custody-split boundary. `persist-wait` is the blocking client for summit.service's ExecStartPre (wired up in seismic-images), exiting nonzero on any definitive failure so summit never starts on keys the manifest never pinned.

- Writes summit's keystore wire format byte-for-byte (node_key.pem / consensus_key.pem, hex of the commonware-codec encoding, 0600 in a 0700 dir), pinned by golden-vector tests against a keystore summit's own `keys generate` emitted. commonware is pinned =2026.4.0 — summit's exact version; calver moves APIs across caret-compatible bumps.

- A persist interrupted between the two file writes self-heals on retry, but only when the surviving file provably holds this boot's own RAM key; anything foreign is refused. Production images have no shell and rebooting destroys the RAM keys, so systemd's restart of summit.service is the only recovery path that can exist.

Design: https://github.com/SeismicSystems/seismic/blob/main/docs/tee/network-founding.md