### PR TITLE
chore(attestation): bump attested-tls to current upstream main

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1133,11 +1133,12 @@ dependencies = [
 [[package]]
 name = "attestation"
 version = "0.0.1"
-source = "git+https://github.com/flashbots/attested-tls?rev=9224ae1cd48846202d1c4ce49c97441ea9da9b91#9224ae1cd48846202d1c4ce49c97441ea9da9b91"
+source = "git+https://github.com/SeismicSystems/attested-tls?rev=4fb3f4e06fd9d79cf31f145d13d148bbf11fe850#4fb3f4e06fd9d79cf31f145d13d148bbf11fe850"
 dependencies = [
  "anyhow",
  "attest-measure",
  "attest-types",
+ "az-cvm-vtpm",
  "az-tdx-vtpm",
  "base64 0.22.1",
  "dcap-qvl",
@@ -4358,7 +4359,7 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 [[package]]
 name = "pccs"
 version = "0.0.1"
-source = "git+https://github.com/flashbots/attested-tls?rev=9224ae1cd48846202d1c4ce49c97441ea9da9b91#9224ae1cd48846202d1c4ce49c97441ea9da9b91"
+source = "git+https://github.com/SeismicSystems/attested-tls?rev=4fb3f4e06fd9d79cf31f145d13d148bbf11fe850#4fb3f4e06fd9d79cf31f145d13d148bbf11fe850"
 dependencies = [
  "anyhow",
  "dcap-qvl",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -416,7 +416,7 @@ dependencies = [
  "lru",
  "parking_lot",
  "pin-project",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -460,7 +460,7 @@ dependencies = [
  "alloy-transport-http",
  "futures",
  "pin-project",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "tokio",
@@ -733,7 +733,7 @@ checksum = "e3b5064d1e1e1aabc918b5954e7fb8154c39e77ec6903a581b973198b26628fa"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
- "reqwest",
+ "reqwest 0.12.28",
  "serde_json",
  "tower",
  "tracing",
@@ -1097,11 +1097,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
-name = "attestation"
+name = "attest-measure"
 version = "0.0.1"
-source = "git+https://github.com/flashbots/attested-tls?rev=05a79a3f16a6d074bc10ce7aa29a3cd804fdc613#05a79a3f16a6d074bc10ce7aa29a3cd804fdc613"
+source = "git+https://github.com/easy-tee/attest.git?rev=a64f147362b8948e2288015e476c40d04b11b661#a64f147362b8948e2288015e476c40d04b11b661"
 dependencies = [
  "anyhow",
+ "attest-types",
+ "authenticode",
+ "crc32fast",
+ "hex",
+ "hex-literal",
+ "object",
+ "prost",
+ "rsa",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "sha2 0.10.9",
+ "thiserror 2.0.18",
+ "ureq 3.3.0",
+ "x509-parser 0.18.1",
+]
+
+[[package]]
+name = "attest-types"
+version = "0.0.1"
+source = "git+https://github.com/easy-tee/attest.git?rev=a64f147362b8948e2288015e476c40d04b11b661#a64f147362b8948e2288015e476c40d04b11b661"
+dependencies = [
+ "parity-scale-codec",
+ "serde",
+ "serde_json",
+ "serde_with",
+]
+
+[[package]]
+name = "attestation"
+version = "0.0.1"
+source = "git+https://github.com/flashbots/attested-tls?rev=9224ae1cd48846202d1c4ce49c97441ea9da9b91#9224ae1cd48846202d1c4ce49c97441ea9da9b91"
+dependencies = [
+ "anyhow",
+ "attest-measure",
+ "attest-types",
  "az-tdx-vtpm",
  "base64 0.22.1",
  "dcap-qvl",
@@ -1114,7 +1150,7 @@ dependencies = [
  "pccs",
  "pem-rfc7468",
  "rand_core 0.6.4",
- "reqwest",
+ "reqwest 0.13.4",
  "rustls-webpki",
  "serde",
  "serde_json",
@@ -1125,8 +1161,26 @@ dependencies = [
  "tokio-rustls",
  "tracing",
  "tss-esapi",
- "ureq",
+ "ureq 2.12.1",
  "x509-parser 0.18.1",
+]
+
+[[package]]
+name = "authenticode"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86c421a87e3dd1a3024c86e0787106b6ba40d9b434fe0ebeffbd24a242dc144d"
+dependencies = [
+ "cms",
+ "const-oid",
+ "der",
+ "digest 0.10.7",
+ "object",
+ "rsa",
+ "sha1",
+ "sha2 0.10.9",
+ "spki",
+ "x509-cert",
 ]
 
 [[package]]
@@ -1254,7 +1308,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.18",
- "ureq",
+ "ureq 2.12.1",
  "zerocopy",
 ]
 
@@ -1684,6 +1738,18 @@ name = "cmov"
 version = "0.5.0-pre.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5417da527aa9bf6a1e10a781231effd1edd3ee82f27d5f8529ac9b279babce96"
+
+[[package]]
+name = "cms"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b77c319abfd5219629c45c34c89ba945ed3c5e49fcde9d16b6c3885f118a730"
+dependencies = [
+ "const-oid",
+ "der",
+ "spki",
+ "x509-cert",
+]
 
 [[package]]
 name = "codicon"
@@ -2190,7 +2256,7 @@ dependencies = [
  "p256",
  "parity-scale-codec",
  "pem",
- "reqwest",
+ "reqwest 0.12.28",
  "ring",
  "rustls-pki-types",
  "scale-info",
@@ -3040,6 +3106,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hex-literal"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e712f64ec3850b98572bffac52e2c6f282b29fe6c5fa6d42334b30be438d95c1"
+
+[[package]]
 name = "hickory-proto"
 version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3539,7 +3611,7 @@ dependencies = [
  "pin-project",
  "rustls",
  "rustls-pki-types",
- "rustls-platform-verifier",
+ "rustls-platform-verifier 0.5.3",
  "soketto",
  "thiserror 2.0.18",
  "tokio",
@@ -3591,7 +3663,7 @@ dependencies = [
  "jsonrpsee-core",
  "jsonrpsee-types",
  "rustls",
- "rustls-platform-verifier",
+ "rustls-platform-verifier 0.5.3",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -4086,6 +4158,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "oid"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4277,12 +4358,12 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 [[package]]
 name = "pccs"
 version = "0.0.1"
-source = "git+https://github.com/flashbots/attested-tls?rev=05a79a3f16a6d074bc10ce7aa29a3cd804fdc613#05a79a3f16a6d074bc10ce7aa29a3cd804fdc613"
+source = "git+https://github.com/flashbots/attested-tls?rev=9224ae1cd48846202d1c4ce49c97441ea9da9b91#9224ae1cd48846202d1c4ce49c97441ea9da9b91"
 dependencies = [
  "anyhow",
  "dcap-qvl",
  "hex",
- "reqwest",
+ "reqwest 0.13.4",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -4553,6 +4634,29 @@ dependencies = [
  "rusty-fork",
  "tempfile",
  "unarray",
+]
+
+[[package]]
+name = "prost"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "528ac67416ff8646872a3c02cad9cc4ee5dc9f9540c9b10771855c95cb2e5ae1"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
+dependencies = [
+ "anyhow",
+ "itertools 0.10.5",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -4855,6 +4959,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqwest"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier 0.6.1",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "resolv-conf"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5061,6 +5199,27 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 0.26.11",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be59af91596cac372a6942530653ad0c3a246cdd491aaa9dcaee47f88d67d5a0"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs 1.0.2",
  "windows-sys 0.59.0",
 ]
 
@@ -6582,6 +6741,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "ureq"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
+dependencies = [
+ "base64 0.22.1",
+ "flate2",
+ "log",
+ "percent-encoding",
+ "rustls",
+ "rustls-pki-types",
+ "ureq-proto",
+ "utf8-zero",
+ "webpki-roots 1.0.7",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
+dependencies = [
+ "base64 0.22.1",
+ "http",
+ "httparse",
+ "log",
+]
+
+[[package]]
 name = "url"
 version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6597,6 +6785,12 @@ name = "urlencoding"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
+name = "utf8-zero"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
 
 [[package]]
 name = "utf8_iter"
@@ -7252,6 +7446,7 @@ dependencies = [
  "lazy_static",
  "nom",
  "oid-registry 0.8.1",
+ "ring",
  "rusticata-macros",
  "thiserror 2.0.18",
  "time",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,9 @@ alloy-primitives = { version = "1.0", default-features = false, features = ["std
 alloy-sol-types = "1.0"
 aes-gcm = "0.10"
 anyhow = "1.0"
-attestation = { git = "https://github.com/flashbots/attested-tls", rev = "9224ae1cd48846202d1c4ce49c97441ea9da9b91" }
+# Pointing to https://github.com/SeismicSystems/attested-tls/pull/1
+# which is build on top of https://github.com/flashbots/attested-tls/pull/78
+attestation = { git = "https://github.com/SeismicSystems/attested-tls", rev = "4fb3f4e06fd9d79cf31f145d13d148bbf11fe850" }
 az-cvm-vtpm = { version = "0.7.4", default-features = false }
 az-tdx-vtpm = "0.7.4"
 axum = "0.8.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ alloy-primitives = { version = "1.0", default-features = false, features = ["std
 alloy-sol-types = "1.0"
 aes-gcm = "0.10"
 anyhow = "1.0"
-attestation = { git = "https://github.com/flashbots/attested-tls", rev = "05a79a3f16a6d074bc10ce7aa29a3cd804fdc613" }
+attestation = { git = "https://github.com/flashbots/attested-tls", rev = "9224ae1cd48846202d1c4ce49c97441ea9da9b91" }
 az-cvm-vtpm = { version = "0.7.4", default-features = false }
 az-tdx-vtpm = "0.7.4"
 axum = "0.8.6"

--- a/bin/attestation-service/tests/integration/integration.rs
+++ b/bin/attestation-service/tests/integration/integration.rs
@@ -134,10 +134,15 @@ async fn test_tx_io_evidence_relying_party() {
     );
 
     let mut tampered_evidence = response.evidence;
-    assert!(!tampered_evidence.attestation.is_empty());
+    let quote = &mut tampered_evidence
+        .attestation_evidence
+        .as_mut()
+        .expect("evidence should carry an attestation")
+        .quote;
+    assert!(!quote.is_empty());
     // Azure evidence is a JSON document. Invalid UTF-8 gives us a
     // deterministic malformed-evidence case.
-    tampered_evidence.attestation[0] = 0xff;
+    quote[0] = 0xff;
     assert!(
         verify_evidence(
             tampered_evidence,

--- a/bin/verify-quote/src/main.rs
+++ b/bin/verify-quote/src/main.rs
@@ -21,11 +21,10 @@
 //! non-Azure evidence — is an error on stderr with a nonzero exit and nothing on
 //! stdout.
 //!
-//! Verification-only: this never touches a local TPM, so it runs anywhere Linux
-//! runs. It compiles everywhere, but the `azure` feature gating Azure TDX
-//! verification in the upstream `attestation` crate is enabled through a
-//! Linux-only target block in `crates/attestation/Cargo.toml`, so on macOS
-//! verification fails at runtime — run it in a Linux container there.
+//! Verification-only: this never touches a local TPM. Azure TDX verification
+//! is pure computation over the evidence bytes (the `azure-verifier` feature
+//! of the `attestation` backend), so it builds and runs anywhere, including
+//! macOS.
 
 use anyhow::Context as _;
 use clap::Parser;
@@ -61,10 +60,9 @@ use std::{
                   archive it as harvest provenance. Any failure — unreadable or malformed input, \
                   binding mismatch, measurement mismatch, DCAP failure, non-Azure evidence — \
                   prints an error to stderr and exits nonzero, with nothing on stdout.\n\n\
-                  Verification-only: this never touches a local TPM, so it runs anywhere Linux \
-                  runs. It compiles on macOS but Azure verification fails there at runtime (the \
-                  upstream `azure` feature is Linux-target-gated), so non-Linux callers run it in \
-                  a Linux container."
+                  Verification-only: this never touches a local TPM, and Azure TDX verification \
+                  is pure computation over the evidence bytes, so it builds and runs anywhere, \
+                  including macOS."
 )]
 struct Cli {
     /// JSON-serialized AttestationExchangeMessage the key holder served

--- a/crates/attestation/Cargo.toml
+++ b/crates/attestation/Cargo.toml
@@ -16,13 +16,15 @@ serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
-attestation.workspace = true # all platforms; the Linux block below adds the `azure` feature
+# All platforms: `azure-verifier` is pure computation over evidence bytes, so
+# Azure evidence *verification* (e.g. the verify-quote CLI) works on macOS too.
+attestation = { workspace = true, features = ["azure-verifier"] }
 
-# Linux-only: the `azure` feature turns on attestation *evidence generation*
+# Linux-only: `azure-attester` turns on attestation *evidence generation*
 # (Intel TDX quote + Azure vTPM quote), which depends on crates that only
 # compile on Linux — notably the `tss-esapi` TPM stack.
 [target.'cfg(target_os = "linux")'.dependencies]
-attestation = { workspace = true, features = ["azure"] }
+attestation = { workspace = true, features = ["azure-attester"] }
 
 # Linux-only for the same reason: the examples here (`azure_vtpm_roundtrip`,
 # `capture_azure_tdx_fixture`) produce real Azure TDX + vTPM evidence, pulling

--- a/crates/attestation/examples/azure_vtpm_roundtrip.rs
+++ b/crates/attestation/examples/azure_vtpm_roundtrip.rs
@@ -234,10 +234,14 @@ fn generate_azure_exchange_message(
     binding: [u8; 64],
 ) -> anyhow::Result<AttestationExchangeMessage> {
     let evidence = generate_evidence(AttestationType::AzureTdx, binding)?;
+    let quote_len = evidence
+        .attestation_evidence
+        .as_ref()
+        .map_or(0, |attested| attested.quote.len());
     println!(
-        "Generated {} evidence: {} bytes",
-        evidence.attestation_type,
-        evidence.attestation.len()
+        "Generated {} evidence: {} byte quote",
+        evidence.attestation_type(),
+        quote_len
     );
     Ok(evidence)
 }

--- a/crates/attestation/src/lib.rs
+++ b/crates/attestation/src/lib.rs
@@ -83,7 +83,7 @@ pub async fn verify_evidence_with_options(
     policy: SeismicMeasurementPolicy,
     options: VerifyOptions,
 ) -> Result<VerifiedSeismicAttestation, AttestationError> {
-    let attestation_type = evidence.attestation_type;
+    let attestation_type = evidence.attestation_type();
     let verifier = AttestationVerifier::new(
         policy.into_backend_policy(),
         options.pccs_url,
@@ -129,10 +129,10 @@ pub async fn verify_azure_evidence_with_options(
     policy: SeismicMeasurementPolicy,
     options: VerifyOptions,
 ) -> Result<VerifiedAzureAttestation, AttestationError> {
-    if evidence.attestation_type != AttestationType::AzureTdx {
+    if evidence.attestation_type() != AttestationType::AzureTdx {
         return Err(AttestationError::WrongAttestationType {
             expected: AttestationType::AzureTdx,
-            actual: evidence.attestation_type,
+            actual: evidence.attestation_type(),
         });
     }
 
@@ -212,7 +212,6 @@ pub enum VerifiedSeismicAttestation {
     AzureTdx(VerifiedAzureAttestation),
     DcapTdx(VerifiedTdxAttestation),
     GcpTdx(VerifiedTdxAttestation),
-    QemuTdx(VerifiedTdxAttestation),
     NoAttestation { binding: [u8; 64] },
 }
 
@@ -234,22 +233,16 @@ impl VerifiedSeismicAttestation {
                     },
                 }))
             }
-            (AttestationType::DcapTdx, Some(MultiMeasurements::Dcap(registers))) => {
+            (AttestationType::DcapTdx, Some(MultiMeasurements::Dcap(measurements))) => {
                 Ok(Self::DcapTdx(VerifiedTdxAttestation {
                     binding,
-                    measurements: TdxMeasurements { registers },
+                    measurements: measurements.into(),
                 }))
             }
-            (AttestationType::GcpTdx, Some(MultiMeasurements::Dcap(registers))) => {
+            (AttestationType::GcpTdx, Some(MultiMeasurements::Dcap(measurements))) => {
                 Ok(Self::GcpTdx(VerifiedTdxAttestation {
                     binding,
-                    measurements: TdxMeasurements { registers },
-                }))
-            }
-            (AttestationType::QemuTdx, Some(MultiMeasurements::Dcap(registers))) => {
-                Ok(Self::QemuTdx(VerifiedTdxAttestation {
-                    binding,
-                    measurements: TdxMeasurements { registers },
+                    measurements: measurements.into(),
                 }))
             }
             (attestation_type, None) => {
@@ -258,7 +251,7 @@ impl VerifiedSeismicAttestation {
             (attestation_type, Some(measurements)) => {
                 Err(AttestationError::MeasurementTypeMismatch {
                     attestation_type,
-                    measurements,
+                    measurements: Box::new(measurements),
                 })
             }
         }
@@ -269,7 +262,6 @@ impl VerifiedSeismicAttestation {
             Self::AzureTdx(_) => AttestationType::AzureTdx,
             Self::DcapTdx(_) => AttestationType::DcapTdx,
             Self::GcpTdx(_) => AttestationType::GcpTdx,
-            Self::QemuTdx(_) => AttestationType::QemuTdx,
             Self::NoAttestation { .. } => AttestationType::None,
         }
     }
@@ -277,9 +269,7 @@ impl VerifiedSeismicAttestation {
     pub fn binding(&self) -> &[u8; 64] {
         match self {
             Self::AzureTdx(verified) => &verified.binding,
-            Self::DcapTdx(verified) | Self::GcpTdx(verified) | Self::QemuTdx(verified) => {
-                &verified.binding
-            }
+            Self::DcapTdx(verified) | Self::GcpTdx(verified) => &verified.binding,
             Self::NoAttestation { binding } => binding,
         }
     }
@@ -312,10 +302,26 @@ pub struct VerifiedTdxAttestation {
     pub measurements: TdxMeasurements,
 }
 
-/// TDX measurements surfaced by DCAP/GCP/QEMU backend attestation types.
+/// TDX measurements surfaced by DCAP/GCP backend attestation types.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct TdxMeasurements {
-    pub registers: HashMap<DcapMeasurementRegister, [u8; 48]>,
+    pub mrtd: [u8; 48],
+    pub rtmr0: [u8; 48],
+    pub rtmr1: [u8; 48],
+    pub rtmr2: [u8; 48],
+    pub rtmr3: [u8; 48],
+}
+
+impl From<attestation::measurements::DcapMeasurements> for TdxMeasurements {
+    fn from(measurements: attestation::measurements::DcapMeasurements) -> Self {
+        Self {
+            mrtd: measurements.mrtd,
+            rtmr0: measurements.rtmr0,
+            rtmr1: measurements.rtmr1,
+            rtmr2: measurements.rtmr2,
+            rtmr3: measurements.rtmr3,
+        }
+    }
 }
 
 #[derive(Debug, Error)]
@@ -334,7 +340,7 @@ pub enum AttestationError {
     #[error("backend returned measurements inconsistent with {attestation_type}: {measurements:?}")]
     MeasurementTypeMismatch {
         attestation_type: AttestationType,
-        measurements: MultiMeasurements,
+        measurements: Box<MultiMeasurements>,
     },
 }
 
@@ -379,7 +385,7 @@ mod tests {
         assert!(
             policy
                 .backend_policy
-                .check_measurement(&cross_product_measurements)
+                .check_measurement(&cross_product_measurements, None)
                 .is_err()
         );
 
@@ -387,7 +393,7 @@ mod tests {
             MultiMeasurements::Azure(HashMap::from([(4, image_b_pcr4), (9, image_b_pcr9)]));
         policy
             .backend_policy
-            .check_measurement(&image_b_measurements)
+            .check_measurement(&image_b_measurements, None)
             .unwrap();
     }
 
@@ -398,12 +404,12 @@ mod tests {
 
         policy
             .backend_policy
-            .check_measurement(&MultiMeasurements::Azure(HashMap::new()))
+            .check_measurement(&MultiMeasurements::Azure(HashMap::new()), None)
             .unwrap();
         assert!(
             policy
                 .backend_policy
-                .check_measurement(&MultiMeasurements::NoAttestation)
+                .check_measurement(&MultiMeasurements::NoAttestation, None)
                 .is_err()
         );
     }
@@ -436,10 +442,11 @@ mod tests {
         let verified = VerifiedSeismicAttestation::from_backend(
             AttestationType::DcapTdx,
             binding,
-            Some(MultiMeasurements::Dcap(HashMap::from([(
-                DcapMeasurementRegister::MRTD,
-                mrtd,
-            )]))),
+            Some(MultiMeasurements::Dcap(
+                attestation::measurements::DcapMeasurements::new(
+                    mrtd, [0u8; 48], [1u8; 48], [2u8; 48], [3u8; 48],
+                ),
+            )),
         )
         .unwrap();
 
@@ -448,10 +455,14 @@ mod tests {
         match verified {
             VerifiedSeismicAttestation::DcapTdx(dcap) => {
                 assert_eq!(
-                    dcap.measurements
-                        .registers
-                        .get(&DcapMeasurementRegister::MRTD),
-                    Some(&mrtd),
+                    dcap.measurements,
+                    TdxMeasurements {
+                        mrtd,
+                        rtmr0: [0u8; 48],
+                        rtmr1: [1u8; 48],
+                        rtmr2: [2u8; 48],
+                        rtmr3: [3u8; 48],
+                    }
                 );
             }
             _ => panic!("expected DCAP output"),

--- a/crates/measurement-admission/tests/attested_tls_parity.rs
+++ b/crates/measurement-admission/tests/attested_tls_parity.rs
@@ -28,7 +28,7 @@ fn every_compiled_tuple_is_accepted_by_attested_tls() {
     let policy = MeasurementPolicy::from_json_bytes(POLICY.to_vec()).unwrap();
     for record in &compiled.records {
         policy
-            .check_measurement(&as_azure_evidence(&record.tuple))
+            .check_measurement(&as_azure_evidence(&record.tuple), None)
             .unwrap_or_else(|e| {
                 panic!(
                     "attested-tls rejected the compiled tuple of {:?}: {e:?}",
@@ -53,7 +53,7 @@ fn cross_record_flattening_is_rejected_by_both() {
     assert!(!compiled.admission_ids.contains(&flattened.admission_id()));
     assert!(
         policy
-            .check_measurement(&as_azure_evidence(&flattened))
+            .check_measurement(&as_azure_evidence(&flattened), None)
             .is_err()
     );
 }
@@ -71,7 +71,11 @@ fn deprecated_expected_form_matches_on_both_sides() {
     let policy = MeasurementPolicy::from_json_bytes(doc.into_bytes()).unwrap();
     assert_eq!(compiled.admission_ids.len(), 1);
     let tuple = &compiled.records[0].tuple;
-    assert!(policy.check_measurement(&as_azure_evidence(tuple)).is_ok());
+    assert!(
+        policy
+            .check_measurement(&as_azure_evidence(tuple), None)
+            .is_ok()
+    );
 }
 
 #[test]


### PR DESCRIPTION
Move the `attestation` backend pin from 05a79a3 to 9224ae1, the head of flashbots/attested-tls main. This is the upstream base of our azure-verifier-portability fork branch; switching to the fork lands separately on top of this.

Upstream integrated the easy-tee/attest crates in between, which changes the evidence format and policy API:

- `AttestationExchangeMessage` is now `{ attestation_evidence: Option<AttestationEvidence> }`, where `AttestationEvidence` carries the raw quote (base64 in JSON) plus `PlatformMetadata`. The envelope no longer has an `attestation_type` field; the type is derived from the evidence via `attestation_type()`, with `None` meaning no attestation. Evidence serialized under the old format no longer parses.

- `PlatformMetadata` (`attestation_type`, `ram_bytes`, `num_disks`, ACPI table hashes) is the attester's self-reported VM shape. It exists for upstream's new portable policy form (`ExpectedMeasurements::Image`), where a record pins OS image hashes instead of final register values and the verifier reconstructs the expected MRTD/RTMRs from the image hashes plus this metadata (and, on GCP, known firmware). `MeasurementPolicy::check_measurement` grew an `Option<&PlatformMetadata>` parameter for this. In production the backend extracts the metadata from the evidence itself inside `AttestationVerifier::verify_attestation`; the `None`s in this commit are only in tests calling `check_measurement` directly with Azure PCR policies, where the parameter is never consulted.

- `AttestationType::QemuTdx` is gone: plain DCAP is `DcapTdx`, and policy files keep parsing `"qemu-tdx"` via a serde alias. The corresponding `VerifiedSeismicAttestation::QemuTdx` variant is dropped; nothing consumed it.

- DCAP measurements are the typed `DcapMeasurements` (named mrtd/rtmr0-3 fields) instead of a register-to-value map; `TdxMeasurements` mirrors the named fields. The struct is 240 bytes inline, so the `MeasurementTypeMismatch` error variant boxes it to keep `AttestationError` small (clippy result_large_err).

Azure verification remains gated Linux-only by the upstream `azure` feature; this commit does not change platform support.