### PR TITLE
refactor(measurement-admission): AdmissionId newtype + identity-model docs

### DIFF
--- a/crates/measurement-admission/README.md
+++ b/crates/measurement-admission/README.md
@@ -19,6 +19,29 @@ comes from:
 - **deploy tooling**: promotes raw image measurements into the policy
   artifact and compiles it into registry genesis storage, via the CLI.
 
+```mermaid
+flowchart TD
+    subgraph identity ["guest identity (Azure TDX v1 schema)"]
+        pcrs["verified vTPM PCR bank<br/>(quote-backed, from evidence verification)"]
+        tuple["guest identity tuple (pcr4, pcr9, pcr11)<br/>a missing register fails closed"]
+        id(["admission ID = keccak256(abi.encode(<br/>schema_id, pcr4, pcr9, pcr11))"])
+        pcrs --> tuple --> id
+    end
+
+    subgraph set ["accepted set (authored, then on-chain)"]
+        raw["measurements.json<br/>(raw make-measure output)"]
+        doc["measurement-policy document<br/>(one record = one guest identity)"]
+        ids["accepted admission IDs"]
+        reg["MeasurementRegistry<br/>(live policy, authority-updated)"]
+        raw -- "promote" --> doc
+        doc -- "compile: the same derivation<br/>over each record's PCR values" --> ids
+        ids -- "genesis storage slots" --> reg
+    end
+
+    id -. "responder: eth_call isAccepted(id)" .-> reg
+    id -. "joiner: membership in the compiled<br/>manifest-pinned artifact" .-> ids
+```
+
 Policy documents are Flashbots-compatible record lists restricted to one
 value per register: one record admits one guest identity and compiles to one
 admission ID, so the reviewed document literally lists the accepted set.

--- a/crates/measurement-admission/src/genesis.rs
+++ b/crates/measurement-admission/src/genesis.rs
@@ -10,7 +10,7 @@
 //! here are pinned by golden tests on both sides (Rust here, Solidity in
 //! `MeasurementRegistry.t.sol`) and must never change.
 
-use crate::CompiledPolicy;
+use crate::{AdmissionId, CompiledPolicy};
 use alloy_primitives::{B256, U256, b256, keccak256};
 use std::collections::BTreeMap;
 
@@ -59,9 +59,9 @@ const STATUS_ACCEPTED: B256 =
 
 /// Storage slot of `statuses[admissionId]`:
 /// `keccak256(abi.encode(admissionId, REGISTRY_STORAGE_LOCATION))`.
-pub fn admission_status_slot(admission_id: B256) -> B256 {
+pub fn admission_status_slot(admission_id: AdmissionId) -> B256 {
     let mut preimage = [0u8; 64];
-    preimage[..32].copy_from_slice(admission_id.as_slice());
+    preimage[..32].copy_from_slice(admission_id.as_b256().as_slice());
     preimage[32..].copy_from_slice(REGISTRY_STORAGE_LOCATION.as_slice());
     keccak256(preimage)
 }
@@ -125,7 +125,7 @@ mod tests {
     #[test]
     fn status_slot_golden_matches_solidity() {
         assert_eq!(
-            admission_status_slot(B256::from(U256::from(1))),
+            admission_status_slot(AdmissionId::from(B256::from(U256::from(1)))),
             b256!("0x375f13b0f395f58180c4440e3093a15026ebe690dc75ff0edddf4387bd26fae6")
         );
     }

--- a/crates/measurement-admission/src/lib.rs
+++ b/crates/measurement-admission/src/lib.rs
@@ -25,7 +25,8 @@
 //! never key chain state.)
 
 use alloy_primitives::{B256, keccak256};
-use std::collections::HashMap;
+use serde::Serialize;
+use std::{collections::HashMap, fmt};
 
 pub mod genesis;
 pub mod policy;
@@ -35,6 +36,61 @@ pub mod report;
 pub use policy::{CompiledPolicy, CompiledRecord, PolicyError, compile_policy};
 pub use promote::{PromoteError, promote_measurements};
 pub use report::CompileReport;
+
+/// One guest identity, in the form the on-chain `MeasurementRegistry` keys
+/// it: `keccak256(abi.encode(schema_id, <schema registers>))`.
+///
+/// The name says what the value is *for*, and the purpose is also what
+/// defines the value. An admission ID keys exactly one decision —
+/// `isAccepted(id)` — and identifies the equivalence class of guests that
+/// are indistinguishable for admission purposes: every machine booting the
+/// same measured image derives the same ID, and registers outside the
+/// schema never contribute. It is deliberately not a "guest ID" or "VM ID".
+/// Nothing about the instance, machine, or operator is in it, and there is
+/// no schema-independent identity of a guest — which registers count is
+/// itself a policy choice, pinned by the schema word in the preimage. A
+/// different register set or attestation backend is a new schema and a
+/// deliberately disjoint ID space.
+///
+/// The derivation is one-way but never opaque: the published policy
+/// document lists every accepted identity in preimage form (its register
+/// values, one record per identity), so each ID is recomputable from the
+/// reviewed document. Serialized and displayed as lowercase 0x-hex;
+/// converts to/from [`B256`] at ABI and storage boundaries, where wrapping
+/// asserts nothing — a wrapped value means something only if it came from
+/// this derivation or from the registry.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
+pub struct AdmissionId(B256);
+
+impl AdmissionId {
+    pub const fn as_b256(&self) -> &B256 {
+        &self.0
+    }
+}
+
+impl From<B256> for AdmissionId {
+    fn from(word: B256) -> Self {
+        Self(word)
+    }
+}
+
+impl From<AdmissionId> for B256 {
+    fn from(id: AdmissionId) -> Self {
+        id.0
+    }
+}
+
+impl fmt::Display for AdmissionId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl fmt::Debug for AdmissionId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "AdmissionId({})", self.0)
+    }
+}
 
 /// Azure TDX v1 admission schema: a Seismic guest image on Azure is
 /// identified by the correlated vTPM register tuple `(PCR4, PCR9, PCR11)`.
