### PR TITLE
docs(tdx-init): make the genesis-hash enforcement comment deploy-agnostic

### DIFF
--- a/bin/tdx-init/src/reth_genesis.rs
+++ b/bin/tdx-init/src/reth_genesis.rs
@@ -9,9 +9,10 @@
 //! the header. tdx-init also does not recompute that hash in-process (it
 //! would need reth's own chain-spec parse path), so POST-time validation here is
 //! structural: valid JSON whose `config.chainId` matches the manifest's
-//! `eth.chain_id`. The block-hash commitment is enforced deploy-side
-//! (`manifest assemble` shells out to `seismic-reth genesis-hash`) and again
-//! at ceremony time (every node's reth must serve the pinned hash as block 0).
+//! `eth.chain_id`. The block-hash commitment is enforced outside the node:
+//! the deploy tooling recomputes the hash with reth's own implementation
+//! when it assembles the manifest, and checks at launch that every node's
+//! reth serves the pinned hash as block 0.
 //!
 //! Like the manifest, the file travels base64-encoded and is written
 //! verbatim — reth parses it itself, so tdx-init must not re-render it.


### PR DESCRIPTION
The module doc described where the eth.genesis_hash commitment is enforced in terms of the deploy CLI's shape ("`manifest assemble` shells out to `seismic-reth genesis-hash`"), which rots whenever deploy reworks its UX — it just did, flattening the manifest group into top-level verbs (https://github.com/SeismicSystems/deploy/pull/93) — and one clause had already rotted: "at ceremony time" refers to the genesis ceremony deploy deleted in favor of configure's launch assertions (https://github.com/SeismicSystems/deploy/pull/92).

Restate it as the lifecycle contract, which no CLI rename can touch: the deploy tooling recomputes the hash with reth's own implementation when it assembles the manifest, and checks at launch that every node's reth serves the pinned hash as block 0.

Comment-only; no code change.