### PR TITLE
feat(attestation-service): decide root-key admission only at fresh chain state

### DIFF
--- a/bin/attestation-service/Cargo.toml
+++ b/bin/attestation-service/Cargo.toml
@@ -49,3 +49,5 @@ seismic-custodian.workspace = true
 seismic-custodian-service.workspace = true
 serial_test.workspace = true
 tempfile.workspace = true
+# Paused-clock tests: the admission retry sleeps must not cost wall time.
+tokio = { workspace = true, features = ["test-util"] }

--- a/bin/attestation-service/src/admission.rs
+++ b/bin/attestation-service/src/admission.rs
@@ -12,9 +12,11 @@
 //!
 //! - [`RegistryAdmission`] — the responder's predicate. A requester is
 //!   admitted iff its Azure v1 admission ID is currently accepted by the
-//!   on-chain `MeasurementRegistry`, asked via `eth_call isAccepted(id)` on
-//!   the node's local reth. The chain carries the *live* policy: additions and
-//!   deprecations take effect on the next handshake, no node restart needed.
+//!   on-chain `MeasurementRegistry`, asked via `eth_call isAccepted(id)`
+//!   pinned to a provably fresh finalized block of the node's local reth
+//!   (see `fresh_policy_block`). The chain carries the *live* policy:
+//!   additions and deprecations take effect on the next handshake, no node
+//!   restart needed.
 //! - [`DangerouslyAdmitAnyAzureGuest`] — the requester's (joiner's) predicate
 //!   for appraising the responder, intentionally permissive; see its docs.
 //!
@@ -22,14 +24,32 @@
 //! the same derivation deploy tooling compiles the registry's genesis storage
 //! with — the two halves of the system cannot disagree on what an admission ID
 //! means. Every branch fails closed: a non-Azure attestation type, a PCR
-//! bank missing a schema register, an unreachable chain, and a false
+//! bank missing a schema register, an unreachable or stale chain, and a false
 //! `isAccepted` all deny the handshake.
+//!
+//! The freshness gate measures staleness against the guest's wall clock, so
+//! it defends against a lagging, partitioned, or network-eclipsed node — not
+//! against a malicious host that both eclipses the node and controls the
+//! guest's clock. That residual risk is accepted host influence under the
+//! TEE threat model.
 
-use alloy::providers::RootProvider;
-use alloy_primitives::Address;
+use alloy::{
+    eips::{BlockId, BlockNumberOrTag},
+    providers::{Provider, RootProvider},
+    rpc::types::Block,
+    transports::TransportError,
+};
+use alloy_primitives::{Address, B256};
 use seismic_attestation::{AdmissionPredicate, AttestationType, VerifiedSeismicAttestation};
 use seismic_measurement_admission::{AdmissionId, AzureTdxV1Measurements, MissingPcr};
 use seismic_measurement_registry_client::MeasurementRegistry::{self, MeasurementRegistryInstance};
