### PR TITLE
feat(attestation-service): gate joining peers via the on-chain MeasurementRegistry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5466,6 +5466,8 @@ dependencies = [
 name = "seismic-attestation-service"
 version = "0.1.0"
 dependencies = [
+ "alloy",
+ "alloy-primitives 1.3.0",
  "anyhow",
  "clap",
  "hex",
@@ -5477,13 +5479,17 @@ dependencies = [
  "seismic-custodian",
  "seismic-custodian-ipc",
  "seismic-custodian-service",
+ "seismic-measurement-admission",
+ "seismic-measurement-registry-client",
  "serde",
  "serde_json",
  "serial_test",
  "tempfile",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,4 +81,5 @@ toml = "0.8"
 tower = { version = "0.5", features = ["util"] }
 tracing = { version = "0.1.41"}
 tracing-subscriber = { version = "0.3", default-features = false, features = ["env-filter", "fmt", "ansi", "json"] }
+url = "2.5"
 zeroize = "1.8.1"

--- a/bin/attestation-service/Cargo.toml
+++ b/bin/attestation-service/Cargo.toml
@@ -21,7 +21,11 @@ path = "src/main.rs"
 seismic-attestation.workspace = true
 seismic-attestation-rpc.workspace = true
 seismic-custodian-ipc = { workspace = true, features = ["client"] }
+seismic-measurement-admission.workspace = true
+seismic-measurement-registry-client.workspace = true
 
+alloy.workspace = true
+alloy-primitives.workspace = true
 jsonrpsee.workspace = true
 tokio.workspace = true
 serde.workspace = true
@@ -29,9 +33,11 @@ serde_json.workspace = true
 anyhow.workspace = true
 secp256k1.workspace = true
 clap.workspace = true
+thiserror.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 rand.workspace = true
+url.workspace = true
 
 [dev-dependencies]
 # Used by the `capture_measurements` example to render guest measurements.

--- a/bin/attestation-service/examples/capture_measurements.rs
+++ b/bin/attestation-service/examples/capture_measurements.rs
@@ -51,7 +51,7 @@ use seismic_attestation::{
     AttestationType, NetworkId, SeismicMeasurementPolicy, VerifiedSeismicAttestation,
     VerifyOptions,
     bindings::{binding64_from_digest32, tx_io_binding},
-    verify_evidence_with_options,
+    verify_evidence_with_policy_and_options,
 };
 use seismic_attestation_rpc::AttestationRpcClient;
 use std::collections::BTreeMap;
@@ -151,7 +151,7 @@ async fn main() -> anyhow::Result<()> {
     };
 
     println!("Verifying evidence...");
-    let verified = verify_evidence_with_options(
+    let verified = verify_evidence_with_policy_and_options(
         response.evidence,
         expected_binding,
         policy,

--- a/bin/attestation-service/src/admission.rs
+++ b/bin/attestation-service/src/admission.rs
@@ -1,0 +1,282 @@
+//! Admission of new nodes into the network: an operator boots a fresh box,
+//! it asks an existing node for `root_key`, and these predicates are the
+//! yes-or-no on letting it in.
+//!
+//! Holding `root_key` is what makes a machine part of the network's trust
+//! domain — every decryption and purpose key derives from it — so the
+//! root-key bootstrap handshake, the first mandatory step of any join, is
+//! where membership is granted or refused. (Consensus membership — a seat in
+//! the validator set — is gated separately.) Cryptographic evidence
+//! verification (in `seismic-attestation`) establishes which guest is
+//! asking; the predicates here decide whether that guest is allowed:
+//!
+//! - [`RegistryAdmission`] — the responder's predicate. A requester is
+//!   admitted iff its Azure v1 admission ID is currently accepted by the
+//!   on-chain `MeasurementRegistry`, asked via `eth_call isAccepted(id)` on
+//!   the node's local reth. The chain carries the *live* policy: additions and
+//!   deprecations take effect on the next handshake, no node restart needed.
+//! - [`DangerouslyAdmitAnyAzureGuest`] — the requester's (joiner's) predicate
+//!   for appraising the responder, intentionally permissive; see its docs.
+//!
+//! The measurements → admission-ID mapping is `seismic-measurement-admission`,
+//! the same derivation deploy tooling compiles the registry's genesis storage
+//! with — the two halves of the system cannot disagree on what an admission ID
+//! means. Every branch fails closed: a non-Azure attestation type, a PCR
+//! bank missing a schema register, an unreachable chain, and a false
+//! `isAccepted` all deny the handshake.
+
+use alloy::providers::RootProvider;
+use alloy_primitives::Address;
+use seismic_attestation::{AdmissionPredicate, AttestationType, VerifiedSeismicAttestation};
+use seismic_measurement_admission::{AdmissionId, AzureTdxV1Measurements, MissingPcr};
+use seismic_measurement_registry_client::MeasurementRegistry::{self, MeasurementRegistryInstance};
+use tracing::{info, warn};
+
+/// Why a bootstrap admission predicate denied a verified guest.
+#[derive(Debug, thiserror::Error)]
+pub enum AdmissionDenial {
+    #[error("only Azure TDX guests are admitted to the bootstrap; evidence is {0}")]
+    UnsupportedAttestationType(AttestationType),
+    #[error(transparent)]
+    MissingPcr(#[from] MissingPcr),
+    #[error("querying MeasurementRegistry.isAccepted({admission_id}) on local reth: {source}")]
+    RegistryQueryFailed {
+        admission_id: AdmissionId,
+        #[source]
+        source: Box<alloy::contract::Error>,
+    },
+    #[error("admission ID {0} is not accepted by the MeasurementRegistry")]
+    NotAccepted(AdmissionId),
+}
+
+/// The [`AdmissionId`] of a verified guest, under the Azure v1 schema.
+///
+/// Fails closed: only Azure TDX attestation has an admission schema, and a
+/// verified PCR bank missing any schema register yields an error, never a
+/// partial identity.
+fn azure_admission_id(
+    verified: &VerifiedSeismicAttestation,
+) -> Result<AdmissionId, AdmissionDenial> {
+    let VerifiedSeismicAttestation::AzureTdx(azure) = verified else {
+        return Err(AdmissionDenial::UnsupportedAttestationType(
+            verified.attestation_type(),
+        ));
+    };
+    let measurements = AzureTdxV1Measurements::from_pcrs(&azure.guest_measurements.pcrs)?;
+    Ok(measurements.admission_id())
+}
+
+/// Responder-side admission: registry membership of the requester's
+/// admission ID.
+#[derive(Clone)]
+pub struct RegistryAdmission {
+    registry: MeasurementRegistryInstance<RootProvider>,
+}
+
+impl RegistryAdmission {
+    /// Admission backed by the `MeasurementRegistry` at `registry` (the
+    /// manifest's `measurements.contracts.registry`), read over the node's
+    /// local reth HTTP endpoint.
+    pub fn new(reth_rpc_url: url::Url, registry: Address) -> Self {
+        Self::with_provider(RootProvider::new_http(reth_rpc_url), registry)
+    }
+
+    fn with_provider(provider: RootProvider, registry: Address) -> Self {
+        Self {
+            registry: MeasurementRegistry::new(registry, provider),
+        }
+    }
+}
+
+impl AdmissionPredicate for RegistryAdmission {
+    async fn admit(
+        &self,
+        verified: &VerifiedSeismicAttestation,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        let admission_id = azure_admission_id(verified)?;
+        let accepted = self
+            .registry
+            .isAccepted(admission_id.into())
+            .call()
+            .await
+            .map_err(|source| AdmissionDenial::RegistryQueryFailed {
+                admission_id,
+                source: Box::new(source),
+            })?;
+        if !accepted {
+            return Err(AdmissionDenial::NotAccepted(admission_id).into());
+        }
+        info!("bootstrap: MeasurementRegistry accepted admission ID {admission_id}");
+        Ok(())
+    }
+}
+
+/// Requester-side (joiner) appraisal of the responder: any cryptographically
+/// valid Azure TDX guest is admitted, measurements unchecked.
+///
+/// TODO(bootstrap): intentionally temporary. The joiner cannot hold the live
+/// policy — it can't read the chain before it holds `root_key`, and a
+/// manifest-pinned allowlist would be frozen at genesis — so its real defense
+/// is planned as provenance, not measurement appraisal: verifying the
+/// responder against the network's pinned `tx_io_pk` commitment. Until that
+/// lands, a joiner talking to an attacker-chosen "responder" enclave gets no
+/// measurement guarantee beyond genuine Azure TDX hardware.
+pub struct DangerouslyAdmitAnyAzureGuest;
+
+impl AdmissionPredicate for DangerouslyAdmitAnyAzureGuest {
+    async fn admit(
+        &self,
+        verified: &VerifiedSeismicAttestation,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        if !matches!(verified, VerifiedSeismicAttestation::AzureTdx(_)) {
+            return Err(
+                AdmissionDenial::UnsupportedAttestationType(verified.attestation_type()).into(),
+            );
+        }
+        warn!(
+            "bootstrap: admitting responder on any Azure TDX measurements; \
+             its image is NOT being checked against the network policy"
+        );
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy::{rpc::client::RpcClient, transports::mock::Asserter};
+    use alloy_primitives::{Bytes, b256};
+    use seismic_attestation::{AzureGuestMeasurements, VerifiedAzureAttestation};
+    use std::collections::HashMap;
+
+    // The golden Azure v1 vector pinned in `seismic-measurement-admission`:
+    // this tuple's admission ID must match that crate's derivation exactly.
+    const PCR4: [u8; 32] = [0x11; 32];
+    const PCR9: [u8; 32] = [0x22; 32];
+    const PCR11: [u8; 32] = [0x33; 32];
+    const GOLDEN_ADMISSION_ID: alloy_primitives::B256 =
+        b256!("0x0e4c78c6346c15ad1fbbcf16dab1ab9e5c820f4daf5b8001c92d1f40f0f16a8e");
+
+    fn verified_azure(pcrs: HashMap<u32, [u8; 32]>) -> VerifiedSeismicAttestation {
+        VerifiedSeismicAttestation::AzureTdx(VerifiedAzureAttestation {
+            binding: [0u8; 64],
+            guest_measurements: AzureGuestMeasurements { pcrs },
+        })
+    }
+
+    fn golden_pcr_bank() -> HashMap<u32, [u8; 32]> {
+        HashMap::from([(4, PCR4), (9, PCR9), (11, PCR11)])
+    }
+
+    fn mocked_registry(asserter: &Asserter) -> RegistryAdmission {
+        RegistryAdmission::with_provider(
+            RootProvider::new(RpcClient::mocked(asserter.clone())),
+            Address::ZERO,
+        )
+    }
+
+    /// ABI-encoded `isAccepted` return value, as the eth_call response body.
+    fn abi_bool(value: bool) -> Bytes {
+        let mut word = [0u8; 32];
+        word[31] = value as u8;
+        Bytes::from(word.to_vec())
+    }
+
+    #[test]
+    fn derives_golden_admission_id_from_verified_measurements() {
+        // Extra registers in the verified bank don't perturb identity.
+        let mut pcrs = golden_pcr_bank();
+        pcrs.insert(0, [0xaa; 32]);
+        assert_eq!(
+            azure_admission_id(&verified_azure(pcrs)).unwrap(),
+            AdmissionId::from(GOLDEN_ADMISSION_ID)
+        );
+    }
+
+    #[test]
+    fn missing_schema_pcr_fails_closed() {
+        let mut pcrs = golden_pcr_bank();
+        pcrs.remove(&9);
+        assert!(matches!(
+            azure_admission_id(&verified_azure(pcrs)),
+            Err(AdmissionDenial::MissingPcr(MissingPcr(9)))
+        ));
+    }
+
+    #[test]
+    fn non_azure_attestation_fails_closed() {
+        let verified = VerifiedSeismicAttestation::NoAttestation { binding: [0u8; 64] };
+        assert!(matches!(
+            azure_admission_id(&verified),
+            Err(AdmissionDenial::UnsupportedAttestationType(
+                AttestationType::None
+            ))
+        ));
+    }
+
+    #[tokio::test]
+    async fn accepted_tuple_is_admitted() {
+        let asserter = Asserter::new();
+        asserter.push_success(&abi_bool(true));
+        let admission = mocked_registry(&asserter);
+
+        admission
+            .admit(&verified_azure(golden_pcr_bank()))
+            .await
+            .expect("registry-accepted tuple must be admitted");
+    }
+
+    #[tokio::test]
+    async fn unknown_tuple_is_denied() {
+        let asserter = Asserter::new();
+        asserter.push_success(&abi_bool(false));
+        let admission = mocked_registry(&asserter);
+
+        let error = admission
+            .admit(&verified_azure(golden_pcr_bank()))
+            .await
+            .expect_err("tuple the registry rejects must be denied");
+        assert!(error.to_string().contains("not accepted"), "{error}");
+    }
+
+    #[tokio::test]
+    async fn unreachable_registry_fails_closed() {
+        let asserter = Asserter::new();
+        asserter.push_failure_msg("connection refused");
+        let admission = mocked_registry(&asserter);
+
+        let error = admission
+            .admit(&verified_azure(golden_pcr_bank()))
+            .await
+            .expect_err("an unreachable registry must deny, not admit");
+        assert!(error.to_string().contains("isAccepted"), "{error}");
+    }
+
+    #[tokio::test]
+    async fn missing_pcr_denies_without_asking_the_registry() {
+        // No queued response: reaching the registry would error differently,
+        // so a MissingPcr denial proves the RPC was never attempted.
+        let admission = mocked_registry(&Asserter::new());
+        let mut pcrs = golden_pcr_bank();
+        pcrs.remove(&11);
+
+        let error = admission
+            .admit(&verified_azure(pcrs))
+            .await
+            .expect_err("missing schema register must fail closed");
+        assert!(error.to_string().contains("pcr11"), "{error}");
+    }
+
+    #[tokio::test]
+    async fn joiner_predicate_admits_azure_and_denies_other_types() {
+        DangerouslyAdmitAnyAzureGuest
+            .admit(&verified_azure(HashMap::new()))
+            .await
+            .expect("any Azure guest is admitted by the temporary predicate");
+
+        DangerouslyAdmitAnyAzureGuest
+            .admit(&VerifiedSeismicAttestation::NoAttestation { binding: [0u8; 64] })
+            .await
+            .expect_err("non-Azure attestation types are denied even by the temporary predicate");
+    }
+}

--- a/bin/attestation-service/src/bootstrap.rs
+++ b/bin/attestation-service/src/bootstrap.rs
@@ -14,7 +14,8 @@
 //!   q_b = quote over root_key_request_binding(
 //!             network_id, nonce_b, eph_pk_b)
 //!   ----  RootKeyRequest { nonce_b, eph_pk_b, q_b } --->
-//!                                          verify q_b against requester policy,
+//!                                          verify q_b, appraise the requester's
+//!                                          measurements (admission predicate),
 //!                                          recompute its binding from our own
 //!                                          network_id + the request fields
 //!                                          eph (sk_a, pk_a)
@@ -55,9 +56,9 @@ use anyhow::{Context, Result};
 use rand::{TryRngCore as _, rngs::OsRng};
 use secp256k1::PublicKey;
 use seismic_attestation::{
-    AttestationExchangeMessage, AttestationType, NetworkId, SeismicMeasurementPolicy,
+    AdmissionPredicate, AttestationExchangeMessage, AttestationType, NetworkId,
     bindings::{binding64_from_digest32, root_key_request_binding, root_key_response_binding},
-    generate_evidence, verify_evidence,
+    generate_evidence, verify_evidence_with_predicate,
 };
 use seismic_custodian_ipc::CustodianClient;
 use serde::{Deserialize, Serialize};
@@ -124,26 +125,28 @@ pub fn build_root_key_request(
 /// the root key for it, and attest the response.
 ///
 /// The root key itself never appears here: only the custodian touches it, and
-/// only to wrap it once the requester's evidence has verified. `policy` is the
-/// responder's measurement allowlist (the requester must be running an
-/// admitted image). `network_id` is the responder's own — verification
-/// recomputes the requester's binding from it, so a quote for a different
-/// network fails the binding check.
+/// only to wrap it once the requester's evidence has verified. `admission` is
+/// the responder's appraisal of the requester's verified measurements (the
+/// requester must be running an admitted image — in production, registry
+/// membership; see [`crate::admission`]). `network_id` is the responder's own
+/// — verification recomputes the requester's binding from it, so a quote for a
+/// different network fails the binding check.
 pub async fn answer_root_key_request(
     request: &RootKeyRequest,
     network_id: &NetworkId,
     custodian: &mut CustodianClient,
-    policy: SeismicMeasurementPolicy,
+    admission: &impl AdmissionPredicate,
     attestation_type: AttestationType,
 ) -> Result<RootKeyResponse> {
-    // 1. Verify the requester's quote against our policy, recomputing the
-    //    expected binding from *our* network_id + the request's claimed fields.
+    // 1. Verify the requester's quote and appraise its measurements,
+    //    recomputing the expected binding from *our* network_id + the
+    //    request's claimed fields.
     let expected =
         root_key_request_binding(network_id, &request.nonce_b, &request.eph_pk_b.serialize());
-    verify_evidence(
+    verify_evidence_with_predicate(
         request.evidence.clone(),
         binding64_from_digest32(expected),
-        policy,
+        admission,
     )
     .await
     .context("verifying requester attestation evidence")?;
@@ -180,17 +183,17 @@ pub async fn answer_root_key_request(
 /// transcript.
 ///
 /// `request` is the matching request (we re-derive bindings from it rather
-/// than trusting the response to echo them). `policy` is the requester's
-/// allowlist for the responder. Returns the request-transcript binding,
-/// recomputed from our own copies of the request fields — the AEAD AAD the
-/// custodian needs to open the wrapped key on install. The wrapped key stays
-/// sealed through this function: only the custodian, holding the attempt's
-/// ephemeral secret, can open it.
+/// than trusting the response to echo them). `admission` is the requester's
+/// appraisal of the responder's verified measurements. Returns the
+/// request-transcript binding, recomputed from our own copies of the request
+/// fields — the AEAD AAD the custodian needs to open the wrapped key on
+/// install. The wrapped key stays sealed through this function: only the
+/// custodian, holding the attempt's ephemeral secret, can open it.
 pub async fn verify_root_key_response(
     response: &RootKeyResponse,
     request: &RootKeyRequest,
     network_id: &NetworkId,
-    policy: SeismicMeasurementPolicy,
+    admission: &impl AdmissionPredicate,
 ) -> Result<[u8; 32]> {
     // Verify the responder's quote: recompute the response binding from our
     // own network_id + the nonce we chose + the responder's ephemeral key +
@@ -201,10 +204,10 @@ pub async fn verify_root_key_response(
         &response.eph_pk_a.serialize(),
         &response.wrapped,
     );
-    verify_evidence(
+    verify_evidence_with_predicate(
         response.evidence.clone(),
         binding64_from_digest32(expected),
-        policy,
+        admission,
     )
     .await
     .context("verifying responder attestation evidence")?;

--- a/bin/attestation-service/src/lib.rs
+++ b/bin/attestation-service/src/lib.rs
@@ -1,3 +1,4 @@
+mod admission;
 pub mod api;
 mod bootstrap;
 mod luks_status;
@@ -9,6 +10,9 @@ pub mod utils;
 /// joining peers fetch the wrapped root key from here and deploy tooling polls node status.
 const DEFAULT_ENDPOINT_IP: &str = "127.0.0.1";
 const DEFAULT_ENDPOINT_PORT: u16 = 7878;
+/// The node's own reth, assumed to serve HTTP JSON-RPC on the conventional
+/// loopback endpoint.
+const DEFAULT_RETH_RPC_URL: &str = "http://127.0.0.1:8545";
 
 use anyhow::Result;
 use clap::Parser;
@@ -39,6 +43,13 @@ pub struct Args {
     /// way to obtain the root key, so startup fails immediately.
     #[arg(long, env = "SEISMIC_ROOT_KEY_PEERS", value_delimiter = ',')]
     pub peers: Vec<String>,
+
+    /// HTTP JSON-RPC endpoint of this node's own reth, queried to check each
+    /// joining peer's admission ID against the on-chain MeasurementRegistry.
+    /// An unreachable endpoint denies joins (fail closed) — it never blocks
+    /// this service's startup or its other RPCs.
+    #[arg(long, env = "SEISMIC_RETH_RPC_URL", default_value = DEFAULT_RETH_RPC_URL)]
+    pub reth_rpc_url: url::Url,
 }
 
 impl Args {

--- a/bin/attestation-service/src/network.rs
+++ b/bin/attestation-service/src/network.rs
@@ -1,4 +1,5 @@
-//! Startup derivation of this node's [`NetworkId`] from the network manifest.
+//! Startup load of the network manifest: this node's [`NetworkId`] plus the
+//! parsed manifest fields the service consumes (the registry address).
 //!
 //! tdx-init writes the network's `network-manifest.json` verbatim to
 //! [`NETWORK_MANIFEST_PATH`] (tmpfs, re-supplied every boot by deploy tooling).
@@ -8,9 +9,9 @@
 //!
 //! We hash the raw bytes we read rather than trusting any precomputed id, and
 //! deliberately never parse-and-re-serialize: re-rendering could change the
-//! bytes and therefore the id. We still parse once (strict v1) to fail fast
-//! with an actionable error on a malformed or wrong-version manifest, but the
-//! id always comes from [`NetworkId::from_manifest_bytes`] over the file bytes.
+//! bytes and therefore the id. The strict v1 parse also fails fast with an
+//! actionable error on a malformed or wrong-version manifest, but the id
+//! always comes from [`NetworkId::from_manifest_bytes`] over the file bytes.
 
 use anyhow::{Context, Result};
 use seismic_attestation::{NetworkId, NetworkManifestV1};
@@ -19,18 +20,16 @@ use seismic_attestation::{NetworkId, NetworkManifestV1};
 /// `CONF_DIR`/`network-manifest.json`; see that crate's README.
 pub const NETWORK_MANIFEST_PATH: &str = "/run/seismic/conf/network-manifest.json";
 
-/// Read the manifest from `path`, validate it parses as v1, and derive the
+/// Read the manifest from `path`, strictly parse it as v1, and derive the
 /// [`NetworkId`] from the exact file bytes.
-pub fn load_network_id(path: &str) -> Result<NetworkId> {
+pub fn load_manifest(path: &str) -> Result<(NetworkManifestV1, NetworkId)> {
     let bytes =
         std::fs::read(path).with_context(|| format!("reading network manifest from {path}"))?;
 
-    // Strict parse for a fast, actionable error; the id is over the bytes, not
-    // the parsed value.
-    NetworkManifestV1::from_json_bytes(&bytes)
+    let manifest = NetworkManifestV1::from_json_bytes(&bytes)
         .with_context(|| format!("parsing network manifest at {path}"))?;
 
-    Ok(NetworkId::from_manifest_bytes(&bytes))
+    Ok((manifest, NetworkId::from_manifest_bytes(&bytes)))
 }
 
 #[cfg(test)]
@@ -42,25 +41,29 @@ mod tests {
         include_bytes!("../../../crates/network-manifest/fixtures/network-manifest-v1.json");
 
     #[test]
-    fn derives_network_id_from_manifest_file() {
+    fn derives_network_id_and_manifest_from_file() {
         let mut tmp = tempfile::NamedTempFile::new().unwrap();
         tmp.write_all(FIXTURE).unwrap();
         let path = tmp.path().to_str().unwrap();
 
-        let network_id = load_network_id(path).unwrap();
+        let (manifest, network_id) = load_manifest(path).unwrap();
         // Same vector as seismic-attestation's manifest test over the fixture.
         assert_eq!(network_id, NetworkId::from_manifest_bytes(FIXTURE));
+        assert_eq!(
+            hex::encode(manifest.measurements.contracts.registry),
+            "1000000000000000000000000000000000000001"
+        );
     }
 
     #[test]
     fn rejects_malformed_manifest() {
         let mut tmp = tempfile::NamedTempFile::new().unwrap();
         tmp.write_all(b"{ not valid json").unwrap();
-        assert!(load_network_id(tmp.path().to_str().unwrap()).is_err());
+        assert!(load_manifest(tmp.path().to_str().unwrap()).is_err());
     }
 
     #[test]
     fn errors_when_manifest_missing() {
-        assert!(load_network_id("/nonexistent/network-manifest.json").is_err());
+        assert!(load_manifest("/nonexistent/network-manifest.json").is_err());
     }
 }

--- a/bin/attestation-service/src/server.rs
+++ b/bin/attestation-service/src/server.rs
@@ -1,15 +1,17 @@
 use crate::{
     Args,
+    admission::{DangerouslyAdmitAnyAzureGuest, RegistryAdmission},
     api::{LuksProvisioningStatus, NodeStatusRpcServer},
     bootstrap::{
         RootKeyRequest, RootKeyResponse, answer_root_key_request, build_root_key_request,
         verify_root_key_response,
     },
-    network::{NETWORK_MANIFEST_PATH, load_network_id},
+    network::{NETWORK_MANIFEST_PATH, load_manifest},
     utils::{
         internal_rpc_error, invalid_root_key_request_rpc_error, root_key_request_denied_rpc_error,
     },
 };
+use alloy_primitives::Address;
 use anyhow::Context as _;
 use jsonrpsee::{
     core::{RpcResult, async_trait},
@@ -18,7 +20,7 @@ use jsonrpsee::{
 };
 use secp256k1::PublicKey;
 use seismic_attestation::{
-    AttestationType, NetworkId, SeismicMeasurementPolicy,
+    AttestationType, NetworkId,
     bindings::{binding64_from_digest32, tx_io_binding},
     generate_evidence,
 };
@@ -34,7 +36,7 @@ use std::{
 use tracing::{info, warn};
 
 /// Attestation type this build mints and verifies evidence for. Azure TDX +
-/// vTPM is the only supported surface today.
+/// vTPM is the only supported type today.
 const ATTESTATION_TYPE: AttestationType = AttestationType::AzureTdx;
 
 /// Poll interval while waiting for the custodian socket to come up.
@@ -50,13 +52,21 @@ pub struct AttestationService {
     /// This node's network identity: `H(network-manifest.json)`. Every
     /// attestation binding this server mints or verifies is scoped to it.
     network_id: NetworkId,
+    /// Admission gate for joining peers: their verified measurements must be
+    /// accepted by the on-chain `MeasurementRegistry`. See [`crate::admission`].
+    admission: RegistryAdmission,
 }
 
 impl AttestationService {
-    pub fn new(custodian_socket: PathBuf, network_id: NetworkId) -> Self {
+    pub fn new(
+        custodian_socket: PathBuf,
+        network_id: NetworkId,
+        admission: RegistryAdmission,
+    ) -> Self {
         Self {
             custodian_socket,
             network_id,
+            admission,
         }
     }
 
@@ -99,7 +109,7 @@ impl AttestationRpcServer for AttestationService {
             &request,
             &self.network_id,
             &mut custodian,
-            bootstrap_measurement_policy(),
+            &self.admission,
             ATTESTATION_TYPE,
         )
         .await
@@ -142,8 +152,20 @@ pub async fn start_server(addr: SocketAddr, args: Args) -> anyhow::Result<()> {
     // Derive this node's network identity from the manifest tdx-init dropped on
     // tmpfs. Fatal if absent/malformed: without it every attestation binding is
     // unscoped, so we refuse to serve rather than fall back to an unbound quote.
-    let network_id = load_network_id(NETWORK_MANIFEST_PATH)?;
+    let (manifest, network_id) = load_manifest(NETWORK_MANIFEST_PATH)?;
     info!("Derived network_id {network_id} from {NETWORK_MANIFEST_PATH}");
+
+    // Joining peers are admitted by the live on-chain policy: the manifest
+    // names the registry, our own reth answers for it. Construction is lazy —
+    // no connection until a join arrives — so serving never waits on reth;
+    // a join that beats reth's startup is denied (fail closed) and the
+    // requester retries.
+    let registry = Address::from(manifest.measurements.contracts.registry);
+    let admission = RegistryAdmission::new(args.reth_rpc_url.clone(), registry);
+    info!(
+        "Gating joining peers via MeasurementRegistry at {registry} over {}",
+        args.reth_rpc_url
+    );
 
     // The root key lives in the key custodian, a separate local process with
     // no network listener; every key operation goes through its Unix socket.
@@ -153,7 +175,7 @@ pub async fn start_server(addr: SocketAddr, args: Args) -> anyhow::Result<()> {
 
     let server = ServerBuilder::default().build(addr).await?;
 
-    let service = AttestationService::new(args.custodian_socket, network_id);
+    let service = AttestationService::new(args.custodian_socket, network_id, admission);
     let mut rpc = NodeStatusRpcServer::into_rpc(service.clone());
     rpc.merge(AttestationRpcServer::into_rpc(service))?;
     let handle = server.start(rpc);
@@ -288,11 +310,13 @@ async fn try_fetch_root_key_from_peer(
     let response_bytes = client.get_wrapped_root_key(request_bytes).await?;
     let response: RootKeyResponse = serde_json::from_slice(&response_bytes)?;
 
+    // The joiner's appraisal of the responder is intentionally permissive for
+    // now; see [`DangerouslyAdmitAnyAzureGuest`].
     let request_binding = verify_root_key_response(
         &response,
         &request,
         network_id,
-        bootstrap_measurement_policy(),
+        &DangerouslyAdmitAnyAzureGuest,
     )
     .await?;
 
@@ -307,21 +331,4 @@ async fn try_fetch_root_key_from_peer(
         .await
         .context("installing root key in the custodian")?;
     Ok(())
-}
-
-/// Measurement policy for verifying the *other* side of the bootstrap handshake.
-///
-/// TODO(bootstrap): load the policy pinned by the manifest's
-/// `measurements.bootstrap_policy_hash` (the seismic-images
-/// `build/measurements.json` artifact) once it is delivered to the node, and
-/// check the artifact bytes against that hash. Until that artifact is wired in,
-/// this accepts any measurements after the backend's cryptographic quote
-/// verification succeeds — adequate for bringing the encrypted transcript up,
-/// NOT a production allowlist.
-fn bootstrap_measurement_policy() -> SeismicMeasurementPolicy {
-    warn!(
-        "bootstrap: using dangerously-permissive measurement policy; \
-         peer image measurements are NOT being checked against an allowlist"
-    );
-    SeismicMeasurementPolicy::dangerously_accept_any_for_testing(ATTESTATION_TYPE)
 }

--- a/bin/attestation-service/tests/integration/integration.rs
+++ b/bin/attestation-service/tests/integration/integration.rs
@@ -19,12 +19,12 @@ use std::{
     time::Duration,
 };
 
-use crate::utils::{get_args, spawn_custodian};
+use crate::utils::{get_args, spawn_accepting_registry, spawn_custodian};
 use jsonrpsee::http_client::{HttpClient, HttpClientBuilder};
 use seismic_attestation::{
     AttestationType, NetworkId, NetworkManifestV1, SeismicMeasurementPolicy,
     bindings::{binding64_from_digest32, tx_io_binding},
-    verify_evidence,
+    verify_evidence_with_policy,
 };
 use seismic_attestation_rpc::{AttestationRpcClient as _, TxIoAttestationResponse};
 use seismic_attestation_service::{
@@ -109,7 +109,7 @@ async fn test_tx_io_evidence_relying_party() {
         tx_io_binding(&network_id, &response.tx_io_pk.serialize(), response.epoch);
     let expected_binding = binding64_from_digest32(expected_digest);
 
-    verify_evidence(
+    verify_evidence_with_policy(
         response.evidence.clone(),
         expected_binding,
         test_measurement_policy(),
@@ -123,7 +123,7 @@ async fn test_tx_io_evidence_relying_party() {
         response.epoch + 1,
     );
     assert!(
-        verify_evidence(
+        verify_evidence_with_policy(
             response.evidence.clone(),
             binding64_from_digest32(wrong_epoch_digest),
             test_measurement_policy(),
@@ -144,7 +144,7 @@ async fn test_tx_io_evidence_relying_party() {
     // deterministic malformed-evidence case.
     quote[0] = 0xff;
     assert!(
-        verify_evidence(
+        verify_evidence_with_policy(
             tampered_evidence,
             expected_binding,
             test_measurement_policy(),
@@ -222,9 +222,9 @@ async fn test_four_node_root_key_distribution() {
     }
 }
 
-/// The bootstrap path uses the same intentionally temporary permissive policy.
-/// This test is about verifier ownership and transcript integrity; production
-/// measurement admission is covered by the separately tracked on-chain policy.
+/// Deliberately permissive: this test is about verifier ownership and
+/// transcript integrity, not measurement admission — the bootstrap handshake's
+/// registry gate has its own unit coverage in the admission module.
 fn test_measurement_policy() -> SeismicMeasurementPolicy {
     SeismicMeasurementPolicy::dangerously_accept_any_for_testing(AttestationType::AzureTdx)
 }
@@ -325,7 +325,9 @@ async fn start_node(label: &'static str, n: u16, peers: Option<Vec<String>>) -> 
     };
     spawn_custodian(state, &socket);
 
-    let args = get_args(n, peers.unwrap_or_default(), socket.clone());
+    // Each node answers admission reads from its own accepting mock registry.
+    let registry_url = spawn_accepting_registry().await;
+    let args = get_args(n, peers.unwrap_or_default(), socket.clone(), &registry_url);
     let url = format!("http://localhost:{}", args.port);
     let mut handle = tokio::spawn(args.start());
     let client = HttpClientBuilder::default()

--- a/bin/attestation-service/tests/integration/utils.rs
+++ b/bin/attestation-service/tests/integration/utils.rs
@@ -1,16 +1,45 @@
+use jsonrpsee::{RpcModule, server::ServerBuilder};
 use seismic_attestation_service::Args;
 use seismic_custodian_ipc::server::{MethodAcl, bind, serve};
 use seismic_custodian_service::{dispatch::dispatch, state::CustodianState};
 use std::path::{Path, PathBuf};
 
-pub fn get_args(n: u16, peers: Vec<String>, custodian_socket: PathBuf) -> Args {
+pub fn get_args(n: u16, peers: Vec<String>, custodian_socket: PathBuf, reth_rpc_url: &str) -> Args {
     let port = 7878 + n;
     Args {
         ip: "0.0.0.0".to_string(),
         port,
         peers,
         custodian_socket,
+        reth_rpc_url: reth_rpc_url.parse().expect("valid mock registry URL"),
     }
+}
+
+/// Serve a permissive stand-in for the node-local reth that answers the
+/// responder's `MeasurementRegistry.isAccepted` reads: every `eth_call`
+/// returns ABI-encoded `true`, so the runner's own measurements count as
+/// registry-accepted. These tests thereby exercise the full live-TEE
+/// admission path — verified evidence → admission ID → registry query —
+/// while denial behavior is covered by the admission module's unit tests.
+pub async fn spawn_accepting_registry() -> String {
+    let server = ServerBuilder::default()
+        .build("127.0.0.1:0")
+        .await
+        .expect("bind mock registry endpoint");
+    let addr = server.local_addr().expect("mock registry local addr");
+    let mut module = RpcModule::new(());
+    module
+        .register_method("eth_call", |_, _, _| {
+            const ABI_ENCODED_TRUE: &str =
+                "0x0000000000000000000000000000000000000000000000000000000000000001";
+            ABI_ENCODED_TRUE.to_string()
+        })
+        .expect("register eth_call");
+    let handle = server.start(module);
+    // The server stops when its handle drops; park the handle in a task that
+    // outlives the test body.
+    tokio::spawn(handle.stopped());
+    format!("http://{addr}")
 }
 
 /// Serve `state` over a custodian socket from a dedicated thread — the same

--- a/bin/summit-key-holder/src/http.rs
+++ b/bin/summit-key-holder/src/http.rs
@@ -31,7 +31,7 @@ use crate::error::HolderError;
 use crate::state::Holder;
 
 /// Attestation type this build mints evidence for. Azure TDX + vTPM is the
-/// only supported surface today (mirrors attestation-service).
+/// only supported type today (mirrors attestation-service).
 const ATTESTATION_TYPE: AttestationType = AttestationType::AzureTdx;
 
 #[derive(Serialize, Deserialize)]

--- a/bin/verify-quote/src/main.rs
+++ b/bin/verify-quote/src/main.rs
@@ -29,9 +29,10 @@
 use anyhow::Context as _;
 use clap::Parser;
 use seismic_attestation::{
-    AttestationType, SeismicMeasurementPolicy, VerifiedAzureAttestation, VerifyOptions,
+    AttestationExchangeMessage, AttestationType, SeismicMeasurementPolicy,
+    VerifiedAzureAttestation, VerifiedSeismicAttestation, VerifyOptions,
     bindings::{binding64_from_digest32, founding_summit_keys_binding},
-    verify_azure_evidence_with_options,
+    verify_evidence_with_policy_and_options,
 };
 use std::{
     collections::BTreeMap,
@@ -120,14 +121,24 @@ async fn run(cli: Cli) -> anyhow::Result<String> {
     let binding = harvest_binding(&nonce, &node_pk, &consensus_pk);
 
     let evidence_bytes = read_evidence(&cli.evidence).await?;
-    let evidence = serde_json::from_slice(&evidence_bytes)
+    let evidence: AttestationExchangeMessage = serde_json::from_slice(&evidence_bytes)
         .context("--evidence is not a JSON-serialized AttestationExchangeMessage")?;
 
     let policy = SeismicMeasurementPolicy::from_file(cli.policy.clone())
         .await
         .with_context(|| format!("loading measurement policy {}", cli.policy.display()))?;
 
-    let verified = verify_azure_evidence_with_options(
+    // Wrong-platform evidence is rejected on the claimed type, before
+    // verification: DCAP verification costs collateral round-trips, and this
+    // policy format cannot pin a non-Azure platform's measurements anyway.
+    anyhow::ensure!(
+        evidence.attestation_type() == AttestationType::AzureTdx,
+        "expected {} evidence, got {}",
+        AttestationType::AzureTdx.as_str(),
+        evidence.attestation_type().as_str(),
+    );
+
+    let verified = verify_evidence_with_policy_and_options(
         evidence,
         binding,
         policy,
@@ -139,6 +150,9 @@ async fn run(cli: Cli) -> anyhow::Result<String> {
     )
     .await
     .context("verifying harvest evidence")?;
+    let VerifiedSeismicAttestation::AzureTdx(verified) = verified else {
+        anyhow::bail!("verified output is not azure-tdx despite azure-tdx evidence: {verified:?}");
+    };
 
     Ok(report(&verified))
 }

--- a/crates/attestation/examples/azure_vtpm_roundtrip.rs
+++ b/crates/attestation/examples/azure_vtpm_roundtrip.rs
@@ -43,7 +43,8 @@ use clap::{Args as ClapArgs, Parser, Subcommand};
 #[cfg(target_os = "linux")]
 use seismic_attestation::{
     AttestationExchangeMessage, AttestationType, SeismicMeasurementPolicy,
-    VerifiedSeismicAttestation, VerifyOptions, generate_evidence, verify_evidence_with_options,
+    VerifiedSeismicAttestation, VerifyOptions, generate_evidence,
+    verify_evidence_with_policy_and_options,
 };
 
 #[cfg(target_os = "linux")]
@@ -253,7 +254,7 @@ async fn verify_exchange_message(
     policy: SeismicMeasurementPolicy,
     backend: BackendArgs,
 ) -> anyhow::Result<VerifiedSeismicAttestation> {
-    let verified = verify_evidence_with_options(
+    let verified = verify_evidence_with_policy_and_options(
         evidence,
         binding,
         policy,

--- a/crates/attestation/src/bindings.rs
+++ b/crates/attestation/src/bindings.rs
@@ -13,7 +13,7 @@
 //!
 //! These helpers return 32-byte SHA-256 digests. Attestation evidence generation
 //! takes a 64-byte input, so use [`binding64_from_digest32`] before calling
-//! [`crate::generate_evidence`] or [`crate::verify_evidence`].
+//! [`crate::generate_evidence`] or [`crate::verify_evidence_with_policy`].
 
 use crate::manifest::NetworkId;
 use sha2::{Digest, Sha256};

--- a/crates/attestation/src/lib.rs
+++ b/crates/attestation/src/lib.rs
@@ -7,12 +7,21 @@
 //!
 //! # Main entry points
 //!
-//! Production callers usually only need these APIs:
+//! Production callers usually only need these APIs. The two verification
+//! flavors serve different callers, split by what the caller's trust anchor
+//! is:
 //!
 //! - [`generate_evidence`] to produce local attestation evidence for a
 //!   caller-supplied 64-byte protocol binding (see [`bindings`]).
-//! - [`verify_evidence`] to verify remote evidence against a
-//!   [`SeismicMeasurementPolicy`].
+//! - [`verify_evidence_with_policy`] to verify remote evidence against a
+//!   [`SeismicMeasurementPolicy`]. For relying parties anchored to a
+//!   measurement-policy document: clients/SDKs verifying the network's tx-io
+//!   key advertisement, and operator tooling such as `verify-quote`.
+//! - [`verify_evidence_with_predicate`] to verify remote evidence and appraise
+//!   the verified measurements with a caller-supplied [`AdmissionPredicate`]
+//!   (e.g. on-chain `MeasurementRegistry` membership). For nodes appraising
+//!   the peer in the root-key bootstrap handshake, where what is admissible
+//!   is a live decision owned by the caller, not a document.
 //! - [`SeismicMeasurementPolicy::from_json_bytes`] or
 //!   [`SeismicMeasurementPolicy::from_file`] to load measurement policies,
 //!   such as seismic-images' `build/measurements.json`.
@@ -68,24 +77,91 @@ pub fn generate_evidence(
 
 /// Verify remote attestation evidence with the backend, enforce the supplied
 /// measurement policy, and return typed Seismic output.
-pub async fn verify_evidence(
+///
+/// For relying parties whose trust anchor is a measurement-policy document
+/// (e.g. seismic-images' `build/measurements.json`): TxSeismic clients
+/// verifying the network's tx-io key advertisement, and operator tooling.
+/// Nodes appraising the peer in the root-key bootstrap handshake use
+/// [`verify_evidence_with_predicate`] instead.
+pub async fn verify_evidence_with_policy(
     evidence: AttestationExchangeMessage,
     expected_binding: [u8; 64],
     policy: SeismicMeasurementPolicy,
 ) -> Result<VerifiedSeismicAttestation, AttestationError> {
-    verify_evidence_with_options(evidence, expected_binding, policy, VerifyOptions::default()).await
+    verify_evidence_with_policy_and_options(
+        evidence,
+        expected_binding,
+        policy,
+        VerifyOptions::default(),
+    )
+    .await
 }
 
-/// Same as [`verify_evidence`], with backend operational options.
-pub async fn verify_evidence_with_options(
+/// Same as [`verify_evidence_with_policy`], with backend operational options.
+pub async fn verify_evidence_with_policy_and_options(
     evidence: AttestationExchangeMessage,
     expected_binding: [u8; 64],
     policy: SeismicMeasurementPolicy,
     options: VerifyOptions,
 ) -> Result<VerifiedSeismicAttestation, AttestationError> {
+    verify_with_backend_policy(
+        evidence,
+        expected_binding,
+        policy.into_backend_policy(),
+        options,
+    )
+    .await
+}
+
+/// Verify remote attestation evidence with the backend and appraise the
+/// resulting typed measurements with `admission`.
+///
+/// For nodes appraising the peer in the root-key bootstrap handshake, where
+/// admissibility is a live decision the caller owns (e.g. on-chain
+/// `MeasurementRegistry` membership) rather than a policy document. Relying
+/// parties that hold a policy document use [`verify_evidence_with_policy`]
+/// instead.
+///
+/// Verification and admission are one operation: the backend performs full
+/// cryptographic verification (quote chain, freshness, binding) for the
+/// evidence's attestation type, and the predicate then decides whether the
+/// verified guest is admitted. Evidence whose measurements the predicate
+/// denies fails with [`AttestationError::AdmissionDenied`]; there is no way to
+/// obtain the verified output without the predicate passing.
+pub async fn verify_evidence_with_predicate(
+    evidence: AttestationExchangeMessage,
+    expected_binding: [u8; 64],
+    admission: &impl AdmissionPredicate,
+) -> Result<VerifiedSeismicAttestation, AttestationError> {
+    // Backend appraisal pinned to the evidence's own attestation type is
+    // cryptographic verification only — admissibility (including which
+    // attestation types are acceptable at all) is the predicate's job.
+    let crypto_only =
+        BackendMeasurementPolicy::single_attestation_type(evidence.attestation_type());
+    let verified = verify_with_backend_policy(
+        evidence,
+        expected_binding,
+        crypto_only,
+        VerifyOptions::default(),
+    )
+    .await?;
+
+    admission
+        .admit(&verified)
+        .await
+        .map_err(AttestationError::AdmissionDenied)?;
+    Ok(verified)
+}
+
+async fn verify_with_backend_policy(
+    evidence: AttestationExchangeMessage,
+    expected_binding: [u8; 64],
+    backend_policy: BackendMeasurementPolicy,
+    options: VerifyOptions,
+) -> Result<VerifiedSeismicAttestation, AttestationError> {
     let attestation_type = evidence.attestation_type();
     let verifier = AttestationVerifier::new(
-        policy.into_backend_policy(),
+        backend_policy,
         options.pccs_url,
         options.dump_dcap_quotes,
         options.override_azure_outdated_tcb,
@@ -98,54 +174,26 @@ pub async fn verify_evidence_with_options(
     VerifiedSeismicAttestation::from_backend(attestation_type, expected_binding, measurements)
 }
 
-/// Generate local Azure TDX + vTPM evidence bound to `binding`.
-///
-/// Convenience wrapper around [`generate_evidence`] for the backend Seismic uses
-/// today.
-pub fn generate_azure_evidence(
-    binding: [u8; 64],
-) -> Result<AttestationExchangeMessage, AttestationError> {
-    generate_evidence(AttestationType::AzureTdx, binding)
-}
-
-/// Verify remote Azure TDX + vTPM evidence and return typed Azure output.
-///
-/// Measurement parsing and matching still use the backend policy format; this
-/// function only checks that the verified result is Azure and unwraps it for
-/// Azure-specific callers.
-pub async fn verify_azure_evidence(
-    evidence: AttestationExchangeMessage,
-    expected_binding: [u8; 64],
-    policy: SeismicMeasurementPolicy,
-) -> Result<VerifiedAzureAttestation, AttestationError> {
-    verify_azure_evidence_with_options(evidence, expected_binding, policy, VerifyOptions::default())
-        .await
-}
-
-/// Same as [`verify_azure_evidence`], with backend operational options.
-pub async fn verify_azure_evidence_with_options(
-    evidence: AttestationExchangeMessage,
-    expected_binding: [u8; 64],
-    policy: SeismicMeasurementPolicy,
-    options: VerifyOptions,
-) -> Result<VerifiedAzureAttestation, AttestationError> {
-    if evidence.attestation_type() != AttestationType::AzureTdx {
-        return Err(AttestationError::WrongAttestationType {
-            expected: AttestationType::AzureTdx,
-            actual: evidence.attestation_type(),
-        });
-    }
-
-    match verify_evidence_with_options(evidence, expected_binding, policy, options).await? {
-        VerifiedSeismicAttestation::AzureTdx(verified) => Ok(verified),
-        verified => Err(AttestationError::WrongAttestationType {
-            expected: AttestationType::AzureTdx,
-            actual: verified.attestation_type(),
-        }),
-    }
-}
-
 // === Public policy and output types ===
+
+/// Admission appraisal applied to typed verified measurements, the second
+/// phase of [`verify_evidence_with_predicate`].
+///
+/// Cryptographic verification establishes *which* guest produced the evidence
+/// (its verified measurements); an admission predicate decides whether that
+/// guest is *allowed* — for example, membership of its derived admission ID in
+/// the on-chain `MeasurementRegistry`. Predicates own the entire appraisal,
+/// including which attestation types they admit: a predicate must deny
+/// [`VerifiedSeismicAttestation`] variants it does not appraise, in particular
+/// [`VerifiedSeismicAttestation::NoAttestation`], whose cryptographic
+/// verification is vacuous.
+pub trait AdmissionPredicate {
+    /// Appraise verified measurements; any `Err` denies admission.
+    fn admit(
+        &self,
+        verified: &VerifiedSeismicAttestation,
+    ) -> impl Future<Output = Result<(), Box<dyn std::error::Error + Send + Sync>>> + Send;
+}
 
 /// Seismic-safe wrapper around the attestation backend's measurement policy.
 ///
@@ -328,13 +376,10 @@ impl From<attestation::measurements::DcapMeasurements> for TdxMeasurements {
 pub enum AttestationError {
     #[error("attestation backend error: {0}")]
     Backend(#[from] attestation::AttestationError),
+    #[error("verified measurements denied admission: {0}")]
+    AdmissionDenied(#[source] Box<dyn std::error::Error + Send + Sync>),
     #[error("measurement policy format error: {0}")]
     PolicyFormat(#[from] MeasurementFormatError),
-    #[error("expected {expected} attestation, got {actual}")]
-    WrongAttestationType {
-        expected: AttestationType,
-        actual: AttestationType,
-    },
     #[error("attestation backend returned no measurements for {attestation_type}")]
     MissingMeasurements { attestation_type: AttestationType },
     #[error("backend returned measurements inconsistent with {attestation_type}: {measurements:?}")]


### PR DESCRIPTION
The getWrappedRootKey responder now admits a requester iff its Azure v1 admission ID is currently accepted by the on-chain MeasurementRegistry, queried via eth_call isAccepted(id) on the node's own reth at the manifest's measurements.contracts.registry address. The chain carries the live policy — additions and deprecations take effect on the next handshake, no node restart — and this replaces the accept-any measurement policy in the responder's production flow.

Verification is a two-phase seam in seismic-attestation: verify_evidence_with_predicate runs full backend cryptographic verification (quote chain, freshness, binding) pinned to the evidence's own attestation type, then a caller-supplied AdmissionPredicate appraises the typed verified measurements. There is no way to obtain verified output without the predicate passing, and no public crypto-only entry point exists. Predicates own the entire appraisal, including which attestation types they admit.

The measurements → admission-ID derivation is
seismic-measurement-admission, the same one deploy tooling compiles registry genesis storage with, pinned by a shared golden vector. Every branch fails closed: a non-Azure attestation type, a PCR bank missing a schema register, an unreachable chain, and a false isAccepted all deny.

The joiner half keeps the intentionally permissive appraisal of the responder, now the explicit DangerouslyAdmitAnyAzureGuest predicate and still loudly temporary: the joiner cannot read the chain before it holds root_key, so its real defense will be provenance (the pinned tx_io_pk commitment check), not measurement appraisal.

Chain wiring: --reth-rpc-url / SEISMIC_RETH_RPC_URL, default http://127.0.0.1:8545. Construction is lazy, so serving never waits on reth; a join that beats reth's startup is denied (fail closed) and the requester retries. Integration tests run each node against a mock accepting registry; denial branches have unit coverage in the admission module.

Also, seismic-attestation API cleanup in the same spirit:
- verify_evidence → verify_evidence_with_policy (+ _and_options): the two appraisal modes are now symmetric, and each entry point documents its intended callers (policy documents for relying parties, predicates for nodes appraising the bootstrap peer)
- drop the unused generate_azure_evidence / verify_azure_evidence wrappers; verify-quote calls the generic entry point and rejects wrong-platform evidence on the claimed type before verification, so bad evidence never costs DCAP collateral round-trips