### PR TITLE
chore: move all crate deps to shared workspace dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6426,17 +6426,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-log"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
-dependencies = [
- "log",
- "once_cell",
- "tracing-core",
-]
-
-[[package]]
 name = "tracing-serde"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6459,11 +6448,9 @@ dependencies = [
  "serde",
  "serde_json",
  "sharded-slab",
- "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
- "tracing-log",
  "tracing-serde",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ seismic-attestation = { path = "crates/attestation" }
 seismic-attestation-rpc = { path = "crates/attestation-rpc" }
 seismic-crypto = { path = "crates/crypto" }
 seismic-custodian = { path = "crates/custodian" }
-seismic-custodian-ipc = { path = "crates/custodian-ipc" }
+seismic-custodian-ipc = { path = "crates/custodian-ipc", default-features = false }
 seismic-custodian-service = { path = "bin/custodian-service" }
 seismic-measurement-admission = { path = "crates/measurement-admission" }
 seismic-measurement-registry-client = { path = "crates/measurement-registry-client" }
@@ -53,6 +53,7 @@ attestation = { git = "https://github.com/flashbots/attested-tls", rev = "05a79a
 az-cvm-vtpm = { version = "0.7.4", default-features = false }
 az-tdx-vtpm = "0.7.4"
 axum = "0.8.6"
+base64 = "0.22"
 bincode = "1.3.3"
 ciborium = "0.2"
 clap = { version = "4.5.51", features = ["derive", "env"] }
@@ -61,6 +62,7 @@ base64-url = "3.0.0"
 thiserror = "2.0"
 hex = "0.4.3"
 hkdf = "0.12"
+http-body-util = "0.1"
 jsonrpsee = { version = "0.26.0", features = ["server", "client","macros"] }
 libc = "0.2.177"
 rand = "0.9.2"
@@ -69,8 +71,12 @@ secp256k1 = { version = "0.30", features = ["rand", "recovery", "std", "serde"] 
 serde = { version = "1.0", features = ["derive"] }
 serde_bytes = "0.11"
 serde_json = "1.0"
+serial_test = "3.2.0"
 sha2 = "0.10.9"
+tempfile = "3.17"
 tokio = { version = "1.44", features = ["full"] }
+toml = "0.8"
+tower = { version = "0.5", features = ["util"] }
 tracing = { version = "0.1.41"}
 tracing-subscriber = { version = "0.3", default-features = false, features = ["env-filter", "fmt", "ansi", "json"] }
 zeroize = "1.8.1"

--- a/bin/attestation-service/Cargo.toml
+++ b/bin/attestation-service/Cargo.toml
@@ -20,7 +20,7 @@ path = "src/main.rs"
 [dependencies]
 seismic-attestation.workspace = true
 seismic-attestation-rpc.workspace = true
-seismic-custodian-ipc.workspace = true
+seismic-custodian-ipc = { workspace = true, features = ["client"] }
 
 jsonrpsee.workspace = true
 tokio.workspace = true
@@ -41,5 +41,5 @@ hex.workspace = true
 seismic-custodian-ipc = { workspace = true, features = ["server"] }
 seismic-custodian.workspace = true
 seismic-custodian-service.workspace = true
-serial_test = "3.2.0"
-tempfile = "3.17.1"
+serial_test.workspace = true
+tempfile.workspace = true

--- a/bin/custodian-service/Cargo.toml
+++ b/bin/custodian-service/Cargo.toml
@@ -21,7 +21,7 @@ seismic-custodian.workspace = true
 # built in its own cargo invocation — see the feature note in
 # crates/custodian-ipc/Cargo.toml. A path dependency rather than `workspace =
 # true` because workspace inheritance cannot turn default features off.
-seismic-custodian-ipc = { path = "../../crates/custodian-ipc", default-features = false, features = ["server"] }
+seismic-custodian-ipc = { workspace = true, features = ["server"] }
 
 anyhow.workspace = true
 clap.workspace = true
@@ -35,5 +35,5 @@ tracing-subscriber.workspace = true
 # Tests drive the served socket with the async client. Dev-only: resolver v2
 # keeps dev-dep features out of `cargo build`, so the binary stays tokio-free.
 seismic-custodian-ipc = { workspace = true, features = ["client"] }
-tempfile = "3.17.1"
+tempfile.workspace = true
 tokio.workspace = true

--- a/bin/summit-key-holder/Cargo.toml
+++ b/bin/summit-key-holder/Cargo.toml
@@ -53,6 +53,6 @@ tracing-subscriber.workspace = true
 
 [dev-dependencies]
 # Router tests drive handlers through tower's `oneshot` without a socket.
-http-body-util = "0.1"
-tempfile = "3.17"
-tower = { version = "0.5", features = ["util"] }
+http-body-util.workspace = true
+tempfile.workspace = true
+tower.workspace = true

--- a/bin/tdx-init/Cargo.toml
+++ b/bin/tdx-init/Cargo.toml
@@ -13,15 +13,15 @@ description = "Boot-time node initialization: receives node config over HTTP and
 seismic-network-manifest.workspace = true
 
 axum.workspace = true
-base64 = "0.22"
-clap = { version = "4.5.51", features = ["derive"] }
-serde = { version = "1.0.228", features = ["derive"] }
-serde_json = "1.0"
-thiserror = "2.0.17"
-tokio = { version = "1.48.0", features = ["macros", "rt-multi-thread", "fs", "io-util"] }
-toml = "0.8"
-tracing = "0.1.41"
-tracing-subscriber = "0.3.20"
+base64.workspace = true
+clap.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+thiserror.workspace = true
+tokio.workspace = true
+toml.workspace = true
+tracing.workspace = true
+tracing-subscriber.workspace = true
 
 [dev-dependencies]
-tempfile = "3.17"
+tempfile.workspace = true

--- a/bin/verify-quote/Cargo.toml
+++ b/bin/verify-quote/Cargo.toml
@@ -25,4 +25,4 @@ tokio.workspace = true
 [dev-dependencies]
 # The error-path tests hand `run` real files, since the failures under test are
 # file-reading and file-parsing failures.
-tempfile = "3.17.1"
+tempfile.workspace = true

--- a/crates/custodian-ipc/Cargo.toml
+++ b/crates/custodian-ipc/Cargo.toml
@@ -32,9 +32,10 @@ hex = { workspace = true, optional = true }
 sha2 = { workspace = true, optional = true }
 
 [features]
-# Default-on client keeps async consumers frictionless; the custodian binary
-# opts out with default-features = false, features = ["server"] and links no
-# tokio at all.
+# Default-on client keeps out-of-workspace async consumers (reth) frictionless.
+# Within the workspace, the root pins this crate with default-features = false,
+# so each consumer states its features explicitly; the custodian binary takes
+# only ["server"] and links no tokio at all.
 #
 # CAUTION — feature unification: that no-tokio guarantee only holds when the
 # server-only consumer is built in its own cargo invocation. Building it


### PR DESCRIPTION
Every member crate now takes its dependencies via workspace = true; the workspace root is the single place versions are pinned. The only exceptions are summit-key-holder's commonware pins and its rand_08 companion, which stay local for now.

seismic-custodian-ipc is pinned at the root with default-features = false (cargo forbids members overriding default-features to false), so each consumer states its features explicitly: attestation-service takes ["client"], custodian-service takes ["server"], preserving the no-tokio guarantee for the key-holding binary.