### PR TITLE
test(attestation-service): admission suite against a policy-seeded reth

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,8 +74,8 @@ jobs:
         run: cargo test -p seismic-custodian-ipc --all-features
       # The live seismic-attestation-service test targets (evidence,
       # admission) need a TDX CVM, and seismic-measurement-admission's
-      # reth_registry test needs a seismic-reth binary; each runs in its own
-      # job. Everything else can run on the hosted runner.
+      # reth_registry test needs a seismic-reth binary; those run in their
+      # own jobs. Everything else can run on the hosted runner.
       - name: Run workspace tests
         run: >-
           cargo test --workspace
@@ -125,24 +125,14 @@ jobs:
           SEISMIC_RETH_BIN: ${{ steps.sreth.outputs.seismic-reth-path }}
         run: cargo test -p seismic-measurement-admission
 
-  attestation_service_evidence_tdx_tests:
-    runs-on: [self-hosted, linux, x64, azure-tdx-v6]
-    # This runner has passwordless sudo and must never execute fork PR code.
-    if: >-
-      github.event_name != 'pull_request' ||
-      github.event.pull_request.head.repo.full_name == github.repository
-    timeout-minutes: 30
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-        with:
-          cache-on-failure: true
-
-      - name: Run evidence tests
-        run: ./scripts/run_attestation_service_evidence_tdx_tests.sh
-
-  attestation_service_admission_tdx_tests:
+  # Both live-TEE suites in one job: the single TDX box serializes these
+  # tests regardless (one runner, one vTPM), and the suites share most of
+  # one dependency graph, so one job pays compilation once — the second
+  # suite's cargo build is incremental in the same workspace. Test suites
+  # run as separate steps, evidence first: it has no reth dependency, so
+  # its results are in before the admission half touches the nightly
+  # release binary.
+  attestation_service_tdx_tests:
     runs-on: [self-hosted, linux, x64, azure-tdx-v6]
     # This runner has passwordless sudo and must never execute fork PR code.
     if: >-
@@ -155,6 +145,10 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
+
+      - name: Run evidence tests
+        run: ./scripts/run_attestation_service_evidence_tdx_tests.sh
+
       # The admission suite boots real seismic-reth dev nodes from a prebuilt
       # nightly release binary.
       - id: sreth

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,10 @@ jobs:
       - name: Build workspace and deny warnings
         run: RUSTFLAGS="-D warnings" cargo build --workspace
 
+  # Everything hermetic given committed files: the hosted test suites plus
+  # the cross-repo parity gates, which read files checked out from the
+  # seismic repo's main branch — never a built artifact. Keeping built
+  # artifacts out is what lets this job serve as the required per-PR check.
   tests:
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -68,10 +72,10 @@ jobs:
       # skips the `cli` binary entirely (required-features). Cover them here.
       - name: Run seismic-custodian-ipc tests (all features)
         run: cargo test -p seismic-custodian-ipc --all-features
-      # The one live seismic-attestation-service integration target needs a TDX CVM,
-      # and seismic-measurement-admission's reth_registry test needs a
-      # seismic-reth binary; both run in their own jobs. Everything else can
-      # run on the hosted runner.
+      # The live seismic-attestation-service test targets (evidence,
+      # admission) need a TDX CVM, and seismic-measurement-admission's
+      # reth_registry test needs a seismic-reth binary; each runs in its own
+      # job. Everything else can run on the hosted runner.
       - name: Run workspace tests
         run: >-
           cargo test --workspace
@@ -97,6 +101,10 @@ jobs:
       - name: Run attestation-service unit tests
         run: cargo test -p seismic-attestation-service --lib --bins
 
+  # Hosted, but dependent on a prebuilt artifact from another repo: the
+  # reth_registry test boots a real seismic-reth dev node from the nightly
+  # release binary. Its own job — outside the required `tests` check — so a
+  # lagging or broken nightly surfaces here without blocking enclave merges.
   measurement_admission_tests:
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -117,7 +125,7 @@ jobs:
           SEISMIC_RETH_BIN: ${{ steps.sreth.outputs.seismic-reth-path }}
         run: cargo test -p seismic-measurement-admission
 
-  attestation_service_tdx_tests:
+  attestation_service_evidence_tdx_tests:
     runs-on: [self-hosted, linux, x64, azure-tdx-v6]
     # This runner has passwordless sudo and must never execute fork PR code.
     if: >-
@@ -131,7 +139,29 @@ jobs:
         with:
           cache-on-failure: true
 
-      # TODO: add a separate reth-backed integration job for contract-backed
-      # bootstrap admission with PCR policy seeded in genesis.
-      - name: Run integration tests
-        run: ./scripts/run_attestation_service_tdx_tests.sh
+      - name: Run evidence tests
+        run: ./scripts/run_attestation_service_evidence_tdx_tests.sh
+
+  attestation_service_admission_tdx_tests:
+    runs-on: [self-hosted, linux, x64, azure-tdx-v6]
+    # This runner has passwordless sudo and must never execute fork PR code.
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+      # The admission suite boots real seismic-reth dev nodes from a prebuilt
+      # nightly release binary.
+      - id: sreth
+        uses: SeismicSystems/seismic/.github/actions/setup-sreth@main
+        with:
+          version: nightly
+      - name: Run admission tests
+        env:
+          SEISMIC_RETH_BIN: ${{ steps.sreth.outputs.seismic-reth-path }}
+        run: ./scripts/run_attestation_service_admission_tdx_tests.sh