+use std::{
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
 use tracing::{info, warn};
 
 /// Why a bootstrap admission predicate denied a verified guest.
@@ -39,14 +59,53 @@ pub enum AdmissionDenial {
     UnsupportedAttestationType(AttestationType),
     #[error(transparent)]
     MissingPcr(#[from] MissingPcr),
+    #[error("admission ID {0} is not accepted by the MeasurementRegistry")]
+    RegistryNotAccepted(AdmissionId),
     #[error("querying MeasurementRegistry.isAccepted({admission_id}) on local reth: {source}")]
     RegistryQueryFailed {
         admission_id: AdmissionId,
         #[source]
         source: Box<alloy::contract::Error>,
     },
-    #[error("admission ID {0} is not accepted by the MeasurementRegistry")]
-    NotAccepted(AdmissionId),
+    #[error("querying local reth for the {tag} block: {source}")]
+    ChainQueryFailed {
+        tag: BlockNumberOrTag,
+        #[source]
+        source: Box<TransportError>,
+    },
+    #[error("local reth has no {tag} block")]
+    ChainBlockMissing { tag: BlockNumberOrTag },
+    #[error(
+        "finalized block {number} is {age_secs}s old (bound: {max_age_secs}s); \
+         refusing to admit on a possibly stale policy view"
+    )]
+    ChainStale {
+        number: u64,
+        age_secs: u64,
+        max_age_secs: u64,
+    },
+    #[error("local reth is at genesis after chain progress was observed")]
+    ChainRegressedToGenesis,
+}
+
+impl AdmissionDenial {
+    /// Whether this denial is the responder failing to *decide* — the local
+    /// chain or registry read did not produce a usable answer — as opposed to
+    /// a verdict on the requester (whose evidence will keep failing the same
+    /// way). Transient denials are worth retrying: against the same responder
+    /// moments later, or against another responder entirely.
+    pub fn is_transient(&self) -> bool {
+        match self {
+            Self::RegistryQueryFailed { .. }
+            | Self::ChainQueryFailed { .. }
+            | Self::ChainBlockMissing { .. }
+            | Self::ChainStale { .. }
+            | Self::ChainRegressedToGenesis => true,
+            Self::UnsupportedAttestationType(_)
+            | Self::MissingPcr(_)
+            | Self::RegistryNotAccepted(_) => false,
+        }
+    }
 }
 
 /// The [`AdmissionId`] of a verified guest, under the Azure v1 schema.
@@ -66,11 +125,24 @@ fn azure_admission_id(
     Ok(measurements.admission_id())
 }
 
+/// Upper bound on the age of the finalized block an admission decision is
+/// allowed to read the policy at. This is the longest an eclipsed or lagging
+/// responder can keep admitting on an allowlist the network has since
+/// deprecated, so smaller is stricter; summit finalizes within seconds, so
+/// a minute of slack denies nothing in healthy operation, and a joiner
+/// refused during a brief stall simply retries.
+const MAX_POLICY_AGE: Duration = Duration::from_secs(60);
+
 /// Responder-side admission: registry membership of the requester's