@@ -66,18 +122,18 @@ pub struct AzureTdxV1Measurements {
 }
 
 impl AzureTdxV1Measurements {
-    /// Canonical admission ID:
+    /// This tuple's [`AdmissionId`]:
     /// `keccak256(abi.encode(schemaId, pcr4, pcr9, pcr11))`. All four fields
     /// are static 32-byte words, so the ABI encoding is their concatenation —
     /// fixed-width, unambiguous, and recomputable by a future on-chain
     /// catalog from the same preimage.
-    pub fn admission_id(&self) -> B256 {
+    pub fn admission_id(&self) -> AdmissionId {
         let mut preimage = [0u8; 128];
         preimage[..32].copy_from_slice(azure_tdx_v1_schema_id().as_slice());
         preimage[32..64].copy_from_slice(self.pcr4.as_slice());
         preimage[64..96].copy_from_slice(self.pcr9.as_slice());
         preimage[96..128].copy_from_slice(self.pcr11.as_slice());
-        keccak256(preimage)
+        AdmissionId(keccak256(preimage))
     }
 
     /// Extract the schema tuple from a verified PCR map (the shape evidence
@@ -129,7 +185,10 @@ mod tests {
 
     #[test]
     fn admission_id_golden() {
-        assert_eq!(GOLDEN_TUPLE.admission_id(), GOLDEN_ADMISSION_ID);
+        assert_eq!(
+            GOLDEN_TUPLE.admission_id(),
+            AdmissionId::from(GOLDEN_ADMISSION_ID)
+        );
     }
 
     #[test]

--- a/crates/measurement-admission/src/policy.rs
+++ b/crates/measurement-admission/src/policy.rs
@@ -17,7 +17,7 @@
 //! binding a single 32-byte value. Parity tests hold the accepted semantics
 //! equal to `check_measurement` for every document this compiler accepts.
 
-use crate::{AZURE_TDX_ATTESTATION_TYPE, AZURE_TDX_V1_PCRS, AzureTdxV1Measurements};
+use crate::{AZURE_TDX_ATTESTATION_TYPE, AZURE_TDX_V1_PCRS, AdmissionId, AzureTdxV1Measurements};
 use alloy_primitives::B256;
 use serde::Deserialize;
 use sha2::{Digest, Sha256};
@@ -34,7 +34,7 @@ pub struct CompiledPolicy {
     pub records: Vec<CompiledRecord>,
     /// Unique admission IDs across all records, ascending. The length is the
     /// registry's `acceptedCount` at genesis.
-    pub admission_ids: Vec<B256>,
+    pub admission_ids: Vec<AdmissionId>,
 }
 
 /// One record's compiled form: the concrete guest identity it admits.
@@ -48,7 +48,7 @@ pub struct CompiledRecord {
 
 impl CompiledRecord {
     /// Admission ID of this record's tuple.
-    pub fn admission_id(&self) -> B256 {
+    pub fn admission_id(&self) -> AdmissionId {
         self.tuple.admission_id()
     }
 }
@@ -132,7 +132,7 @@ pub fn compile_policy(bytes: &[u8]) -> Result<CompiledPolicy, PolicyError> {
     }
 
     let mut seen_measurement_ids: HashSet<&str> = HashSet::new();
-    let mut unique_ids: BTreeSet<B256> = BTreeSet::new();
+    let mut unique_ids: BTreeSet<AdmissionId> = BTreeSet::new();
     let mut records = Vec::with_capacity(raw_records.len());
 
     for (position, raw) in raw_records.iter().enumerate() {

--- a/crates/measurement-admission/src/report.rs
+++ b/crates/measurement-admission/src/report.rs
@@ -7,7 +7,7 @@
 //! durable audit record of what a policy document compiled to and seeded
 //! at genesis.
 
-use crate::{AZURE_TDX_V1_SCHEMA, CompiledPolicy, azure_tdx_v1_schema_id, genesis};
+use crate::{AZURE_TDX_V1_SCHEMA, AdmissionId, CompiledPolicy, azure_tdx_v1_schema_id, genesis};
 use alloy_primitives::B256;
 use serde::Serialize;
 use std::collections::BTreeMap;
@@ -25,7 +25,7 @@ pub struct CompileReport {
     /// Number of unique admission IDs (the registry's `acceptedCount`).
     pub accepted_count: usize,
     /// Unique admission IDs across all records, ascending.
-    pub admission_ids: Vec<B256>,
+    pub admission_ids: Vec<AdmissionId>,
     /// Per-record expansions, in document order.
     pub records: Vec<RecordReport>,
     /// keccak256 of the canonical registry runtime bytecode the genesis
@@ -40,7 +40,7 @@ pub struct CompileReport {
 pub struct RecordReport {
     pub measurement_id: String,
     /// The admission ID of this record's measurement tuple.
-    pub admission_id: B256,
+    pub admission_id: AdmissionId,
 }
 
 impl CompileReport {

--- a/crates/measurement-admission/tests/reth_registry.rs
+++ b/crates/measurement-admission/tests/reth_registry.rs
@@ -185,7 +185,9 @@ fn launch_seeded_node(reth: &PathBuf) -> (RethNode, Vec<B256>, B256) {
         dir,
         http_url: format!("http://127.0.0.1:{http_port}"),
     };
-    (node, compiled.admission_ids, compiled.policy_hash)
+    // The contract ABI speaks bytes32; cross the boundary once, here.
+    let admission_ids = compiled.admission_ids.into_iter().map(B256::from).collect();
+    (node, admission_ids, compiled.policy_hash)
 }
 
 async fn wait_for_rpc(node: &RethNode) -> impl Provider + Clone + use<> {

--- a/crates/network-manifest/src/lib.rs
+++ b/crates/network-manifest/src/lib.rs
@@ -27,6 +27,16 @@ use thiserror::Error;
 /// A network's identity: SHA-256 of the exact bytes of its
 /// `network-manifest.json`.
 ///
+/// Note that we don't serialize before hashing on purpose. We want the
+/// artifact itself to be the identity, not its values. This is similar to
+/// git objects, OCI digests, and other content-addressed objects. The manifest
+/// has a single emitter and travels verbatim, so any holder of the bytes
+/// derives the id with no schema and no canonical-JSON spec that every
+/// language must reimplement bit-identically, and there is no canonicalizer
+/// whose bugs could silently give two differing documents one id. The flip
+/// side is intended: any byte change, even a reformat, names a different
+/// network and fails loudly at the first binding check.
+///
 /// Transcript form is the raw 32 bytes ([`NetworkId::as_bytes`]).
 /// Presentation form is lowercase 0x-hex ([`fmt::Display`]).
 /// Equivalently: `sha256sum network-manifest.json`.


### PR DESCRIPTION
Type admission IDs as a dedicated AdmissionId newtype instead of bare B256, so the identity model is documented once on the type and every consumer inherits it, and so admission IDs cannot cross-contaminate with the crate's other 32-byte words (policy hashes, the runtime-code hash, storage slots). Serialization is unchanged: serde renders newtype structs transparently, so the compile report, CLI output, and the byte-pinned golden fixture are identical.

Also:
- measurement-admission README: mermaid diagram of the admission-ID derivation and its consumers (one derivation shared by registry genesis seeding and the live membership checks)
- network-manifest: document on NetworkId why the id hashes exact file bytes (artifact identity, not value identity)