--- a/bin/attestation-service/src/admission.rs
+++ b/bin/attestation-service/src/admission.rs
@@ -138,6 +138,9 @@ const MAX_POLICY_AGE: Duration = Duration::from_secs(60);
 #[derive(Clone)]
 pub struct RegistryAdmission {
     registry: MeasurementRegistryInstance<RootProvider>,
+    /// Bound on the finalized-block age this admission accepts; defaults to
+    /// [`MAX_POLICY_AGE`].
+    max_policy_age: Duration,
     /// Latched once any admission observes the chain past genesis. The
     /// genesis admission window (see `fresh_policy_block`) never reopens
     /// within this process: a reth back at block 0 after progress was
@@ -156,8 +159,17 @@ impl RegistryAdmission {
     fn with_provider(provider: RootProvider, registry: Address) -> Self {
         Self {
             registry: MeasurementRegistry::new(registry, provider),
+            max_policy_age: MAX_POLICY_AGE,
             chain_has_advanced: Arc::new(AtomicBool::new(false)),
         }
+    }
+
+    /// The same admission with a tighter policy-age bound. The admission
+    /// integration suite injects seconds here, so the staleness denial is
+    /// observable without waiting out the production bound.
+    pub fn with_max_policy_age(mut self, max_policy_age: Duration) -> Self {
+        self.max_policy_age = max_policy_age;
+        self
     }
 
     /// The block to answer `isAccepted` at: local reth's finalized block,
@@ -198,11 +210,11 @@ impl RegistryAdmission {
             .as_millis() as u64;
         let age =
             Duration::from_millis(now_millis.saturating_sub(finalized.header.inner.timestamp));
-        if age > MAX_POLICY_AGE {
+        if age > self.max_policy_age {
             return Err(AdmissionDenial::ChainStale {
                 number: finalized.header.inner.number,
                 age_secs: age.as_secs(),
-                max_age_secs: MAX_POLICY_AGE.as_secs(),
+                max_age_secs: self.max_policy_age.as_secs(),
             });
         }
         Ok(finalized.header.hash)

--- a/bin/attestation-service/src/lib.rs
+++ b/bin/attestation-service/src/lib.rs
@@ -1,6 +1,6 @@
 mod admission;
 pub mod api;
-mod bootstrap;
+pub mod bootstrap;
 mod luks_status;
 mod network;
 mod server;
@@ -50,6 +50,13 @@ pub struct Args {
     /// this service's startup or its other RPCs.
     #[arg(long, env = "SEISMIC_RETH_RPC_URL", default_value = DEFAULT_RETH_RPC_URL)]
     pub reth_rpc_url: url::Url,
+
+    /// Bound on the finalized-block age admission decisions accept; `None`
+    /// keeps the production default. Deliberately not a CLI flag: only the
+    /// admission integration suite tightens it, to observe the staleness
+    /// denial without waiting out the production bound.
+    #[arg(skip)]
+    pub max_policy_age: Option<std::time::Duration>,
 }
 
 impl Args {

--- a/bin/attestation-service/src/server.rs
+++ b/bin/attestation-service/src/server.rs
@@ -159,7 +159,13 @@ pub async fn start_server(addr: SocketAddr, args: Args) -> anyhow::Result<()> {
     // a join that beats reth's startup is denied (fail closed) and the
     // requester retries.
     let registry = Address::from(manifest.measurements.contracts.registry);
-    let admission = RegistryAdmission::new(args.reth_rpc_url.clone(), registry);
+    let mut admission = RegistryAdmission::new(args.reth_rpc_url.clone(), registry);
+    if let Some(max_policy_age) = args.max_policy_age {
+        warn!(
+            "Admission accepts a finalized policy view no older than {max_policy_age:?} (test override)"
+        );
+        admission = admission.with_max_policy_age(max_policy_age);
+    }
     info!(
         "Gating joining peers via MeasurementRegistry at {registry} over {}",
         args.reth_rpc_url

--- a/bin/attestation-service/tests/admission.rs
+++ b/bin/attestation-service/tests/admission.rs
@@ -1,0 +1,715 @@
+//! Reth-backed responder-admission suite, run through
+//! `scripts/run_attestation_service_admission_tdx_tests.sh` on an Azure TDX
+//! runner: the service's `getWrappedRootKey` gate against a real
+//! `seismic-reth` dev node whose genesis storage carries the measurement
+//! policy. The complement to
+//! the registry-only tests in
+//! `crates/measurement-admission/tests/reth_registry.rs` and to the
+//! admission module's mocked unit tests: here the full live path — verified
+//! vTPM evidence → admission ID → fresh finalized chain state → registry
+//! verdict — decides real handshakes, and the assertions ride the wire codes
+//! a joiner sees.
+//!
+//! - an **accepted** tuple authorizes exactly one root-key wrap (a real
+//!   joiner service completes its bootstrap);
+//! - a **deprecated** tuple is denied (`-32001`) by the same still-running
+//!   responder — the policy is read live from the chain, never cached;
+//! - an **unknown** tuple is denied (`-32001`);
+//! - an unreachable (`-32002`) or **stale** (`-32002`, via a tightened
+//!   policy-age bound) local reth fails closed.
+//!
+//! The genesis is generated at runtime, not committed: evidence carries the
+//! runner's real PCRs, so the seeded policy is compiled either from the
+//! observed values (the runner's own image is the accepted tuple) or from
+//! synthetic values no real quote can match (the runner's image is the
+//! unknown tuple). Two dev-miner behaviors shape the fixture: `finalized` is
+//! served from block 0 but stays on the genesis block until the chain is
+//! ~64 blocks deep, so the genesis timestamp is stamped to now — in
+//! milliseconds, the chain's timestamp convention — to keep that view inside
+//! the freshness bound; and at block 0 the gate's genesis window admits
+//! unconditionally, so every rejection scenario first waits for the chain to
+//! advance.
+//!
+//! TPM discipline is the same as the `evidence` target: quote generation
+//! opens the raw single-open TPM device, so every test carries
+//! `serial(attestation_evidence)` and runs its handshakes sequentially.
+//!
+//! Requires sudo (TPM access), the `/run/seismic` manifest handoff, and a
+//! `seismic-reth` binary (`SEISMIC_RETH_BIN`, `$PATH`, or a sibling
+//! checkout's target directory).
+
+use std::{
+    collections::HashMap,
+    env, fs,
+    net::TcpListener,
+    path::{Path, PathBuf},
+    process::{Child, Command, Stdio},
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
+    time::{Duration, Instant, SystemTime, UNIX_EPOCH},
+};
+
+use alloy::{
+    eips::BlockId,
+    network::EthereumWallet,
+    providers::{Provider, ProviderBuilder, RootProvider},
+    signers::local::PrivateKeySigner,
+    sol,
+};
+use alloy_primitives::{Address, B256, address, keccak256};
+use jsonrpsee::http_client::{HttpClient, HttpClientBuilder};
+use seismic_attestation::{
+    AttestationType, NetworkId, SeismicMeasurementPolicy, VerifiedSeismicAttestation,
+    generate_evidence, verify_evidence_with_policy,
+};
+use seismic_attestation_rpc::AttestationRpcClient as _;
+use seismic_attestation_service::{
+    Args,
+    api::NodeStatusRpcClient as _,
+    bootstrap::build_root_key_request,
+    utils::{init_tracing, is_sudo},
+};
+use seismic_custodian::Custodian;
+use seismic_custodian_ipc::{
+    Request,
+    server::{MethodAcl, bind, serve},
+};
+use seismic_custodian_service::{dispatch::dispatch, state::CustodianState};
+use seismic_measurement_admission::{
+    AZURE_TDX_V1_PCRS, AzureTdxV1Measurements, compile_policy,
+    genesis::{REGISTRY_RUNTIME_CODE_HASH, registry_genesis_storage},
+};
+use seismic_measurement_registry_client::{MEASUREMENT_REGISTRY_ADDRESS, MeasurementRegistry};
+
+/// The manifest both sides of every handshake derive their network ID from;
+/// the runner script installs the same fixture at the server's fixed
+/// `/run/seismic` handoff path.
+const NETWORK_MANIFEST: &[u8] =
+    include_bytes!("../../../crates/network-manifest/fixtures/network-manifest-v1.json");
+
+/// `MeasurementAuthorityDev` genesis predeploy (the manifest's
+/// `measurements.contracts.authority`).
+const AUTHORITY: Address = address!("0x1000000000000000000000000000000000000002");
+/// Anvil dev account 0 — `MeasurementAuthorityDev.OWNER`, funded in the
+/// genesis template.
+const OWNER_SK: &str = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
+/// Fixed gas for `applyPolicyUpdate`: plain `eth_estimateGas` is an unsigned
+/// read, for which seismic-reth zeroes `msg.sender`, tripping the owner check
+/// during the preflight (see `reth_registry.rs` for the long version).
+const APPLY_POLICY_UPDATE_GAS: u64 = 500_000;
+
+/// The wire contract under test (`src/utils.rs` keeps the service's copy):
+/// a terminal admission verdict, and a responder that could not decide.
+const ROOT_KEY_REQUEST_DENIED_CODE: i32 = -32001;
+const ROOT_KEY_ADMISSION_UNAVAILABLE_CODE: i32 = -32002;
+
+/// Interval-mining period. The freshness gate reads the finalized view, which
+/// trails `latest` by ~63 blocks in dev mode: 500ms blocks hold that view
+/// ~32s old in steady state — inside the production 60s bound with headroom,
+/// and past any per-test tightened bound.
+const BLOCK_TIME: &str = "500ms";
+/// Tightened policy-age bound for the staleness scenario, far under the ~32s
+/// steady-state finalized age.
+const STALE_MAX_POLICY_AGE: Duration = Duration::from_secs(3);
+
+const NODE_STARTUP_TIMEOUT: Duration = Duration::from_secs(5 * 60);
+/// One direct handshake: a fresh quote, verification with collateral
+/// fetches, and up to three chain-read attempts on the responder.
+const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(5 * 60);
+const RETRY_INTERVAL: Duration = Duration::from_secs(2);
+
+sol! {
+    #[sol(rpc)]
+    interface IMeasurementAuthorityDev {
+        function applyPolicyUpdate(
+            bytes32[] calldata accept,
+            bytes32[] calldata deprecate,
+            bytes32 newActivePolicyHash
+        ) external;
+    }
+}
+
+/// The accepted path, and deprecation applying live: a joiner service
+/// bootstraps against a responder whose registry accepts the runner's own
+/// measurements (exactly one root-key wrap); the authority then deprecates
+/// that admission ID on chain, and the same responder process denies the
+/// next handshake.
+#[serial_test::serial(attestation_evidence)]
+#[tokio::test]
+async fn test_accepted_tuple_wraps_once_then_deprecation_applies_live() {
+    init_tracing();
+    if !is_sudo() {
+        panic!("test_accepted_tuple_wraps_once_then_deprecation_applies_live: requires sudo");
+    }
+
+    let pcrs = observed_pcrs().await;
+    let admission_id = *AzureTdxV1Measurements::from_pcrs(&pcrs)
+        .expect("quoted PCR bank carries every schema register")
+        .admission_id()
+        .as_b256();
+    let node = launch_seeded_reth("suite-observed", &pcrs);
+    let provider = wait_for_rpc(&node).await;
+    wait_past_genesis(&provider).await;
+
+    let responder = start_service("responder", 30, None, &node.http_url, None).await;
+    let joiner = start_service(
+        "joiner",
+        31,
+        Some(vec![responder.url.clone()]),
+        &node.http_url,
+        None,
+    )
+    .await;
+    // The joiner's health wait spans the attested exchange, so its return is
+    // the join completing — authorized by exactly one custodian wrap.
+    assert_eq!(
+        responder.wrap_count.load(Ordering::SeqCst),
+        1,
+        "an accepted join must wrap the root key exactly once"
+    );
+    joiner.handle.abort();
+
+    // Deprecate the runner's admission ID through the authority owner. The
+    // responder reads the policy at the finalized block, so wait for the
+    // deprecated verdict to finalize before asserting on a handshake.
+    let authority = IMeasurementAuthorityDev::new(AUTHORITY, owner_provider(&node));
+    let receipt = authority
+        .applyPolicyUpdate(vec![], vec![admission_id], keccak256("suite revision 2"))
+        .gas(APPLY_POLICY_UPDATE_GAS)
+        .send()
+        .await
+        .expect("send deprecation")
+        .get_receipt()
+        .await
+        .expect("deprecation receipt");
+    assert!(receipt.status(), "deprecation transaction reverted");
+    wait_finalized_rejects(&provider, admission_id).await;
+
+    // Same responder process, no restart: the live chain read alone flips
+    // the verdict, and the denied handshake never reaches the custodian.
+    let denied = request_root_key(&responder.url).await;
+    assert_eq!(denial_code(denied), ROOT_KEY_REQUEST_DENIED_CODE);
+    assert_eq!(
+        responder.wrap_count.load(Ordering::SeqCst),
+        1,
+        "a denied handshake must not wrap the root key"
+    );
+    assert_eq!(
+        responder
+            .client
+            .health_check()
+            .await
+            .expect("responder still serving after the denial"),
+        "OK"
+    );
+    responder.handle.abort();
+}
+
+/// A cryptographically valid guest whose tuple the registry never accepted
+/// is denied; killing the responder's reth then fails closed as temporarily
+/// unavailable — the same responder cannot decide without its chain.
+#[serial_test::serial(attestation_evidence)]
+#[tokio::test]
+async fn test_unknown_tuple_is_denied_and_reth_outage_fails_closed() {
+    init_tracing();
+    if !is_sudo() {
+        panic!("test_unknown_tuple_is_denied_and_reth_outage_fails_closed: requires sudo");
+    }
+
+    // Synthetic policy: real quotes carry the runner's PCRs, which can never
+    // match these values, so the runner's admission ID is unknown on chain.
+    let mut node = launch_seeded_reth("suite-synthetic", &synthetic_pcrs());
+    let provider = wait_for_rpc(&node).await;
+    wait_past_genesis(&provider).await;
+
+    let responder = start_service("responder", 32, None, &node.http_url, None).await;
+    let denied = request_root_key(&responder.url).await;
+    assert_eq!(denial_code(denied), ROOT_KEY_REQUEST_DENIED_CODE);
+    assert_eq!(responder.wrap_count.load(Ordering::SeqCst), 0);
+
+    node.stop();
+    let unavailable = request_root_key(&responder.url).await;
+    assert_eq!(
+        denial_code(unavailable),
+        ROOT_KEY_ADMISSION_UNAVAILABLE_CODE
+    );
+    assert_eq!(responder.wrap_count.load(Ordering::SeqCst), 0);
+    responder.handle.abort();
+}
+
+/// A responder whose finalized policy view is older than its bound refuses
+/// to decide. The registry would accept this tuple (the policy is compiled
+/// from the runner's observed PCRs) and the chain is alive and mining — the
+/// tightened bound alone turns the answer into temporarily unavailable.
+#[serial_test::serial(attestation_evidence)]
+#[tokio::test]
+async fn test_stale_policy_view_fails_closed() {
+    init_tracing();
+    if !is_sudo() {
+        panic!("test_stale_policy_view_fails_closed: requires sudo");
+    }
+
+    let pcrs = observed_pcrs().await;
+    let node = launch_seeded_reth("suite-observed", &pcrs);
+    let provider = wait_for_rpc(&node).await;
+    wait_past_genesis(&provider).await;
+
+    let responder = start_service(
+        "responder",
+        33,
+        None,
+        &node.http_url,
+        Some(STALE_MAX_POLICY_AGE),
+    )
+    .await;
+    // Let the finalized view age well past the bound (it only grows from
+    // here: the genesis stamp recedes until the ~64-block flip, after which
+    // the view sits at the ~32s steady-state lag), so every retry attempt
+    // within the handshake sees a stale chain.
+    wait_finalized_older_than(&provider, STALE_MAX_POLICY_AGE * 3).await;
+
+    let stale = request_root_key(&responder.url).await;
+    assert_eq!(denial_code(stale), ROOT_KEY_ADMISSION_UNAVAILABLE_CODE);
+    assert_eq!(responder.wrap_count.load(Ordering::SeqCst), 0);
+    responder.handle.abort();
+}
+
+/// Quote the local vTPM once and return the verified PCR bank — the values
+/// the fixture policy pins as the network-accepted tuple. The binding is
+/// self-chosen and self-verified; only the PCR bank matters here.
+async fn observed_pcrs() -> HashMap<u32, [u8; 32]> {
+    let binding = [0x42u8; 64];
+    let evidence = generate_evidence(AttestationType::AzureTdx, binding)
+        .expect("vTPM quote (needs sudo and a free TPM device)");
+    let verified = verify_evidence_with_policy(
+        evidence,
+        binding,
+        SeismicMeasurementPolicy::dangerously_accept_any_for_testing(AttestationType::AzureTdx),
+    )
+    .await
+    .expect("verifying our own quote");
+    match verified {
+        VerifiedSeismicAttestation::AzureTdx(azure) => azure
+            .guest_measurements
+            .pcrs
+            .iter()
+            .map(|(index, value)| (*index, *value))
+            .collect(),
+        other => panic!("expected an Azure TDX attestation, got {other:?}"),
+    }
+}
+
+/// A full schema bank of values no real quote can carry.
+fn synthetic_pcrs() -> HashMap<u32, [u8; 32]> {
+    HashMap::from([(4, [0xA4u8; 32]), (9, [0xA9u8; 32]), (11, [0xB1u8; 32])])
+}
+
+/// Compile a one-record policy from `pcrs`, seed the committed genesis
+/// template's registry account with its storage, stamp the genesis timestamp
+/// to now (milliseconds, the chain's convention — this is what keeps the
+/// dev miner's genesis-pinned finalized view inside the freshness bound),
+/// and boot `seismic-reth` on the result.
+fn launch_seeded_reth(measurement_id: &str, pcrs: &HashMap<u32, [u8; 32]>) -> RethNode {
+    let policy_measurements: serde_json::Map<String, serde_json::Value> = AZURE_TDX_V1_PCRS
+        .iter()
+        .map(|index| {
+            (
+                format!("pcr{index}"),
+                serde_json::json!({ "expected_any": [hex::encode(pcrs[index])] }),
+            )
+        })
+        .collect();
+    let policy_doc = serde_json::json!([{
+        "measurement_id": measurement_id,
+        "attestation_type": "azure-tdx",
+        "measurements": policy_measurements,
+    }]);
+    let compiled = compile_policy(&serde_json::to_vec(&policy_doc).expect("serialize policy"))
+        .expect("suite policy document compiles");
+
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let template_path =
+        manifest_dir.join("../../crates/measurement-admission/fixtures/reth-genesis-template.json");
+    let template = fs::read_to_string(&template_path)
+        .unwrap_or_else(|e| panic!("reading {}: {e}", template_path.display()));
+    let mut genesis: serde_json::Value =
+        serde_json::from_str(&template).expect("genesis template JSON");
+
+    let registry_account = &mut genesis["alloc"][&format!("{MEASUREMENT_REGISTRY_ADDRESS:#x}")];
+    let code = hex::decode(
+        registry_account["code"]
+            .as_str()
+            .expect("registry code in template")
+            .trim_start_matches("0x"),
+    )
+    .expect("registry code hex");
+    assert_eq!(
+        keccak256(&code),
+        REGISTRY_RUNTIME_CODE_HASH,
+        "template registry code drifted from the canonical artifact"
+    );
+    let storage: serde_json::Map<String, serde_json::Value> = registry_genesis_storage(&compiled)
+        .iter()
+        .map(|(slot, value)| {
+            (
+                format!("{slot}"),
+                serde_json::Value::from(format!("{value}")),
+            )
+        })
+        .collect();
+    registry_account["storage"] = serde_json::Value::Object(storage);
+    genesis["timestamp"] = serde_json::Value::from(format!("{:#x}", now_millis()));
+
+    let http_port = free_port();
+    let dir = env::temp_dir().join(format!("attestation-admission-reth-{http_port}"));
+    fs::create_dir_all(&dir).expect("create node scratch dir");
+    let genesis_path = dir.join("genesis.json");
+    fs::write(
+        &genesis_path,
+        serde_json::to_string_pretty(&genesis).unwrap(),
+    )
+    .expect("write genesis");
+
+    // --seismic.purpose-keys-source built-in: the default source waits on the
+    // custodian socket and aborts when absent. --ipcdisable and explicit
+    // authrpc/p2p ports: their defaults are global (one path/port per chain
+    // ID), so concurrent test nodes would collide.
+    let child = Command::new(find_reth().expect(
+        "no seismic-reth binary: set SEISMIC_RETH_BIN, add seismic-reth to PATH, \
+         or build the sibling checkout (cargo build --bin seismic-reth)",
+    ))
+    .args(["node", "--dev", "--dev.block-time", BLOCK_TIME])
+    .args(["--chain", genesis_path.to_str().unwrap()])
+    .args(["--datadir", dir.join("data").to_str().unwrap()])
+    .args([
+        "--http",
+        "--http.addr",
+        "127.0.0.1",
+        "--http.port",
+        &http_port.to_string(),
+    ])
+    .args(["--authrpc.port", &free_port().to_string()])
+    .args(["--ipcdisable", "--port", "0", "--disable-discovery"])
+    .args(["--log.file.directory", dir.join("logs").to_str().unwrap()])
+    .args(["--seismic.purpose-keys-source", "built-in"])
+    .stdout(Stdio::null())
+    .stderr(Stdio::from(
+        fs::File::create(dir.join("reth.stderr")).expect("stderr log"),
+    ))
+    .spawn()
+    .expect("spawn seismic-reth");
+
+    RethNode {
+        child,
+        dir,
+        http_url: format!("http://127.0.0.1:{http_port}"),
+    }
+}
+
+fn find_reth() -> Option<PathBuf> {
+    if let Ok(explicit) = env::var("SEISMIC_RETH_BIN") {
+        let explicit = PathBuf::from(explicit);
+        assert!(
+            explicit.is_file(),
+            "SEISMIC_RETH_BIN points at {}, which is not a file",
+            explicit.display()
+        );
+        return Some(explicit);
+    }
+    if let Some(paths) = env::var_os("PATH") {
+        for dir in env::split_paths(&paths) {
+            let candidate = dir.join("seismic-reth");
+            if candidate.is_file() {
+                return Some(candidate);
+            }
+        }
+    }
+    // Workspace-sibling checkout (enclave/ and seismic-reth/ share a parent).
+    let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    for profile in ["debug", "release"] {
+        let candidate = manifest
+            .join("../../../seismic-reth/target")
+            .join(profile)
+            .join("seismic-reth");
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+    }
+    None
+}
+
+fn free_port() -> u16 {
+    TcpListener::bind("127.0.0.1:0")
+        .expect("bind ephemeral port")
+        .local_addr()
+        .unwrap()
+        .port()
+}
+
+fn now_millis() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock after epoch")
+        .as_millis() as u64
+}
+
+/// A running dev node; the process and its scratch directory live exactly as
+/// long as this value.
+struct RethNode {
+    child: Child,
+    dir: PathBuf,
+    http_url: String,
+}
+
+impl RethNode {
+    /// Kill the node while keeping the value alive — the chain-outage
+    /// scenario takes reth away from a responder that keeps serving.
+    fn stop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+impl Drop for RethNode {
+    fn drop(&mut self) {
+        self.stop();
+        let _ = fs::remove_dir_all(&self.dir);
+    }
+}
+
+async fn wait_for_rpc(node: &RethNode) -> RootProvider {
+    let provider = RootProvider::new_http(node.http_url.parse().expect("node HTTP URL"));
+    let deadline = Instant::now() + Duration::from_secs(30);
+    loop {
+        match provider.get_chain_id().await {
+            Ok(id) => {
+                assert_eq!(id, 5124, "node came up on an unexpected chain");
+                return provider;
+            }
+            Err(_) if Instant::now() < deadline => {
+                tokio::time::sleep(Duration::from_millis(250)).await
+            }
+            Err(e) => panic!(
+                "seismic-reth RPC not ready within 30s: {e} (see {})",
+                node.dir.join("reth.stderr").display()
+            ),
+        }
+    }
+}
+
+/// Wait until `latest` is past block 0: the admission gate's genesis window
+/// admits unconditionally at block 0, so every rejection scenario starts
+/// after the chain has advanced.
+async fn wait_past_genesis(provider: &RootProvider) {
+    let deadline = Instant::now() + Duration::from_secs(30);
+    loop {
+        let number = provider.get_block_number().await.expect("latest number");
+        if number > 0 {
+            return;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "dev node mined no block within 30s"
+        );
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+}
+
+/// Wait until the registry's *finalized* view rejects `admission_id` — the
+/// view admission decisions read, trailing `latest` by ~63 blocks in dev
+/// mode, so a deprecation takes ~32s at 500ms blocks to become decisive.
+async fn wait_finalized_rejects(provider: &RootProvider, admission_id: B256) {
+    let registry = MeasurementRegistry::new(MEASUREMENT_REGISTRY_ADDRESS, provider.clone());
+    let deadline = Instant::now() + Duration::from_secs(120);
+    loop {
+        let accepted = registry
+            .isAccepted(admission_id)
+            .block(BlockId::finalized())
+            .call()
+            .await
+            .expect("isAccepted at the finalized tag");
+        if !accepted {
+            return;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "deprecation did not reach the finalized view within 120s"
+        );
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
+}
+
+/// Wait until the finalized block's timestamp is at least `age` behind the
+/// wall clock.
+async fn wait_finalized_older_than(provider: &RootProvider, age: Duration) {
+    let deadline = Instant::now() + Duration::from_secs(60);
+    loop {
+        let finalized = provider
+            .get_block_by_number(alloy::eips::BlockNumberOrTag::Finalized)
+            .await
+            .expect("finalized query")
+            .expect("dev node serves a finalized block");
+        let observed =
+            Duration::from_millis(now_millis().saturating_sub(finalized.header.inner.timestamp));
+        if observed >= age {
+            return;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "finalized view did not age past {age:?} within 60s"
+        );
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
+}
+
+/// One custodian/attestation-service pair under test, with a counter over
+/// the custodian's `WrapRootKey` dispatches — each count is one root-key
+/// release this responder authorized.
+struct ServiceNode {
+    /// Owns the runtime directory (custodian socket, LUKS keyfile path).
+    _runtime: tempfile::TempDir,
+    url: String,
+    client: HttpClient,
+    handle: tokio::task::JoinHandle<anyhow::Result<()>>,
+    wrap_count: Arc<AtomicUsize>,
+}
+
+/// Start a custodian/attestation-service pair against `reth_rpc_url` and
+/// wait until its RPC listener is healthy.
+///
+/// `peers: None` starts a responder (genesis custodian, fresh root key);
+/// `Some(urls)` starts a joiner whose custodian acquires the root key from
+/// those peers, so returning implies the join completed. `n` offsets the
+/// HTTP port; keep offsets distinct across tests — they share one process,
+/// and a just-aborted listener may still hold its port.
+async fn start_service(
+    label: &'static str,
+    n: u16,
+    peers: Option<Vec<String>>,
+    reth_rpc_url: &str,
+    max_policy_age: Option<Duration>,
+) -> ServiceNode {
+    let runtime = tempfile::tempdir().expect("create service runtime directory");
+    let socket = runtime.path().join("custodian.sock");
+    let luks_keyfile = runtime.path().join("luks-keys");
+    let state = if peers.is_none() {
+        CustodianState::new_with_root_key(
+            Custodian::new_as_genesis().expect("generate genesis root key"),
+            luks_keyfile,
+        )
+        .expect("construct genesis custodian")
+    } else {
+        CustodianState::new_awaiting_root_key(luks_keyfile)
+    };
+    let wrap_count = spawn_counting_custodian(state, &socket);
+
+    let args = Args {
+        ip: "0.0.0.0".to_string(),
+        port: 7878 + n,
+        peers: peers.unwrap_or_default(),
+        custodian_socket: socket,
+        reth_rpc_url: reth_rpc_url.parse().expect("valid reth RPC URL"),
+        max_policy_age,
+    };
+    let url = format!("http://localhost:{}", args.port);
+    let mut handle = tokio::spawn(args.start());
+    let client = HttpClientBuilder::default()
+        .build(url.clone())
+        .unwrap_or_else(|e| panic!("create {label} client: {e}"));
+    wait_for_health(&client, label, &mut handle).await;
+
+    ServiceNode {
+        _runtime: runtime,
+        url,
+        client,
+        handle,
+        wrap_count,
+    }
+}
+
+/// Serve `state` over a custodian socket from a dedicated thread — the same
+/// transport and dispatch the standalone `seismic-custodian-service` binary
+/// runs — counting `WrapRootKey` requests on the way through.
+fn spawn_counting_custodian(state: CustodianState, socket: &Path) -> Arc<AtomicUsize> {
+    let wrap_count = Arc::new(AtomicUsize::new(0));
+    let counter = wrap_count.clone();
+    let listener = bind(socket).expect("bind custodian socket");
+    std::thread::spawn(move || {
+        serve(listener, MethodAcl::own_uid_only(), move |request| {
+            if matches!(request, Request::WrapRootKey { .. }) {
+                counter.fetch_add(1, Ordering::SeqCst);
+            }
+            dispatch(&state, request)
+        })
+    });
+    wrap_count
+}
+
+/// Wait until the server's `healthCheck` RPC returns `OK`.
+///
+/// A joining server binds its RPC listener after fetching and installing the
+/// root key, so readiness also confirms that its bootstrap exchange completed.
+async fn wait_for_health(
+    client: &HttpClient,
+    service: &str,
+    server_handle: &mut tokio::task::JoinHandle<anyhow::Result<()>>,
+) {
+    let deadline = tokio::time::Instant::now() + NODE_STARTUP_TIMEOUT;
+    loop {
+        let last_error = match client.health_check().await {
+            Ok(status) if status == "OK" => return,
+            Ok(status) => format!("unexpected health response: {status}"),
+            Err(error) => error.to_string(),
+        };
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "{service} did not become healthy within {NODE_STARTUP_TIMEOUT:?}: {last_error}"
+        );
+        tokio::select! {
+            result = &mut *server_handle => {
+                panic!("{service} exited before becoming healthy: {result:?}")
+            }
+            () = tokio::time::sleep(RETRY_INTERVAL) => {}
+        }
+    }
+}
+
+/// One direct requester handshake: an attested `RootKeyRequest` over the
+/// runner's real quote, POSTed to `responder_url`. The denial scenarios ride
+/// this instead of a joiner service, whose fetch loop would retry denials
+/// forever. The ephemeral key is fixed — no response is ever unwrapped here.
+async fn request_root_key(responder_url: &str) -> Result<Vec<u8>, jsonrpsee::core::client::Error> {
+    let eph_sk = secp256k1::SecretKey::from_slice(&[0x42u8; 32]).expect("valid test secret key");
+    let eph_pk = secp256k1::PublicKey::from_secret_key(&secp256k1::Secp256k1::new(), &eph_sk);
+    let request = build_root_key_request(
+        &NetworkId::from_manifest_bytes(NETWORK_MANIFEST),
+        &eph_pk,
+        AttestationType::AzureTdx,
+    )
+    .expect("build attested root-key request");
+    let client = HttpClientBuilder::default()
+        .request_timeout(HANDSHAKE_TIMEOUT)
+        .build(responder_url)
+        .expect("create handshake client");
+    client
+        .get_wrapped_root_key(serde_json::to_vec(&request).expect("serialize root-key request"))
+        .await
+}
+
+/// The JSON-RPC error code a failed handshake surfaced.
+fn denial_code(result: Result<Vec<u8>, jsonrpsee::core::client::Error>) -> i32 {
+    match result {
+        Err(jsonrpsee::core::client::Error::Call(error)) => error.code(),
+        Ok(_) => panic!("handshake must be denied, but a wrapped root key came back"),
+        Err(other) => panic!("handshake must fail with a JSON-RPC call error, got: {other}"),
+    }
+}
+
+fn owner_provider(node: &RethNode) -> impl Provider + Clone {
+    let signer: PrivateKeySigner = OWNER_SK.parse().unwrap();
+    ProviderBuilder::new()
+        .wallet(EthereumWallet::from(signer))
+        .connect_http(node.http_url.parse().unwrap())
+}

--- a/bin/attestation-service/tests/evidence/evidence.rs
+++ b/bin/attestation-service/tests/evidence/evidence.rs
@@ -1,7 +1,14 @@
-//! Live-TEE integration coverage run through
-//! `scripts/run_integration_tests.sh`. The script prepares the runtime
-//! manifest, frees the TPM, and executes these tests with the required
-//! privileges.
+//! Live-TEE coverage of the evidence layer — attested transcripts, quote
+//! verification, and the key flows built on them — run through
+//! `scripts/run_attestation_service_evidence_tdx_tests.sh`. The script
+//! prepares the runtime manifest, frees the TPM, and executes these tests
+//! with the required privileges.
+//!
+//! Each node here answers admission reads from a permissive mock registry
+//! (see `utils::spawn_accepting_registry`), isolating what evidence
+//! establishes — which guest is asking — from whether that guest is
+//! allowed. The complementary `admission` target holds this layer fixed
+//! and tests the registry verdict against a real seismic-reth.
 //!
 //! Quote generation opens the raw TPM device, which the kernel hands to one
 //! process at a time (az-cvm-vtpm hardcodes tss-esapi's default TCTI,

--- a/bin/attestation-service/tests/evidence/main.rs
+++ b/bin/attestation-service/tests/evidence/main.rs
@@ -1,4 +1,4 @@
 #[cfg(test)]
-mod integration;
+mod evidence;
 
 mod utils;

--- a/bin/attestation-service/tests/evidence/utils.rs
+++ b/bin/attestation-service/tests/evidence/utils.rs
@@ -12,6 +12,7 @@ pub fn get_args(n: u16, peers: Vec<String>, custodian_socket: PathBuf, reth_rpc_
         peers,
         custodian_socket,
         reth_rpc_url: reth_rpc_url.parse().expect("valid mock registry URL"),
+        max_policy_age: None,
     }
 }
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,7 +1,9 @@
 # Integration Tests
 
-`run_attestation_service_tdx_tests.sh` runs the live-TEE attestation-service integration
-tests on the self-hosted Azure TDX runner.
+`run_attestation_service_evidence_tdx_tests.sh` runs the live-TEE
+attestation-service evidence suite on the self-hosted Azure TDX runner.
+`run_attestation_service_admission_tdx_tests.sh` runs the service's
+reth-backed responder-admission suite on the same runner.
 
 ## Covered flows
 
@@ -23,8 +25,13 @@ joining pairs — two bootstrapping from the genesis node, one from an
 already-bootstrapped joiner — and checks that every join completes and all
 four custodians derive the same `tx_io_pk`.
 
-TODO: add contract-backed bootstrap-admission coverage as a distinct
-reth-backed integration test with PCR policy seeded in genesis.
+The admission suite (`bin/attestation-service/tests/admission.rs`) covers the
+responder's contract-backed bootstrap admission against real `seismic-reth`
+dev nodes seeded with a measurement policy compiled at runtime from the
+runner's own quoted PCRs: an accepted tuple authorizes exactly one root-key
+wrap, an on-chain deprecation denies the next handshake without a service
+restart, an unknown tuple is denied, and an unreachable or stale chain fails
+closed. It additionally needs a `seismic-reth` binary (`SEISMIC_RETH_BIN`).
 
 ## Requirements
 
@@ -35,15 +42,16 @@ reth-backed integration test with PCR policy seeded in genesis.
   TPM. On the CI image, the script asks Supervisor to stop it if present.
 - A Rust toolchain.
 
-The script installs the checked-in network-manifest fixture under
-`/run/seismic/conf`, builds the integration-test binary as the runner user, and
+Each script installs the checked-in network-manifest fixture under
+`/run/seismic/conf`, builds its test binary as the runner user, and
 executes it with `sudo`.
 
 ## Running
 
 ```bash
-./scripts/run_attestation_service_tdx_tests.sh
+./scripts/run_attestation_service_evidence_tdx_tests.sh
+./scripts/run_attestation_service_admission_tdx_tests.sh
 ```
 
-CI runs the same script in the `attestation_service_tdx_tests` job in
-`.github/workflows/ci.yml`.
+CI runs the same scripts in the `attestation_service_evidence_tdx_tests` and
+`attestation_service_admission_tdx_tests` jobs in `.github/workflows/ci.yml`.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -53,5 +53,6 @@ executes it with `sudo`.
 ./scripts/run_attestation_service_admission_tdx_tests.sh
 ```
 
-CI runs the same scripts in the `attestation_service_evidence_tdx_tests` and
-`attestation_service_admission_tdx_tests` jobs in `.github/workflows/ci.yml`.
+CI runs the same scripts as the two steps of the
+`attestation_service_tdx_tests` job in `.github/workflows/ci.yml` — one job,
+so the suites share a single dependency build on the TDX runner.

--- a/scripts/run_attestation_service_admission_tdx_tests.sh
+++ b/scripts/run_attestation_service_admission_tdx_tests.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+# Self-hosted runner for the attestation service's reth-backed admission
+# test suite
+# (bin/attestation-service/tests/admission.rs). The tests need direct TPM
+# access, the image's /run/seismic layout, and a seismic-reth binary
+# (SEISMIC_RETH_BIN — CI installs it via setup-sreth), so build as the runner
+# user and execute the resulting test binary with sudo.
+
+set -e
+
+export RUST_BACKTRACE=1
+export RUST_LOG=info
+
+echo "🚀 Starting attestation-service admission tests..."
+
+# The image service normally creates these runtime directories. Ensure they
+# also exist when the test job starts from a clean runner boot.
+sudo install -d -m 0755 /run/seismic/conf
+sudo install -m 0644 \
+    crates/network-manifest/fixtures/network-manifest-v1.json \
+    /run/seismic/conf/network-manifest.json
+
+# Free the TPM before the tests start their handshakes: quote generation
+# opens the raw TPM device (/dev/tpm0), which the kernel hands to one process
+# at a time (tpmrm0 support is kinvolk/azure-cvm-tooling#92). Seismic images
+# may have a Supervisor-managed server; stock CI runners do not. The
+# Supervisor program keeps its deployed name (enclave-server) until the
+# runner image is regenerated with the split services.
+if command -v supervisorctl >/dev/null 2>&1 && \
+    sudo supervisorctl status enclave-server >/dev/null 2>&1; then
+    sudo supervisorctl stop enclave-server
+else
+    echo "ℹ️ No running Supervisor-managed enclave-server to stop."
+fi
+sleep 2
+
+cd bin/attestation-service
+OUTPUT=$(CARGO_TERM_COLOR=never cargo test --test admission --no-run 2>&1)
+echo "$OUTPUT"
+mapfile -t binaries < <(echo "$OUTPUT" | sed -nE 's/^[[:space:]]*Executable .*\((.+)\)$/\1/p')
+if [ ${#binaries[@]} -eq 0 ]; then
+    echo "❌ Could not find the attestation-service admission test binary"
+    exit 1
+fi
+
+# The target compiles to one test binary that runs every test in a single
+# process, serialized around the runner's single vTPM by serial_test — no
+# filtering or thread capping needed. The loop only covers cargo ever listing
+# more executables. sudo strips the environment, so pass the log/backtrace
+# config and the reth binary location through explicitly.
+for binary in "${binaries[@]}"; do
+    echo "🚀 Executing: sudo $binary"
+    sudo env RUST_LOG="$RUST_LOG" RUST_BACKTRACE="$RUST_BACKTRACE" \
+        SEISMIC_RETH_BIN="${SEISMIC_RETH_BIN:-}" PATH="$PATH" \
+        "$binary"
+done
+
+echo "🎉 All attestation-service admission tests passed!"

--- a/scripts/run_attestation_service_evidence_tdx_tests.sh
+++ b/scripts/run_attestation_service_evidence_tdx_tests.sh
@@ -1,15 +1,15 @@
 #!/bin/bash
 
-# Self-hosted integration test runner. The test needs direct TPM access plus
-# the image's /run/seismic layout, so build as the runner user and execute the
-# resulting test binary with sudo.
+# Self-hosted runner for the attestation service's evidence test suite. The
+# tests need direct TPM access plus the image's /run/seismic layout, so build
+# as the runner user and execute the resulting test binary with sudo.
 
 set -e
 
 export RUST_BACKTRACE=1
 export RUST_LOG=info
 
-echo "🚀 Starting attestation-service integration tests..."
+echo "🚀 Starting attestation-service evidence tests..."
 
 # The image service normally creates these runtime directories. Ensure they
 # also exist when the test job starts from a clean runner boot.
@@ -33,11 +33,11 @@ fi
 sleep 2
 
 cd bin/attestation-service
-OUTPUT=$(CARGO_TERM_COLOR=never cargo test --test integration --no-run 2>&1)
+OUTPUT=$(CARGO_TERM_COLOR=never cargo test --test evidence --no-run 2>&1)
 echo "$OUTPUT"
 mapfile -t binaries < <(echo "$OUTPUT" | sed -nE 's/^[[:space:]]*Executable .*\((.+)\)$/\1/p')
 if [ ${#binaries[@]} -eq 0 ]; then
-    echo "❌ Could not find the attestation-service integration test binary"
+    echo "❌ Could not find the attestation-service evidence test binary"
     exit 1
 fi
 
@@ -51,4 +51,4 @@ for binary in "${binaries[@]}"; do
     sudo env RUST_LOG="$RUST_LOG" RUST_BACKTRACE="$RUST_BACKTRACE" "$binary"
 done
 
-echo "🎉 All attestation-service integration tests passed!"
+echo "🎉 All attestation-service evidence tests passed!"


### PR DESCRIPTION
Service-level coverage of the responder's chain-backed admission gate, complementing the evidence suite (which answers admission reads from a permissive mock registry) and the admission module's mocked unit tests. Four scenarios ride the wire codes a joiner sees, against a real seismic-reth dev node whose genesis storage carries the measurement policy:

- an accepted tuple authorizes exactly one root-key wrap (a real joiner service completes its bootstrap);
- deprecating that tuple through the on-chain authority denies the next handshake (-32001) with no service restart — the policy is read live from the chain;
- an unknown tuple is denied (-32001);
- an unreachable or stale local reth fails closed (-32002).

The genesis is generated at runtime rather than committed: evidence carries the runner's real PCRs, so the seeded policy is compiled from the observed values (the accepted tuple) or from synthetic values no real quote can match (the unknown tuple). The genesis timestamp is stamped to now in milliseconds — the chain's timestamp convention — so the dev miner's genesis-pinned finalized view stays inside the freshness bound until the chain is ~64 blocks deep.

Supporting changes:

- RegistryAdmission carries its policy-age bound as a field, and Args.max_policy_age (deliberately not a CLI flag) lets the stale scenario tighten it instead of waiting out the production bound.
- The bootstrap module is public, so the denial scenarios can build attested requests directly rather than through a joiner service, whose fetch loop retries denials forever.
- The pre-existing `integration` target is renamed `evidence`, naming the two suites by the split the admission module draws: evidence verification establishes which guest is asking; admission decides whether that guest is allowed. Scripts and CI jobs are component-scoped to match: attestation_service_{evidence,admission}_tdx_tests.
- The new CI job runs on the TDX runner and installs the prebuilt seismic-reth via setup-sreth. Job comments now document the CI dependency tiers: `tests` stays hermetic given committed files (the required check), while artifact-dependent jobs live outside it.