-/// admission ID.
+/// admission ID, decided at fresh local chain state.
 #[derive(Clone)]
 pub struct RegistryAdmission {
     registry: MeasurementRegistryInstance<RootProvider>,
+    /// Latched once any admission observes the chain past genesis. The
+    /// genesis admission window (see `fresh_policy_block`) never reopens
+    /// within this process: a reth back at block 0 after progress was
+    /// observed has been wiped or replaced, and must not admit on its say-so.
+    chain_has_advanced: Arc<AtomicBool>,
 }
 
 impl RegistryAdmission {
@@ -84,19 +156,75 @@ impl RegistryAdmission {
     fn with_provider(provider: RootProvider, registry: Address) -> Self {
         Self {
             registry: MeasurementRegistry::new(registry, provider),
+            chain_has_advanced: Arc::new(AtomicBool::new(false)),
         }
     }
-}
 
-impl AdmissionPredicate for RegistryAdmission {
-    async fn admit(
-        &self,
-        verified: &VerifiedSeismicAttestation,
-    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-        let admission_id = azure_admission_id(verified)?;
+    /// The block to answer `isAccepted` at: local reth's finalized block,
+    /// proven fresh. Pinning the query to this exact hash means the policy
+    /// answer comes from the state that passed the freshness check, not from
+    /// whatever "latest" happens to be a moment later.
+    ///
+    /// Freshness is the finalized block's timestamp against the guest's wall
+    /// clock. A lagging or eclipsed node cannot see the true chain head, so
+    /// no local comparison of heights can detect staleness — a recent
+    /// timestamp is the one locally checkable witness that this view of the
+    /// allowlist is current. The finalized tag (summit publishes it
+    /// every forkchoice update, trailing head by at most a block or two)
+    /// additionally guarantees the decision can never sit on a block that
+    /// reorgs away.
+    ///
+    /// The one exception is a chain still at genesis, where finality is not
+    /// yet being published and the genesis timestamp is arbitrarily old.
+    /// Admitting there is sound by construction — block-0 state *is* the
+    /// genesis-pinned policy, and no deprecation can predate the chain — and
+    /// it is what lets the founding cohort join before consensus starts.
+    async fn fresh_policy_block(&self) -> Result<B256, AdmissionDenial> {
+        let latest = self.block_by_tag(BlockNumberOrTag::Latest).await?;
+        if latest.header.inner.number == 0 {
+            if self.chain_has_advanced.load(Ordering::Relaxed) {
+                return Err(AdmissionDenial::ChainRegressedToGenesis);
+            }
+            return Ok(latest.header.hash);
+        }
+        self.chain_has_advanced.store(true, Ordering::Relaxed);
+
+        let finalized = self.block_by_tag(BlockNumberOrTag::Finalized).await?;
+        let now_secs = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+        let age_secs = now_secs.saturating_sub(finalized.header.inner.timestamp);
+        if age_secs > MAX_POLICY_AGE.as_secs() {
+            return Err(AdmissionDenial::ChainStale {
+                number: finalized.header.inner.number,
+                age_secs,
+                max_age_secs: MAX_POLICY_AGE.as_secs(),
+            });
+        }
+        Ok(finalized.header.hash)
+    }
+
+    async fn block_by_tag(&self, tag: BlockNumberOrTag) -> Result<Block, AdmissionDenial> {
+        self.registry
+            .provider()
+            .get_block_by_number(tag)
+            .await
+            .map_err(|source| AdmissionDenial::ChainQueryFailed {
+                tag,
+                source: Box::new(source),
+            })?
+            .ok_or(AdmissionDenial::ChainBlockMissing { tag })
+    }
+
+    /// One attempt at the chain-backed decision: fresh policy block, then the
+    /// registry's verdict for `admission_id` at exactly that block.
+    async fn decide(&self, admission_id: AdmissionId) -> Result<(), AdmissionDenial> {
+        let policy_block = self.fresh_policy_block().await?;
         let accepted = self
             .registry
             .isAccepted(admission_id.into())
+            .block(BlockId::hash(policy_block))
             .call()
             .await
             .map_err(|source| AdmissionDenial::RegistryQueryFailed {
@@ -104,10 +232,47 @@ impl AdmissionPredicate for RegistryAdmission {
                 source: Box::new(source),
             })?;
         if !accepted {
-            return Err(AdmissionDenial::NotAccepted(admission_id).into());
+            return Err(AdmissionDenial::RegistryNotAccepted(admission_id));
         }
-        info!("bootstrap: MeasurementRegistry accepted admission ID {admission_id}");
+        info!(
+            "bootstrap: MeasurementRegistry accepted admission ID {admission_id} \
+             at block {policy_block}"
+        );
         Ok(())
+    }
+}
+
+/// How many times `admit` attempts the chain-backed decision, and the pause
+/// between attempts. By this point the requester's evidence has already
+/// verified — the expensive half of the handshake, a fresh quote per try on
+/// the joiner — so a local reth that is restarting, or just catching back
+/// under the freshness bound, deserves a few seconds' grace before the
+/// handshake is failed and the joiner has to start over. Bounded small so a
+/// genuinely stale responder still answers well within the joiner's request
+/// timeout.
+const DECIDE_ATTEMPTS: u32 = 3;
+const DECIDE_RETRY_DELAY: Duration = Duration::from_secs(2);
+
+impl AdmissionPredicate for RegistryAdmission {
+    async fn admit(
+        &self,
+        verified: &VerifiedSeismicAttestation,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        let admission_id = azure_admission_id(verified)?;
+        let mut attempt = 1;
+        loop {
+            match self.decide(admission_id).await {
+                Err(denial) if denial.is_transient() && attempt < DECIDE_ATTEMPTS => {
+                    warn!(
+                        "bootstrap: admission attempt {attempt}/{DECIDE_ATTEMPTS} \
+                         hit a transient failure, retrying: {denial}"
+                    );
+                    attempt += 1;
+                    tokio::time::sleep(DECIDE_RETRY_DELAY).await;
+                }
+                decision => return decision.map_err(Into::into),
+            }
+        }
     }
 }
 
@@ -182,6 +347,91 @@ mod tests {
         Bytes::from(word.to_vec())
     }
 
+    /// An `eth_getBlockByNumber` response body, with a hash derived from the
+    /// block number so distinct blocks are tellable apart.
+    fn rpc_block(number: u64, timestamp: u64) -> Block {
+        let mut block: Block = Block::default();
+        block.header.hash = alloy_primitives::B256::with_last_byte(number as u8);
+        block.header.inner.number = number;
+        block.header.inner.timestamp = timestamp;
+        block
+    }
+
+    fn now_secs() -> u64 {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock after epoch")
+            .as_secs()
+    }
+
+    /// Queue responses for the two chain reads `admit` issues before the
+    /// registry call. The [`Asserter`] is parameter-blind and serves queued
+    /// responses in request order, so these stand in for the `latest`-tag and
+    /// `finalized`-tag queries respectively; that the code really asks with
+    /// those tags (and pins the registry call to the finalized hash) is
+    /// proven by `policy_read_is_pinned_to_the_fresh_finalized_block`.
+    fn push_fresh_chain(asserter: &Asserter) {
+        asserter.push_success(&rpc_block(7, now_secs()));
+        asserter.push_success(&rpc_block(6, now_secs()));
+    }
+
+    /// A parameter-checking reth stand-in: serves `latest` and `finalized`
+    /// blocks by tag, errors on any other `eth_getBlockByNumber` query, and
+    /// answers `isAccepted` with `true` only when the `eth_call` is pinned
+    /// to the finalized block's hash. Any admission that queries the wrong
+    /// tag or reads the policy at any other block therefore fails.
+    async fn spawn_tag_checking_reth(latest: Block, finalized: Block) -> String {
+        use jsonrpsee::{server::ServerBuilder, types::ErrorObjectOwned};
+
+        fn unexpected(message: String) -> ErrorObjectOwned {
+            ErrorObjectOwned::owned(-32000, message, None::<()>)
+        }
+
+        let server = ServerBuilder::default()
+            .build("127.0.0.1:0")
+            .await
+            .expect("bind mock reth endpoint");
+        let addr = server.local_addr().expect("mock reth local addr");
+        let finalized_hash = finalized.header.hash;
+        let mut module = jsonrpsee::RpcModule::new(());
+        module
+            .register_method("eth_getBlockByNumber", move |params, _, _| {
+                let (tag, _full_transactions): (String, bool) = params.parse()?;
+                let block = match tag.as_str() {
+                    "latest" => &latest,
+                    "finalized" => &finalized,
+                    other => return Err(unexpected(format!("unexpected block tag {other}"))),
+                };
+                Ok(serde_json::to_value(block).expect("serialize mock block"))
+            })
+            .expect("register eth_getBlockByNumber");
+        module
+            .register_method("eth_call", move |params, _, _| {
+                let (_call, block_id): (serde_json::Value, serde_json::Value) = params.parse()?;
+                let pinned = block_id
+                    .get("blockHash")
+                    .cloned()
+                    .and_then(|hash| serde_json::from_value::<alloy_primitives::B256>(hash).ok())
+                    .ok_or_else(|| {
+                        unexpected(format!("eth_call not pinned to a block hash: {block_id}"))
+                    })?;
+                if pinned != finalized_hash {
+                    return Err(unexpected(format!(
+                        "eth_call pinned to {pinned}, not the finalized block {finalized_hash}"
+                    )));
+                }
+                const ABI_ENCODED_TRUE: &str =
+                    "0x0000000000000000000000000000000000000000000000000000000000000001";
+                Ok(serde_json::Value::String(ABI_ENCODED_TRUE.to_string()))
+            })
+            .expect("register eth_call");
+        let handle = server.start(module);
+        // The server stops when its handle drops; park the handle in a task
+        // that outlives the test body.
+        tokio::spawn(handle.stopped());
+        format!("http://{addr}")
+    }
+
     #[test]
     fn derives_golden_admission_id_from_verified_measurements() {
         // Extra registers in the verified bank don't perturb identity.
@@ -215,8 +465,24 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn policy_read_is_pinned_to_the_fresh_finalized_block() {
+        // The mock denies every request except the two tag queries and an
+        // eth_call at exactly the finalized hash, so this admission succeeding
+        // proves the gate reads the finalized tag and pins the registry query
+        // to the block it freshness-checked.
+        let url = spawn_tag_checking_reth(rpc_block(7, now_secs()), rpc_block(6, now_secs())).await;
+        let admission = RegistryAdmission::new(url.parse().expect("mock reth URL"), Address::ZERO);
+
+        admission
+            .admit(&verified_azure(golden_pcr_bank()))
+            .await
+            .expect("admission at the pinned fresh finalized block must succeed");
+    }
+
+    #[tokio::test]
     async fn accepted_tuple_is_admitted() {
         let asserter = Asserter::new();
+        push_fresh_chain(&asserter);
         asserter.push_success(&abi_bool(true));
         let admission = mocked_registry(&asserter);
 
@@ -229,6 +495,7 @@ mod tests {
     #[tokio::test]
     async fn unknown_tuple_is_denied() {
         let asserter = Asserter::new();
+        push_fresh_chain(&asserter);
         asserter.push_success(&abi_bool(false));
         let admission = mocked_registry(&asserter);
 
@@ -236,13 +503,39 @@ mod tests {
             .admit(&verified_azure(golden_pcr_bank()))
             .await
             .expect_err("tuple the registry rejects must be denied");
+        // A registry verdict is final, not transient: no responses are queued
+        // for a second attempt, so a retry would surface a chain error here
+        // instead of the verdict.
         assert!(error.to_string().contains("not accepted"), "{error}");
     }
 
-    #[tokio::test]
+    // Transient denials are retried DECIDE_ATTEMPTS times within one
+    // handshake, so the denial tests below queue one round of responses per
+    // attempt, and pause tokio's clock so the between-attempt sleeps cost the
+    // suite nothing.
+
+    #[tokio::test(start_paused = true)]
+    async fn unreachable_chain_fails_closed() {
+        let asserter = Asserter::new();
+        for _ in 0..DECIDE_ATTEMPTS {
+            asserter.push_failure_msg("connection refused");
+        }
+        let admission = mocked_registry(&asserter);
+
+        let error = admission
+            .admit(&verified_azure(golden_pcr_bank()))
+            .await
+            .expect_err("an unreachable chain must deny, not admit");
+        assert!(error.to_string().contains("latest block"), "{error}");
+    }
+
+    #[tokio::test(start_paused = true)]
     async fn unreachable_registry_fails_closed() {
         let asserter = Asserter::new();
-        asserter.push_failure_msg("connection refused");
+        for _ in 0..DECIDE_ATTEMPTS {
+            push_fresh_chain(&asserter);
+            asserter.push_failure_msg("connection refused");
+        }
         let admission = mocked_registry(&asserter);
 
         let error = admission
@@ -250,6 +543,92 @@ mod tests {
             .await
             .expect_err("an unreachable registry must deny, not admit");
         assert!(error.to_string().contains("isAccepted"), "{error}");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn stale_finalized_view_is_denied() {
+        let asserter = Asserter::new();
+        for _ in 0..DECIDE_ATTEMPTS {
+            asserter.push_success(&rpc_block(7, now_secs()));
+            asserter.push_success(&rpc_block(6, now_secs() - 3600));
+        }
+        let admission = mocked_registry(&asserter);
+
+        let error = admission
+            .admit(&verified_azure(golden_pcr_bank()))
+            .await
+            .expect_err("a stale finalized view must deny, not admit");
+        assert!(error.to_string().contains("stale"), "{error}");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn missing_finalized_block_is_denied() {
+        // Reth answers `finalized` with an error until consensus publishes a
+        // forkchoice update; the mock's null response covers the same branch.
+        let asserter = Asserter::new();
+        for _ in 0..DECIDE_ATTEMPTS {
+            asserter.push_success(&rpc_block(7, now_secs()));
+            asserter.push_success(&serde_json::Value::Null);
+        }
+        let admission = mocked_registry(&asserter);
+
+        let error = admission
+            .admit(&verified_azure(golden_pcr_bank()))
+            .await
+            .expect_err("chain progress without a finalized block must deny");
+        assert!(error.to_string().contains("no finalized block"), "{error}");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn transient_chain_failure_is_retried_within_the_handshake() {
+        // First attempt fails at the chain read; the retry finds a fresh
+        // chain and an accepting registry. The handshake must succeed without
+        // the joiner having to start over.
+        let asserter = Asserter::new();
+        asserter.push_failure_msg("connection refused");
+        push_fresh_chain(&asserter);
+        asserter.push_success(&abi_bool(true));
+        let admission = mocked_registry(&asserter);
+
+        admission
+            .admit(&verified_azure(golden_pcr_bank()))
+            .await
+            .expect("a transient chain failure must be retried, not surfaced");
+    }
+
+    #[tokio::test]
+    async fn genesis_window_admits_at_block_zero() {
+        // The genesis timestamp is far in the past; the window ignores it.
+        let asserter = Asserter::new();
+        asserter.push_success(&rpc_block(0, 1_000));
+        asserter.push_success(&abi_bool(true));
+        let admission = mocked_registry(&asserter);
+
+        admission
+            .admit(&verified_azure(golden_pcr_bank()))
+            .await
+            .expect("an accepted tuple must be admitted while the chain is at genesis");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn genesis_window_never_reopens_after_progress() {
+        let asserter = Asserter::new();
+        push_fresh_chain(&asserter);
+        asserter.push_success(&abi_bool(true));
+        let admission = mocked_registry(&asserter);
+        admission
+            .admit(&verified_azure(golden_pcr_bank()))
+            .await
+            .expect("fresh chain past genesis must admit");
+
+        for _ in 0..DECIDE_ATTEMPTS {
+            asserter.push_success(&rpc_block(0, now_secs()));
+        }
+        let error = admission
+            .admit(&verified_azure(golden_pcr_bank()))
+            .await
+            .expect_err("a chain back at genesis after progress must deny");
+        assert!(error.to_string().contains("genesis"), "{error}");
     }
 
     #[tokio::test]

--- a/bin/attestation-service/src/server.rs
+++ b/bin/attestation-service/src/server.rs
@@ -7,9 +7,7 @@ use crate::{
         verify_root_key_response,
     },
     network::{NETWORK_MANIFEST_PATH, load_manifest},
-    utils::{
-        internal_rpc_error, invalid_root_key_request_rpc_error, root_key_request_denied_rpc_error,
-    },
+    utils::{internal_rpc_error, invalid_root_key_request_rpc_error, root_key_answer_rpc_error},
 };
 use alloy_primitives::Address;
 use anyhow::Context as _;
@@ -113,7 +111,7 @@ impl AttestationRpcServer for AttestationService {
             ATTESTATION_TYPE,
         )
         .await
-        .map_err(root_key_request_denied_rpc_error)?;
+        .map_err(root_key_answer_rpc_error)?;
 
         serde_json::to_vec(&response)
             .map_err(|error| internal_rpc_error("serializing root-key response", error))

--- a/bin/attestation-service/src/utils.rs
+++ b/bin/attestation-service/src/utils.rs
@@ -1,9 +1,16 @@
+use crate::admission::AdmissionDenial;
 use jsonrpsee::types::{ErrorCode, ErrorObjectOwned};
 use std::fmt::Debug;
 use tracing::{error, info, warn};
 use tracing_subscriber::{EnvFilter, FmtSubscriber};
 
+/// Terminal verdict: the requester does not get the key, and retrying with
+/// the same image cannot change the answer.
 const ROOT_KEY_REQUEST_DENIED_CODE: i32 = -32001;
+/// Transient failure: the responder could not decide, because its own chain
+/// or registry read produced no usable answer. Worth retrying — against this
+/// responder moments later, or against another peer.
+const ROOT_KEY_ADMISSION_UNAVAILABLE_CODE: i32 = -32002;
 
 pub(crate) fn invalid_root_key_request_rpc_error(error: impl Debug) -> ErrorObjectOwned {
     warn!(?error, "invalid root-key request");
@@ -21,6 +28,33 @@ pub(crate) fn root_key_request_denied_rpc_error(error: impl Debug) -> ErrorObjec
         "Root-key request denied",
         None::<()>,
     )
+}
+
+pub(crate) fn root_key_admission_unavailable_rpc_error(error: impl Debug) -> ErrorObjectOwned {
+    warn!(?error, "root-key admission temporarily unavailable");
+    ErrorObjectOwned::owned(
+        ROOT_KEY_ADMISSION_UNAVAILABLE_CODE,
+        "Root-key admission temporarily unavailable",
+        None::<()>,
+    )
+}
+
+/// Route a failed root-key answer to its wire error. An [`AdmissionDenial`]
+/// that is transient (see [`AdmissionDenial::is_transient`]) maps to
+/// [`ROOT_KEY_ADMISSION_UNAVAILABLE_CODE`]; everything else — admission
+/// verdicts, and failures carrying no typed denial (e.g. quote verification)
+/// — maps to [`ROOT_KEY_REQUEST_DENIED_CODE`]. Either way the message is a
+/// stable constant; failure detail stays in the responder's log.
+pub(crate) fn root_key_answer_rpc_error(error: anyhow::Error) -> ErrorObjectOwned {
+    let transient = error
+        .chain()
+        .find_map(|cause| cause.downcast_ref::<AdmissionDenial>())
+        .is_some_and(AdmissionDenial::is_transient);
+    if transient {
+        root_key_admission_unavailable_rpc_error(error)
+    } else {
+        root_key_request_denied_rpc_error(error)
+    }
 }
 
 pub(crate) fn internal_rpc_error(operation: &'static str, error: impl Debug) -> ErrorObjectOwned {
@@ -85,12 +119,46 @@ mod tests {
         assert_eq!(denied.code(), ROOT_KEY_REQUEST_DENIED_CODE);
         assert_eq!(denied.message(), "Root-key request denied");
 
+        let unavailable = root_key_admission_unavailable_rpc_error("private chain detail");
+        assert_eq!(unavailable.code(), ROOT_KEY_ADMISSION_UNAVAILABLE_CODE);
+        assert_eq!(
+            unavailable.message(),
+            "Root-key admission temporarily unavailable"
+        );
+
         let internal = internal_rpc_error("generating evidence", "private backend detail");
         assert_eq!(internal.code(), ErrorCode::InternalError.code());
         assert_eq!(internal.message(), "Internal error");
 
-        for error in [invalid, denied, internal] {
+        for error in [invalid, denied, unavailable, internal] {
             assert!(!error.to_string().contains("private"));
         }
+    }
+
+    #[test]
+    fn transient_admission_failures_map_to_unavailable_others_to_denied() {
+        use seismic_attestation::AttestationError;
+
+        // The nesting a real handshake produces: the bootstrap wraps the
+        // attestation error in anyhow context, which carries the typed
+        // denial as a source.
+        let handshake_error = |denial: AdmissionDenial| {
+            anyhow::Error::new(AttestationError::AdmissionDenied(Box::new(denial)))
+                .context("verifying requester attestation evidence")
+        };
+
+        let unavailable =
+            root_key_answer_rpc_error(handshake_error(AdmissionDenial::ChainRegressedToGenesis));
+        assert_eq!(unavailable.code(), ROOT_KEY_ADMISSION_UNAVAILABLE_CODE);
+
+        let verdict = root_key_answer_rpc_error(handshake_error(
+            AdmissionDenial::RegistryNotAccepted(alloy_primitives::B256::ZERO.into()),
+        ));
+        assert_eq!(verdict.code(), ROOT_KEY_REQUEST_DENIED_CODE);
+
+        // Failures with no admission denial in the chain (e.g. quote
+        // verification) stay on the denied verdict.
+        let other = root_key_answer_rpc_error(anyhow::anyhow!("quote verification failed"));
+        assert_eq!(other.code(), ROOT_KEY_REQUEST_DENIED_CODE);
     }
 }

--- a/bin/attestation-service/tests/integration/utils.rs
+++ b/bin/attestation-service/tests/integration/utils.rs
@@ -16,11 +16,14 @@ pub fn get_args(n: u16, peers: Vec<String>, custodian_socket: PathBuf, reth_rpc_
 }
 
 /// Serve a permissive stand-in for the node-local reth that answers the
-/// responder's `MeasurementRegistry.isAccepted` reads: every `eth_call`
-/// returns ABI-encoded `true`, so the runner's own measurements count as
+/// responder's admission reads: `eth_getBlockByNumber` answers the `latest`
+/// and `finalized` tag queries — and only those — with a fresh block past
+/// genesis (so the freshness gate passes), and every `eth_call` returns
+/// ABI-encoded `true`, so the runner's own measurements count as
 /// registry-accepted. These tests thereby exercise the full live-TEE
-/// admission path — verified evidence → admission ID → registry query —
-/// while denial behavior is covered by the admission module's unit tests.
+/// admission path — verified evidence → admission ID → fresh chain state →
+/// registry query — while denial behavior is covered by the admission
+/// module's unit tests.
 pub async fn spawn_accepting_registry() -> String {
     let server = ServerBuilder::default()
         .build("127.0.0.1:0")
@@ -28,6 +31,25 @@ pub async fn spawn_accepting_registry() -> String {
         .expect("bind mock registry endpoint");
     let addr = server.local_addr().expect("mock registry local addr");
     let mut module = RpcModule::new(());
+    module
+        .register_method("eth_getBlockByNumber", |params, _, _| {
+            let (tag, _full_transactions): (String, bool) = params.parse()?;
+            if tag != "latest" && tag != "finalized" {
+                return Err(jsonrpsee::types::ErrorObjectOwned::owned(
+                    -32000,
+                    format!("mock reth serves only the latest and finalized tags, got {tag}"),
+                    None::<()>,
+                ));
+            }
+            let mut block = alloy::rpc::types::Block::<alloy::rpc::types::Transaction>::default();
+            block.header.inner.number = 1;
+            block.header.inner.timestamp = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("system clock after epoch")
+                .as_secs();
+            Ok(serde_json::to_value(block).expect("serialize mock block"))
+        })
+        .expect("register eth_getBlockByNumber");
     module
         .register_method("eth_call", |_, _, _| {
             const ABI_ENCODED_TRUE: &str =


### PR DESCRIPTION
A responder must not serve getWrappedRootKey from a stale view of the allowlist: contract success alone would let a lagging or eclipsed node keep admitting images the network has deprecated. RegistryAdmission now reads the policy at a provably fresh block and fails closed otherwise:

- Pin isAccepted to the finalized block's hash (summit publishes safe == finalized on every forkchoice update), after checking that block's timestamp is within 60s of the guest clock. Staleness is measured against wall time because an eclipsed node cannot see the true head; the bound is the longest a lagging responder can keep admitting after an emergency deprecation.
- Admit at genesis unconditionally — block-0 state is the genesis-pinned policy, which lets the founding cohort join before consensus starts — and latch the genesis window shut for the process lifetime once the chain advances.
- Retry transient chain/registry failures (3 attempts, 2s apart) before failing a handshake whose evidence already verified.
- Split the wire error: transient denials return -32002 "temporarily unavailable" (retry, or try another peer) instead of the terminal -32001 "denied" verdict, so a joiner distinguishes "my image is not allowlisted" from "this responder cannot decide right now".

The gate defends against lag, partitions, and network-level eclipse — not a host that also controls the guest clock; that residual risk is accepted host influence under the TEE threat model.