### PR TITLE
fix(attestation-service): install a rustls crypto provider at startup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5151,6 +5151,7 @@ version = "0.23.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ebcbd2f03de0fc1122ad9bb24b127a5a6cd51d72604a3f3c50ac459762b6cc"
 dependencies = [
+ "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
@@ -5236,6 +5237,7 @@ version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted 0.9.0",
@@ -5473,6 +5475,7 @@ dependencies = [
  "hex",
  "jsonrpsee",
  "rand 0.9.2",
+ "rustls",
  "secp256k1",
  "seismic-attestation",
  "seismic-attestation-rpc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,9 @@ http-body-util = "0.1"
 jsonrpsee = { version = "0.26.0", features = ["server", "client","macros"] }
 libc = "0.2.177"
 rand = "0.9.2"
+# Provider choice for the process-level rustls default that attested-tls's
+# collateral fetching requires the application to install.
+rustls = { version = "0.23", default-features = false, features = ["aws_lc_rs"] }
 schnorrkel = { version = "0.11.2", features = ["serde"] }
 secp256k1 = { version = "0.30", features = ["rand", "recovery", "std", "serde"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/bin/attestation-service/Cargo.toml
+++ b/bin/attestation-service/Cargo.toml
@@ -37,6 +37,7 @@ thiserror.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 rand.workspace = true
+rustls.workspace = true
 url.workspace = true
 
 [dev-dependencies]

--- a/bin/attestation-service/src/lib.rs
+++ b/bin/attestation-service/src/lib.rs
@@ -61,6 +61,13 @@ pub struct Args {
 
 impl Args {
     pub async fn start(self) -> Result<()> {
+        // Quote verification's collateral fetching (attested-tls) builds
+        // rustls-backed HTTP clients, which need a process-level crypto
+        // provider that only the application can choose. Install it before
+        // anything verifies evidence; a provider installed even earlier by
+        // an embedding process wins, and any provider serves.
+        let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+
         let addr: SocketAddr = format!("{}:{}", self.ip, self.port).parse()?;
 
         info!("Starting attestation-service JSON-RPC server on {addr}...");


### PR DESCRIPTION
Fixes SEI-201

Quote verification's collateral fetching (attested-tls) builds rustls-backed HTTP clients. rustls 0.23 requires the application to install a process-level default crypto provider; without one, the first verification panics with "no process-level CryptoProvider available".

Install the aws-lc-rs provider at service start, before anything verifies evidence. The install is best-effort: a provider installed earlier by an embedding process wins, and any provider serves.

Related to, but orthogonal to, our upstream PR https://github.com/flashbots/attested-tls/pull/80.