### PR TITLE
ci(measurement-admission): pin seismic's fixture copies to the golden pair

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,15 +48,20 @@ jobs:
       - name: Install TPM build dependencies
         run: sudo apt-get update && sudo apt-get install -y libtss2-dev
       # Keep the Rust registry interfaces and the registry runtime-code pin tied
-      # to the canonical artifact that feeds reth genesis. The artifact remains
-      # owned by the seismic repo; this checkout prevents a local ABI copy.
-      - name: Check out canonical MeasurementRegistry artifact
+      # to the canonical artifact that feeds reth genesis, and the seismic
+      # repo's committed copy of the golden fixture pair tied to the goldens.
+      # The artifact remains owned by the seismic repo and the fixture pair by
+      # this one; each side checks out the other's committed file rather than
+      # trusting a local copy to stay current.
+      - name: Check out seismic contracts artifact and fixture copies
         uses: actions/checkout@v4
         with:
           repository: SeismicSystems/seismic
           ref: main
           path: .context/seismic
-          sparse-checkout: contracts/artifacts/MeasurementRegistry.json
+          sparse-checkout: |
+            contracts/artifacts/MeasurementRegistry.json
+            contracts/test/fixtures
           sparse-checkout-cone-mode: false
       # The workspace pass builds seismic-custodian-ipc with default features
       # only, which compiles out the `server` module (and its ACL tests) and
@@ -82,6 +87,13 @@ jobs:
         run: >-
           cargo test -p seismic-measurement-registry-client --test abi_parity -- --ignored
           && cargo test -p seismic-measurement-admission --test registry_abi -- --ignored
+      # The seismic repo's Solidity fixture tests run against a committed copy
+      # of this crate's golden fixture pair; regenerating the goldens must
+      # fail here until that copy is updated in step.
+      - name: Check measurement-policy fixture parity
+        env:
+          SEISMIC_CONTRACTS_FIXTURES: ${{ github.workspace }}/.context/seismic/contracts/test/fixtures
+        run: cargo test -p seismic-measurement-admission --test fixture_parity -- --ignored
       - name: Run attestation-service unit tests
         run: cargo test -p seismic-attestation-service --lib --bins
 

--- a/crates/measurement-admission/tests/fixture_parity.rs
+++ b/crates/measurement-admission/tests/fixture_parity.rs
@@ -1,0 +1,53 @@
+//! Byte parity between the golden measurement-policy fixture pair and its
+//! committed copy in the seismic repo
+//! (https://github.com/SeismicSystems/seismic/tree/main/contracts/test/fixtures).
+//!
+//! The golden pair stays owned by this crate — the policy compiler that
+//! produces the compiled report lives here — while the seismic repo commits a
+//! verbatim copy so its Solidity fixture tests run self-contained. A committed
+//! copy can only agree with the pair it last saw, so CI checks out the seismic
+//! copy and compares bytes: regenerating the golden pair fails here until the
+//! seismic copy is updated in step, instead of drifting silently.
+
+use std::{env, fs, path::PathBuf};
+
+const SEISMIC_FIXTURES_ENV: &str = "SEISMIC_CONTRACTS_FIXTURES";
+
+/// Basename and golden bytes of every fixture the seismic repo copies.
+const COPIED_FIXTURES: [(&str, &[u8]); 2] = [
+    (
+        "measurement-policy-v1.json",
+        include_bytes!("../fixtures/golden/measurement-policy-v1.json"),
+    ),
+    (
+        "measurement-policy-v1.compiled.json",
+        include_bytes!("../fixtures/golden/measurement-policy-v1.compiled.json"),
+    ),
+];
+
+/// CI checks out `SeismicSystems/seismic` and points this test at its
+/// committed `contracts/test/fixtures` directory. It is ignored in an
+/// ordinary local run because the copy intentionally lives in the seismic
+/// repo.
+#[test]
+#[ignore = "CI supplies the seismic/contracts fixture copies"]
+fn seismic_fixture_copies_match_golden_pair() {
+    let dir = PathBuf::from(env::var_os(SEISMIC_FIXTURES_ENV).unwrap_or_else(|| {
+        panic!("{SEISMIC_FIXTURES_ENV} must point to seismic's contracts/test/fixtures")
+    }));
+    for (name, golden) in COPIED_FIXTURES {
+        let path = dir.join(name);
+        let copy = fs::read(&path).unwrap_or_else(|error| {
+            panic!(
+                "failed to read {}: {error}; seismic/contracts must commit a verbatim copy of \
+                 fixtures/golden/{name}",
+                path.display()
+            )
+        });
+        assert!(
+            copy == golden,
+            "seismic's contracts/test/fixtures/{name} is not byte-identical to \
+             fixtures/golden/{name}; copy the regenerated golden pair into the seismic repo"
+        );
+    }
+}


### PR DESCRIPTION
The seismic repo's Solidity fixture tests run against a committed copy of this crate's golden measurement-policy pair (https://github.com/SeismicSystems/seismic/tree/main/contracts/test/fixtures). That copy is self-consistent — its sha256 and slot assertions are all internal to the pair — so regenerating the goldens here would leave it passing on a stale snapshot with nothing to notice.

Add a fixture_parity test in the registry_abi mold: the tests job's seismic sparse-checkout widens to contracts/test/fixtures, and the test asserts both copied files are byte-identical to the goldens (missing files fail too). Regenerating the golden pair now fails on the PR that changes it until the seismic copy is updated in step — the same PR-that-causes-it property the ABI and runtime-code-hash parity checks already have, with the same landing order: seismic first, this repo right behind.