### PR TITLE
feat(attestation-service): pin the admission policy read to the manifest genesis

### DIFF
--- a/bin/attestation-service/src/admission.rs
+++ b/bin/attestation-service/src/admission.rs
@@ -13,8 +13,9 @@
 //! - [`RegistryAdmission`] — the responder's predicate. A requester is
 //!   admitted iff its Azure v1 admission ID is currently accepted by the
 //!   on-chain `MeasurementRegistry`, asked via `eth_call isAccepted(id)`
-//!   pinned to a provably fresh finalized block of the node's local reth
-//!   (see `fresh_policy_block`). The chain carries the *live* policy:
+//!   pinned to a provably fresh finalized block of the node's local reth, on
+//!   the chain the network manifest commits to (see `fresh_policy_block` and
+//!   `check_pinned_genesis`). The chain carries the *live* policy:
 //!   additions and deprecations take effect on the next handshake, no node
 //!   restart needed.
 //! - [`DangerouslyAdmitAnyAzureGuest`] — the requester's (joiner's) predicate
@@ -27,11 +28,14 @@
 //! bank missing a schema register, an unreachable or stale chain, and a false
 //! `isAccepted` all deny the handshake.
 //!
-//! The freshness gate measures staleness against the guest's wall clock, so
-//! it defends against a lagging, partitioned, or network-eclipsed node — not
-//! against a malicious host that both eclipses the node and controls the
-//! guest's clock. That residual risk is accepted host influence under the
-//! TEE threat model.
+//! Every input to the decision is host-supplied state, so each is anchored as
+//! tightly as a locally checkable witness allows: the policy is read on the
+//! chain `network_id` commits to, at a finalized block whose timestamp is
+//! recent. Two residuals survive, both accepted host influence under the TEE
+//! threat model — a host that eclipses the guest *and* controls its clock, and
+//! a host that rewinds the guest's chain view to block 0, where the genesis
+//! window applies and no timestamp check bites. The pinned-genesis check
+//! bounds the second to the network's founding accepted set.
 
 use alloy::{
     eips::{BlockId, BlockNumberOrTag},
@@ -86,24 +90,54 @@ pub enum AdmissionDenial {
     },
     #[error("local reth is at genesis after chain progress was observed")]
     ChainRegressedToGenesis,
+    #[error(
+        "local reth serves genesis {found}, not the {expected} this node's \
+         network_id commits to; its chain is not this network's chain"
+    )]
+    ChainGenesisMismatch { expected: B256, found: B256 },
+}
+
+/// Whose problem a denial is, and whether time alone can change it. Both
+/// consumers of a denial read this: the retry loop below asks whether to try
+/// again, and the wire layer asks what to tell the requester.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DenialKind {
+    /// A verdict on the requester: its evidence was appraised and refused, and
+    /// the same image asking again gets the same answer.
+    RequesterVerdict,
+    /// The responder cannot decide, and no waiting changes that: it reads a
+    /// chain the network manifest does not commit to until an operator gives
+    /// it the right one. The requester's evidence is not what failed, so its
+    /// move is another peer.
+    ResponderMisconfigured,
+    /// The responder cannot decide right now: a reth that is restarting,
+    /// resyncing, or catching back under the freshness bound answers the same
+    /// query differently moments later.
+    ResponderTransient,
+}
+
+impl DenialKind {
+    /// Whether retrying inside the handshake can change the answer.
+    pub fn is_retryable(self) -> bool {
+        matches!(self, Self::ResponderTransient)
+    }
 }
 
 impl AdmissionDenial {
-    /// Whether this denial is the responder failing to *decide* — the local
-    /// chain or registry read did not produce a usable answer — as opposed to
-    /// a verdict on the requester (whose evidence will keep failing the same
-    /// way). Transient denials are worth retrying: against the same responder
-    /// moments later, or against another responder entirely.
-    pub fn is_transient(&self) -> bool {
+    /// Classify this denial. One exhaustive match, so a denial added later
+    /// cannot inherit a class by omission — least of all the requester
+    /// verdict, which tells a healthy joiner to stop asking.
+    pub fn kind(&self) -> DenialKind {
         match self {
+            Self::UnsupportedAttestationType(_)
+            | Self::MissingPcr(_)
+            | Self::RegistryNotAccepted(_) => DenialKind::RequesterVerdict,
+            Self::ChainGenesisMismatch { .. } => DenialKind::ResponderMisconfigured,
             Self::RegistryQueryFailed { .. }
             | Self::ChainQueryFailed { .. }
             | Self::ChainBlockMissing { .. }
             | Self::ChainStale { .. }
-            | Self::ChainRegressedToGenesis => true,
-            Self::UnsupportedAttestationType(_)
-            | Self::MissingPcr(_)
-            | Self::RegistryNotAccepted(_) => false,
+            | Self::ChainRegressedToGenesis => DenialKind::ResponderTransient,
         }
     }
 }
@@ -138,6 +172,10 @@ const MAX_POLICY_AGE: Duration = Duration::from_secs(60);
 #[derive(Clone)]
 pub struct RegistryAdmission {
     registry: MeasurementRegistryInstance<RootProvider>,
+    /// The genesis block `network_id` commits to, from the manifest's
+    /// `eth.genesis_hash`. Every policy read is checked against it, so a
+    /// verdict can only come from this network's chain.
+    pinned_genesis: B256,
     /// Bound on the finalized-block age this admission accepts; defaults to
     /// [`MAX_POLICY_AGE`].
     max_policy_age: Duration,
@@ -151,14 +189,20 @@ pub struct RegistryAdmission {
 impl RegistryAdmission {
     /// Admission backed by the `MeasurementRegistry` at `registry` (the
     /// manifest's `measurements.contracts.registry`), read over the node's
-    /// local reth HTTP endpoint.
-    pub fn new(reth_rpc_url: url::Url, registry: Address) -> Self {
-        Self::with_provider(RootProvider::new_http(reth_rpc_url), registry)
+    /// local reth HTTP endpoint, on the chain whose genesis is
+    /// `pinned_genesis` (the manifest's `eth.genesis_hash`).
+    pub fn new(reth_rpc_url: url::Url, registry: Address, pinned_genesis: B256) -> Self {
+        Self::with_provider(
+            RootProvider::new_http(reth_rpc_url),
+            registry,
+            pinned_genesis,
+        )
     }
 
-    fn with_provider(provider: RootProvider, registry: Address) -> Self {
+    fn with_provider(provider: RootProvider, registry: Address, pinned_genesis: B256) -> Self {
         Self {
             registry: MeasurementRegistry::new(registry, provider),
+            pinned_genesis,
             max_policy_age: MAX_POLICY_AGE,
             chain_has_advanced: Arc::new(AtomicBool::new(false)),
         }
@@ -188,17 +232,26 @@ impl RegistryAdmission {
     ///
     /// The one exception is a chain still at genesis, where finality is not
     /// yet being published and the genesis timestamp is arbitrarily old.
-    /// Admitting there is sound by construction — block-0 state *is* the
-    /// genesis-pinned policy, and no deprecation can predate the chain — and
-    /// it is what lets the founding cohort join before consensus starts.
+    /// Admitting there reads the policy `network_id` itself commits to — the
+    /// pinned-genesis check is what makes that equivalence hold — and no
+    /// deprecation can predate the chain, so this is what lets the founding
+    /// cohort join before consensus starts. The window latches shut for the
+    /// rest of the process once the chain is seen past genesis; a host that
+    /// restarts the service on a wiped reth reopens it, bounded by the pin to
+    /// the founding accepted set.
     async fn fresh_policy_block(&self) -> Result<B256, AdmissionDenial> {
         let latest = self.block_by_tag(BlockNumberOrTag::Latest).await?;
         if latest.header.inner.number == 0 {
+            // At genesis the block the policy is read at *is* block 0, so the
+            // pin is checked on it directly rather than queried again.
+            self.check_pinned_genesis(latest.header.hash)?;
             if self.chain_has_advanced.load(Ordering::Relaxed) {
                 return Err(AdmissionDenial::ChainRegressedToGenesis);
             }
             return Ok(latest.header.hash);
         }
+        let genesis = self.block_by_tag(BlockNumberOrTag::Earliest).await?;
+        self.check_pinned_genesis(genesis.header.hash)?;
         self.chain_has_advanced.store(true, Ordering::Relaxed);
 
         let finalized = self.block_by_tag(BlockNumberOrTag::Finalized).await?;
@@ -218,6 +271,25 @@ impl RegistryAdmission {
             });
         }
         Ok(finalized.header.hash)
+    }
+
+    /// Deny unless local reth's genesis is the one the network manifest pins.
+    ///
+    /// A registry read is only as trustworthy as the chain it runs against,
+    /// and that chain is host-supplied: reth boots from a genesis file the
+    /// host POSTs, and the guest is the only place able to check it at
+    /// decision time. Comparing block 0 against `eth.genesis_hash` ties every
+    /// verdict back to `network_id`, and reth validating state transitions
+    /// from that genesis does the rest — reaching a policy the network never
+    /// authorized then needs the authority key, not an edited JSON file.
+    fn check_pinned_genesis(&self, genesis: B256) -> Result<(), AdmissionDenial> {
+        if genesis != self.pinned_genesis {
+            return Err(AdmissionDenial::ChainGenesisMismatch {
+                expected: self.pinned_genesis,
+                found: genesis,
+            });
+        }
+        Ok(())
     }
 
     async fn block_by_tag(&self, tag: BlockNumberOrTag) -> Result<Block, AdmissionDenial> {
@@ -277,7 +349,7 @@ impl AdmissionPredicate for RegistryAdmission {
         let mut attempt = 1;
         loop {
             match self.decide(admission_id).await {
-                Err(denial) if denial.is_transient() && attempt < DECIDE_ATTEMPTS => {
+                Err(denial) if denial.kind().is_retryable() && attempt < DECIDE_ATTEMPTS => {
                     warn!(
                         "bootstrap: admission attempt {attempt}/{DECIDE_ATTEMPTS} \
                          hit a transient failure, retrying: {denial}"
@@ -348,10 +420,15 @@ mod tests {
         HashMap::from([(4, PCR4), (9, PCR9), (11, PCR11)])
     }
 
+    /// The genesis the mocked manifest pins, and the hash [`rpc_block`] gives
+    /// block 0.
+    const PINNED_GENESIS: B256 = B256::repeat_byte(0xb0);
+
     fn mocked_registry(asserter: &Asserter) -> RegistryAdmission {
         RegistryAdmission::with_provider(
             RootProvider::new(RpcClient::mocked(asserter.clone())),
             Address::ZERO,
+            PINNED_GENESIS,
         )
     }
 
@@ -363,12 +440,22 @@ mod tests {
     }
 
     /// An `eth_getBlockByNumber` response body, with a hash derived from the
-    /// block number so distinct blocks are tellable apart.
+    /// block number so distinct blocks are tellable apart. No block hashes to
+    /// `B256::ZERO`, so a default-constructed block can never satisfy a hash
+    /// comparison by accident.
     fn rpc_block(number: u64, timestamp: u64) -> Block {
         let mut block: Block = Block::default();
-        block.header.hash = alloy_primitives::B256::with_last_byte(number as u8);
+        block.header.hash = B256::repeat_byte(0xb0 ^ number as u8);
         block.header.inner.number = number;
         block.header.inner.timestamp = timestamp;
+        block
+    }
+
+    /// A block reth serves on a chain whose genesis the manifest does not pin:
+    /// a forged genesis, or simply the wrong network.
+    fn foreign_block(number: u64, timestamp: u64) -> Block {
+        let mut block = rpc_block(number, timestamp);
+        block.header.hash = B256::repeat_byte(0xef);
         block
     }
 
@@ -382,23 +469,25 @@ mod tests {
             .as_millis() as u64
     }
 
-    /// Queue responses for the two chain reads `admit` issues before the
+    /// Queue responses for the three chain reads `admit` issues before the
     /// registry call. The [`Asserter`] is parameter-blind and serves queued
-    /// responses in request order, so these stand in for the `latest`-tag and
-    /// `finalized`-tag queries respectively; that the code really asks with
-    /// those tags (and pins the registry call to the finalized hash) is
-    /// proven by `policy_read_is_pinned_to_the_fresh_finalized_block`.
+    /// responses in request order, so these stand in for the `latest`-,
+    /// `earliest`- and `finalized`-tag queries respectively; that the code
+    /// really asks with those tags (and pins the registry call to the
+    /// finalized hash) is proven by
+    /// `policy_read_is_pinned_to_the_fresh_finalized_block`.
     fn push_fresh_chain(asserter: &Asserter) {
         asserter.push_success(&rpc_block(7, now_millis()));
+        asserter.push_success(&rpc_block(0, 1_000));
         asserter.push_success(&rpc_block(6, now_millis()));
     }
 
-    /// A parameter-checking reth stand-in: serves `latest` and `finalized`
-    /// blocks by tag, errors on any other `eth_getBlockByNumber` query, and
-    /// answers `isAccepted` with `true` only when the `eth_call` is pinned
-    /// to the finalized block's hash. Any admission that queries the wrong
-    /// tag or reads the policy at any other block therefore fails.
-    async fn spawn_tag_checking_reth(latest: Block, finalized: Block) -> String {
+    /// A parameter-checking reth stand-in: serves `latest`, `earliest` and
+    /// `finalized` blocks by tag, errors on any other `eth_getBlockByNumber`
+    /// query, and answers `isAccepted` with `true` only when the `eth_call` is
+    /// pinned to the finalized block's hash. Any admission that queries the
+    /// wrong tag or reads the policy at any other block therefore fails.
+    async fn spawn_tag_checking_reth(latest: Block, genesis: Block, finalized: Block) -> String {
         use jsonrpsee::{server::ServerBuilder, types::ErrorObjectOwned};
 
         fn unexpected(message: String) -> ErrorObjectOwned {
@@ -417,6 +506,7 @@ mod tests {
                 let (tag, _full_transactions): (String, bool) = params.parse()?;
                 let block = match tag.as_str() {
                     "latest" => &latest,
+                    "earliest" => &genesis,
                     "finalized" => &finalized,
                     other => return Err(unexpected(format!("unexpected block tag {other}"))),
                 };
@@ -484,13 +574,22 @@ mod tests {
 
     #[tokio::test]
     async fn policy_read_is_pinned_to_the_fresh_finalized_block() {
-        // The mock denies every request except the two tag queries and an
+        // The mock denies every request except the three tag queries and an
         // eth_call at exactly the finalized hash, so this admission succeeding
-        // proves the gate reads the finalized tag and pins the registry query
-        // to the block it freshness-checked.
-        let url =
-            spawn_tag_checking_reth(rpc_block(7, now_millis()), rpc_block(6, now_millis())).await;
-        let admission = RegistryAdmission::new(url.parse().expect("mock reth URL"), Address::ZERO);
+        // proves the gate checks the pin at the earliest tag, reads the
+        // finalized tag, and pins the registry query to the block it
+        // freshness-checked.
+        let url = spawn_tag_checking_reth(
+            rpc_block(7, now_millis()),
+            rpc_block(0, 1_000),
+            rpc_block(6, now_millis()),
+        )
+        .await;
+        let admission = RegistryAdmission::new(
+            url.parse().expect("mock reth URL"),
+            Address::ZERO,
+            PINNED_GENESIS,
+        );
 
         admission
             .admit(&verified_azure(golden_pcr_bank()))
@@ -569,6 +668,7 @@ mod tests {
         let asserter = Asserter::new();
         for _ in 0..DECIDE_ATTEMPTS {
             asserter.push_success(&rpc_block(7, now_millis()));
+            asserter.push_success(&rpc_block(0, 1_000));
             asserter.push_success(&rpc_block(6, now_millis() - 3_600_000));
         }
         let admission = mocked_registry(&asserter);
@@ -587,6 +687,7 @@ mod tests {
         let asserter = Asserter::new();
         for _ in 0..DECIDE_ATTEMPTS {
             asserter.push_success(&rpc_block(7, now_millis()));
+            asserter.push_success(&rpc_block(0, 1_000));
             asserter.push_success(&serde_json::Value::Null);
         }
         let admission = mocked_registry(&asserter);
@@ -617,7 +718,9 @@ mod tests {
 
     #[tokio::test]
     async fn genesis_window_admits_at_block_zero() {
-        // The genesis timestamp is far in the past; the window ignores it.
+        // The genesis timestamp is far in the past; the window ignores it. Only
+        // two responses are queued, so the pin is checked on `latest` itself
+        // here — a second block query would surface as a missing response.
         let asserter = Asserter::new();
         asserter.push_success(&rpc_block(0, 1_000));
         asserter.push_success(&abi_bool(true));
@@ -648,6 +751,50 @@ mod tests {
             .await
             .expect_err("a chain back at genesis after progress must deny");
         assert!(error.to_string().contains("genesis"), "{error}");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn foreign_genesis_is_denied_past_the_window() {
+        // One round of chain responses and no registry response: a retry or a
+        // policy read would surface as a missing response rather than the
+        // mismatch, so this also pins the denial as final and as taken before
+        // the registry is consulted.
+        let asserter = Asserter::new();
+        asserter.push_success(&rpc_block(7, now_millis()));
+        asserter.push_success(&foreign_block(0, 1_000));
+        let admission = mocked_registry(&asserter);
+
+        let error = admission
+            .admit(&verified_azure(golden_pcr_bank()))
+            .await
+            .expect_err("a chain whose genesis the manifest does not pin must deny");
+        let denial = error
+            .downcast_ref::<AdmissionDenial>()
+            .expect("typed admission denial");
+        assert!(
+            matches!(denial, AdmissionDenial::ChainGenesisMismatch { .. }),
+            "{denial}"
+        );
+        // Not the joiner's fault, and no amount of waiting fixes it.
+        assert_eq!(denial.kind(), DenialKind::ResponderMisconfigured);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn foreign_genesis_is_denied_inside_the_window() {
+        // The genesis window is the one branch that admits on an arbitrarily
+        // old timestamp, so it is the branch a forged genesis aims at.
+        let asserter = Asserter::new();
+        asserter.push_success(&foreign_block(0, now_millis()));
+        let admission = mocked_registry(&asserter);
+
+        let error = admission
+            .admit(&verified_azure(golden_pcr_bank()))
+            .await
+            .expect_err("a forged genesis must deny even at block 0");
+        assert!(
+            error.to_string().contains("network_id commits to"),
+            "{error}"
+        );
     }
 
     #[tokio::test]

--- a/bin/attestation-service/src/rpc_error.rs
+++ b/bin/attestation-service/src/rpc_error.rs
@@ -6,7 +6,7 @@
 //! stable constant — an unauthenticated caller learns the outcome and nothing
 //! about why — so the failure detail lives in this responder's log instead.
 
-use crate::admission::AdmissionDenial;
+use crate::admission::{AdmissionDenial, DenialKind};
 use jsonrpsee::types::{ErrorCode, ErrorObjectOwned};
 use std::fmt::Debug;
 use tracing::{error, warn};
@@ -14,9 +14,9 @@ use tracing::{error, warn};
 /// Terminal verdict: the requester does not get the key, and retrying with
 /// the same image cannot change the answer.
 pub const ROOT_KEY_REQUEST_DENIED_CODE: i32 = -32001;
-/// Transient failure: the responder could not decide, because its own chain
-/// or registry read produced no usable answer. Worth retrying — against this
-/// responder moments later, or against another peer.
+/// The responder could not decide, because its own chain or registry read
+/// produced no usable answer. The requester's evidence is not what failed:
+/// worth retrying — against another peer, or this responder later.
 pub const ROOT_KEY_ADMISSION_UNAVAILABLE_CODE: i32 = -32002;
 
 pub(crate) fn invalid_root_key_request_rpc_error(error: impl Debug) -> ErrorObjectOwned {
@@ -55,21 +55,27 @@ pub(crate) fn root_key_admission_unavailable_rpc_error(error: impl Debug) -> Err
     )
 }
 
-/// Route a failed root-key answer to its wire error. An [`AdmissionDenial`]
-/// that is transient (see [`AdmissionDenial::is_transient`]) maps to
-/// [`ROOT_KEY_ADMISSION_UNAVAILABLE_CODE`]; everything else — admission
-/// verdicts, and failures carrying no typed denial (e.g. quote verification)
-/// — maps to [`ROOT_KEY_REQUEST_DENIED_CODE`]. Either way the message is a
-/// stable constant; failure detail stays in the responder's log.
+/// Route a failed root-key answer to its wire error, by what the failure says
+/// about the two parties (see [`DenialKind`]). The two codes carry the two
+/// moves open to a requester: change something about itself, or ask someone
+/// else. Either way the message is a stable constant; failure detail stays in
+/// the responder's log.
 pub(crate) fn root_key_answer_rpc_error(error: anyhow::Error) -> ErrorObjectOwned {
-    let transient = error
+    let kind = error
         .chain()
         .find_map(|cause| cause.downcast_ref::<AdmissionDenial>())
-        .is_some_and(AdmissionDenial::is_transient);
-    if transient {
-        root_key_admission_unavailable_rpc_error(error)
-    } else {
-        root_key_request_denied_rpc_error(error)
+        .map(AdmissionDenial::kind);
+    match kind {
+        Some(DenialKind::ResponderMisconfigured | DenialKind::ResponderTransient) => {
+            root_key_admission_unavailable_rpc_error(error)
+        }
+        // A verdict on the requester, and every failure that carries no typed
+        // denial — evidence verification among them, whatever its cause.
+        // TODO: attribute evidence failures the way admission denials are.
+        // Verification fetches collateral over the network, so a fetch this
+        // responder could not complete is its own fault, yet it reaches the
+        // requester here as a terminal verdict on evidence that was fine.
+        Some(DenialKind::RequesterVerdict) | None => root_key_request_denied_rpc_error(error),
     }
 }
 
@@ -104,7 +110,7 @@ mod tests {
     }
 
     #[test]
-    fn transient_admission_failures_map_to_unavailable_others_to_denied() {
+    fn responder_faults_map_to_unavailable_others_to_denied() {
         use seismic_attestation::AttestationError;
 
         // The nesting a real handshake produces: the bootstrap wraps the
@@ -118,6 +124,16 @@ mod tests {
         let unavailable =
             root_key_answer_rpc_error(handshake_error(AdmissionDenial::ChainRegressedToGenesis));
         assert_eq!(unavailable.code(), ROOT_KEY_ADMISSION_UNAVAILABLE_CODE);
+
+        // A responder on the wrong chain is unavailable rather than denying,
+        // even though waiting cannot fix it: the requester's move is to ask
+        // another peer, and its evidence is not what failed.
+        let wrong_chain =
+            root_key_answer_rpc_error(handshake_error(AdmissionDenial::ChainGenesisMismatch {
+                expected: alloy_primitives::B256::repeat_byte(0xb0),
+                found: alloy_primitives::B256::repeat_byte(0xef),
+            }));
+        assert_eq!(wrong_chain.code(), ROOT_KEY_ADMISSION_UNAVAILABLE_CODE);
 
         let verdict = root_key_answer_rpc_error(handshake_error(
             AdmissionDenial::RegistryNotAccepted(alloy_primitives::B256::ZERO.into()),

--- a/bin/attestation-service/src/server.rs
+++ b/bin/attestation-service/src/server.rs
@@ -11,7 +11,7 @@ use crate::{
         internal_rpc_error, invalid_root_key_request_rpc_error, root_key_answer_rpc_error,
     },
 };
-use alloy_primitives::Address;
+use alloy_primitives::{Address, B256};
 use anyhow::Context as _;
 use jsonrpsee::{
     core::{RpcResult, async_trait},
@@ -156,12 +156,13 @@ pub async fn start_server(addr: SocketAddr, args: Args) -> anyhow::Result<()> {
     info!("Derived network_id {network_id} from {NETWORK_MANIFEST_PATH}");
 
     // Joining peers are admitted by the live on-chain policy: the manifest
-    // names the registry, our own reth answers for it. Construction is lazy —
-    // no connection until a join arrives — so serving never waits on reth;
-    // a join that beats reth's startup is denied (fail closed) and the
-    // requester retries.
+    // names the registry and the genesis that identifies the chain to read it
+    // on, our own reth answers for both. Construction is lazy — no connection
+    // until a join arrives — so serving never waits on reth; a join that beats
+    // reth's startup is denied (fail closed) and the requester retries.
     let registry = Address::from(manifest.measurements.contracts.registry);
-    let mut admission = RegistryAdmission::new(args.reth_rpc_url.clone(), registry);
+    let pinned_genesis = B256::from(manifest.eth.genesis_hash);
+    let mut admission = RegistryAdmission::new(args.reth_rpc_url.clone(), registry, pinned_genesis);
     if let Some(max_policy_age) = args.max_policy_age {
         warn!(
             "Admission accepts a finalized policy view no older than {max_policy_age:?} (test override)"
@@ -169,7 +170,8 @@ pub async fn start_server(addr: SocketAddr, args: Args) -> anyhow::Result<()> {
         admission = admission.with_max_policy_age(max_policy_age);
     }
     info!(
-        "Gating joining peers via MeasurementRegistry at {registry} over {}",
+        "Gating joining peers via MeasurementRegistry at {registry} over {}, \
+         on the chain with genesis {pinned_genesis}",
         args.reth_rpc_url
     );
 

--- a/bin/attestation-service/tests/admission.rs
+++ b/bin/attestation-service/tests/admission.rs
@@ -16,7 +16,9 @@
 //!   responder — the policy is read live from the chain, never cached;
 //! - an **unknown** tuple is denied (`-32001`);
 //! - an unreachable (`-32002`) or **stale** (`-32002`, via a tightened
-//!   policy-age bound) local reth fails closed.
+//!   policy-age bound) local reth fails closed;
+//! - a local reth serving a chain the manifest does not commit to fails closed
+//!   (`-32002`), exercising the pinned `eth.genesis_hash` end to end.
 //!
 //! The genesis is generated at runtime, not committed: evidence carries the
 //! runner's real PCRs, so the seeded policy is compiled either from the
@@ -34,9 +36,9 @@
 //! opens the raw single-open TPM device, so every test carries
 //! `serial(attestation_evidence)` and runs its handshakes sequentially.
 //!
-//! Requires sudo (TPM access), the `/run/seismic` manifest handoff, and a
-//! `seismic-reth` binary (`SEISMIC_RETH_BIN`, `$PATH`, or a sibling
-//! checkout's target directory).
+//! Requires sudo (TPM access, and the `/run/seismic` handoff directory the
+//! suite writes each network's manifest into) plus a `seismic-reth` binary
+//! (`SEISMIC_RETH_BIN`, `$PATH`, or a sibling checkout's target directory).
 
 use std::{
     collections::HashMap,
@@ -84,11 +86,19 @@ use seismic_measurement_admission::{
 };
 use seismic_measurement_registry_client::{MEASUREMENT_REGISTRY_ADDRESS, MeasurementRegistry};
 
-/// The manifest both sides of every handshake derive their network ID from;
-/// the runner script installs the same fixture at the server's fixed
-/// `/run/seismic` handoff path.
-const NETWORK_MANIFEST: &[u8] =
+/// The manifest both sides of every handshake derive their network ID from.
+/// The fixture is a template here: a network's identity commits to its genesis
+/// block, and this suite mints a fresh genesis per test — the seeded policy and
+/// the stamped timestamp both move its hash — so `eth.genesis_hash` is filled
+/// in from the live node by [`install_network_manifest`].
+const NETWORK_MANIFEST_TEMPLATE: &[u8] =
     include_bytes!("../../../crates/network-manifest/fixtures/network-manifest-v1.json");
+
+/// Where the image drops the manifest and the service reads it from.
+const NETWORK_MANIFEST_PATH: &str = "/run/seismic/conf/network-manifest.json";
+/// A genesis hash no seeded node here can serve, so a manifest pinning it
+/// names a chain the responder's local reth is not on.
+const FOREIGN_GENESIS: B256 = B256::repeat_byte(0xef);
 
 /// `MeasurementAuthorityDev` genesis predeploy (the manifest's
 /// `measurements.contracts.authority`).
@@ -147,6 +157,7 @@ async fn test_accepted_tuple_wraps_once_then_deprecation_applies_live() {
         .as_b256();
     let node = launch_seeded_reth("suite-observed", &pcrs);
     let provider = wait_for_rpc(&node).await;
+    let manifest = install_network_manifest(&provider).await;
     wait_past_genesis(&provider).await;
 
     let responder = start_service("responder", 30, None, &node.http_url, None).await;
@@ -185,7 +196,7 @@ async fn test_accepted_tuple_wraps_once_then_deprecation_applies_live() {
 
     // Same responder process, no restart: the live chain read alone flips
     // the verdict, and the denied handshake never reaches the custodian.
-    let denied = request_root_key(&responder.url).await;
+    let denied = request_root_key(&responder.url, &manifest).await;
     assert_eq!(denial_code(denied), ROOT_KEY_REQUEST_DENIED_CODE);
     assert_eq!(
         responder.wrap_count.load(Ordering::SeqCst),
@@ -218,15 +229,16 @@ async fn test_unknown_tuple_is_denied_and_reth_outage_fails_closed() {
     // match these values, so the runner's admission ID is unknown on chain.
     let mut node = launch_seeded_reth("suite-synthetic", &synthetic_pcrs());
     let provider = wait_for_rpc(&node).await;
+    let manifest = install_network_manifest(&provider).await;
     wait_past_genesis(&provider).await;
 
     let responder = start_service("responder", 32, None, &node.http_url, None).await;
-    let denied = request_root_key(&responder.url).await;
+    let denied = request_root_key(&responder.url, &manifest).await;
     assert_eq!(denial_code(denied), ROOT_KEY_REQUEST_DENIED_CODE);
     assert_eq!(responder.wrap_count.load(Ordering::SeqCst), 0);
 
     node.stop();
-    let unavailable = request_root_key(&responder.url).await;
+    let unavailable = request_root_key(&responder.url, &manifest).await;
     assert_eq!(
         denial_code(unavailable),
         ROOT_KEY_ADMISSION_UNAVAILABLE_CODE
@@ -250,6 +262,7 @@ async fn test_stale_policy_view_fails_closed() {
     let pcrs = observed_pcrs().await;
     let node = launch_seeded_reth("suite-observed", &pcrs);
     let provider = wait_for_rpc(&node).await;
+    let manifest = install_network_manifest(&provider).await;
     wait_past_genesis(&provider).await;
 
     let responder = start_service(
@@ -266,8 +279,39 @@ async fn test_stale_policy_view_fails_closed() {
     // within the handshake sees a stale chain.
     wait_finalized_older_than(&provider, STALE_MAX_POLICY_AGE * 3).await;
 
-    let stale = request_root_key(&responder.url).await;
+    let stale = request_root_key(&responder.url, &manifest).await;
     assert_eq!(denial_code(stale), ROOT_KEY_ADMISSION_UNAVAILABLE_CODE);
+    assert_eq!(responder.wrap_count.load(Ordering::SeqCst), 0);
+    responder.handle.abort();
+}
+
+/// A responder reading its policy off a chain its manifest does not commit to
+/// refuses to decide. Everything else is the accepted path — the node is
+/// seeded from the runner's observed PCRs, mining, and fresh — so the pinned
+/// genesis alone turns the answer into temporarily unavailable, and it does so
+/// on the manifest field the service reads at startup.
+#[serial_test::serial(attestation_evidence)]
+#[tokio::test]
+async fn test_foreign_pinned_genesis_fails_closed() {
+    init_tracing();
+    if !is_sudo() {
+        panic!("test_foreign_pinned_genesis_fails_closed: requires sudo");
+    }
+
+    let pcrs = observed_pcrs().await;
+    let node = launch_seeded_reth("suite-observed", &pcrs);
+    let provider = wait_for_rpc(&node).await;
+    let manifest = install_manifest_pinning(FOREIGN_GENESIS);
+    // Past genesis the gate reads block 0 through a query of its own, the
+    // branch a forged chain with a progressing head aims at.
+    wait_past_genesis(&provider).await;
+
+    let responder = start_service("responder", 34, None, &node.http_url, None).await;
+    let unavailable = request_root_key(&responder.url, &manifest).await;
+    assert_eq!(
+        denial_code(unavailable),
+        ROOT_KEY_ADMISSION_UNAVAILABLE_CODE
+    );
     assert_eq!(responder.wrap_count.load(Ordering::SeqCst), 0);
     responder.handle.abort();
 }
@@ -495,6 +539,35 @@ async fn wait_for_rpc(node: &RethNode) -> RootProvider {
     }
 }
 
+/// Render the manifest for the chain `provider` serves, drop it at the
+/// service's handoff path, and return the exact bytes written.
+///
+/// Pinning `eth.genesis_hash` to this node's block 0 is what lets the
+/// responder's admission read its registry at all: the gate refuses to answer
+/// on a chain the manifest does not commit to. `network_id` is SHA-256 over the
+/// file's bytes, so callers must hash the returned bytes rather than
+/// re-serialize the manifest.
+async fn install_network_manifest(provider: &RootProvider) -> Vec<u8> {
+    let genesis = provider
+        .get_block_by_number(alloy::eips::BlockNumberOrTag::Earliest)
+        .await
+        .expect("genesis query")
+        .expect("dev node serves block 0");
+    install_manifest_pinning(genesis.header.hash)
+}
+
+/// Render the manifest that pins `genesis_hash`, drop it at the service's
+/// handoff path, and return the exact bytes written.
+fn install_manifest_pinning(genesis_hash: B256) -> Vec<u8> {
+    let mut manifest: serde_json::Value =
+        serde_json::from_slice(NETWORK_MANIFEST_TEMPLATE).expect("manifest template JSON");
+    manifest["eth"]["genesis_hash"] = serde_json::Value::from(format!("{genesis_hash:#x}"));
+    let bytes = serde_json::to_vec_pretty(&manifest).expect("serialize manifest");
+    fs::write(NETWORK_MANIFEST_PATH, &bytes)
+        .unwrap_or_else(|e| panic!("writing {NETWORK_MANIFEST_PATH}: {e}"));
+    bytes
+}
+
 /// Wait until `latest` is past block 0: the admission gate's genesis window
 /// admits unconditionally at block 0, so every rejection scenario starts
 /// after the chain has advanced.
@@ -676,11 +749,14 @@ async fn wait_for_health(
 /// runner's real quote, POSTed to `responder_url`. The denial scenarios ride
 /// this instead of a joiner service, whose fetch loop would retry denials
 /// forever. The ephemeral key is fixed — no response is ever unwrapped here.
-async fn request_root_key(responder_url: &str) -> Result<Vec<u8>, jsonrpsee::core::client::Error> {
+async fn request_root_key(
+    responder_url: &str,
+    manifest: &[u8],
+) -> Result<Vec<u8>, jsonrpsee::core::client::Error> {
     let eph_sk = secp256k1::SecretKey::from_slice(&[0x42u8; 32]).expect("valid test secret key");
     let eph_pk = secp256k1::PublicKey::from_secret_key(&secp256k1::Secp256k1::new(), &eph_sk);
     let request = build_root_key_request(
-        &NetworkId::from_manifest_bytes(NETWORK_MANIFEST),
+        &NetworkId::from_manifest_bytes(manifest),
         &eph_pk,
         AttestationType::AzureTdx,
     )

--- a/bin/attestation-service/tests/evidence/utils.rs
+++ b/bin/attestation-service/tests/evidence/utils.rs
@@ -1,4 +1,6 @@
+use alloy_primitives::B256;
 use jsonrpsee::{RpcModule, server::ServerBuilder};
+use seismic_attestation::NetworkManifestV1;
 use seismic_attestation_service::Args;
 use seismic_custodian_ipc::server::{MethodAcl, bind, serve};
 use seismic_custodian_service::{dispatch::dispatch, state::CustodianState};
@@ -16,15 +18,30 @@ pub fn get_args(n: u16, peers: Vec<String>, custodian_socket: PathBuf, reth_rpc_
     }
 }
 
+/// The genesis block the fixture manifest commits to, read from the fixture
+/// itself so the stand-in chain and the manifest the service loads can never
+/// disagree.
+fn fixture_genesis_hash() -> B256 {
+    const FIXTURE: &[u8] =
+        include_bytes!("../../../../crates/network-manifest/fixtures/network-manifest-v1.json");
+    B256::from(
+        NetworkManifestV1::from_json_bytes(FIXTURE)
+            .expect("fixture manifest is valid")
+            .eth
+            .genesis_hash,
+    )
+}
+
 /// Serve a permissive stand-in for the node-local reth that answers the
-/// responder's admission reads: `eth_getBlockByNumber` answers the `latest`
-/// and `finalized` tag queries — and only those — with a fresh block past
-/// genesis (so the freshness gate passes), and every `eth_call` returns
-/// ABI-encoded `true`, so the runner's own measurements count as
-/// registry-accepted. These tests thereby exercise the full live-TEE
-/// admission path — verified evidence → admission ID → fresh chain state →
-/// registry query — while denial behavior is covered by the admission
-/// module's unit tests.
+/// responder's admission reads: `eth_getBlockByNumber` answers the `earliest`,
+/// `latest` and `finalized` tag queries — and only those — with the manifest's
+/// pinned genesis at block 0 (so the chain is the one `network_id` commits to)
+/// and a fresh block past genesis for the other two (so the freshness gate
+/// passes), and every `eth_call` returns ABI-encoded `true`, so the runner's
+/// own measurements count as registry-accepted. These tests thereby exercise
+/// the full live-TEE admission path — verified evidence → admission ID → fresh
+/// chain state → registry query — while denial behavior is covered by the
+/// admission module's unit tests.
 pub async fn spawn_accepting_registry() -> String {
     let server = ServerBuilder::default()
         .build("127.0.0.1:0")
@@ -32,24 +49,33 @@ pub async fn spawn_accepting_registry() -> String {
         .expect("bind mock registry endpoint");
     let addr = server.local_addr().expect("mock registry local addr");
     let mut module = RpcModule::new(());
+    let genesis_hash = fixture_genesis_hash();
     module
-        .register_method("eth_getBlockByNumber", |params, _, _| {
+        .register_method("eth_getBlockByNumber", move |params, _, _| {
             let (tag, _full_transactions): (String, bool) = params.parse()?;
-            if tag != "latest" && tag != "finalized" {
-                return Err(jsonrpsee::types::ErrorObjectOwned::owned(
-                    -32000,
-                    format!("mock reth serves only the latest and finalized tags, got {tag}"),
-                    None::<()>,
-                ));
-            }
             let mut block = alloy::rpc::types::Block::<alloy::rpc::types::Transaction>::default();
-            block.header.inner.number = 1;
-            // Milliseconds, like real Seismic headers: the freshness gate
-            // reads the timestamp in that unit.
-            block.header.inner.timestamp = std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .expect("system clock after epoch")
-                .as_millis() as u64;
+            match tag.as_str() {
+                "earliest" => block.header.hash = genesis_hash,
+                "latest" | "finalized" => {
+                    block.header.inner.number = 1;
+                    // Milliseconds, like real Seismic headers: the freshness
+                    // gate reads the timestamp in that unit.
+                    block.header.inner.timestamp = std::time::SystemTime::now()
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .expect("system clock after epoch")
+                        .as_millis() as u64;
+                }
+                other => {
+                    return Err(jsonrpsee::types::ErrorObjectOwned::owned(
+                        -32000,
+                        format!(
+                            "mock reth serves only the earliest, latest and finalized tags, \
+                             got {other}"
+                        ),
+                        None::<()>,
+                    ));
+                }
+            }
             Ok(serde_json::to_value(block).expect("serialize mock block"))
         })
         .expect("register eth_getBlockByNumber");

--- a/crates/measurement-admission/SPEC.md
+++ b/crates/measurement-admission/SPEC.md
@@ -532,6 +532,12 @@ A responder MUST:
 - read `isAccepted(admissionId)` from the registry address in the network
   manifest, on local chain state;
 - authorize the join only when that call succeeds and returns true;
+- check that local chain state is this network's chain: block 0 MUST hash to
+  the manifest's `eth.genesis_hash`, on every decision. The genesis file is
+  host-supplied and the responder is the only party able to appraise it at
+  decision time; the pin is what makes the read an appraisal against the
+  accepted set that `network_id` commits to, rather than against whatever
+  policy the local node was booted with;
 - treat local chain state as policy only while it satisfies the readiness
   and freshness gate. A stale or eclipsed node MUST NOT admit a peer,
   because emergency deprecation must not be bypassable;

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -30,8 +30,9 @@ responder's contract-backed bootstrap admission against real `seismic-reth`
 dev nodes seeded with a measurement policy compiled at runtime from the
 runner's own quoted PCRs: an accepted tuple authorizes exactly one root-key
 wrap, an on-chain deprecation denies the next handshake without a service
-restart, an unknown tuple is denied, and an unreachable or stale chain fails
-closed. It additionally needs a `seismic-reth` binary (`SEISMIC_RETH_BIN`).
+restart, an unknown tuple is denied, and an unreachable chain, a stale chain,
+or a chain the manifest does not commit to fails closed. It additionally needs
+a `seismic-reth` binary (`SEISMIC_RETH_BIN`).
 
 ## Requirements
 
@@ -42,9 +43,11 @@ closed. It additionally needs a `seismic-reth` binary (`SEISMIC_RETH_BIN`).
   TPM. On the CI image, the script asks Supervisor to stop it if present.
 - A Rust toolchain.
 
-Each script installs the checked-in network-manifest fixture under
-`/run/seismic/conf`, builds its test binary as the runner user, and
-executes it with `sudo`.
+Each script prepares the `/run/seismic/conf` handoff directory, builds its
+test binary as the runner user, and executes it with `sudo`. The evidence
+script installs the checked-in network-manifest fixture there; the admission
+tests write their own manifest, because a network's identity commits to its
+genesis hash and each of those tests mints a fresh genesis.
 
 ## Running
 

--- a/scripts/run_attestation_service_admission_tdx_tests.sh
+++ b/scripts/run_attestation_service_admission_tdx_tests.sh
@@ -15,11 +15,10 @@ export RUST_LOG=info
 echo "🚀 Starting attestation-service admission tests..."
 
 # The image service normally creates these runtime directories. Ensure they
-# also exist when the test job starts from a clean runner boot.
+# also exist when the test job starts from a clean runner boot. The manifest
+# that lands here is written by the tests themselves: each one pins the genesis
+# of the node it just generated, so only the test can render it.
 sudo install -d -m 0755 /run/seismic/conf
-sudo install -m 0644 \
-    crates/network-manifest/fixtures/network-manifest-v1.json \
-    /run/seismic/conf/network-manifest.json
 
 # Free the TPM before the tests start their handshakes: quote generation
 # opens the raw TPM device (/dev/tpm0), which the kernel hands to one process


### PR DESCRIPTION
Fixes SEI-264

Admission reads the live policy from local reth — isAccepted at a provably fresh finalized block — and nothing bound that reth to the network it serves. eth.genesis_hash sat in the manifest unused at runtime, and tdx-init validates only the chain id of the genesis a host POSTs. So a host could boot its reth on a genesis of its own choosing, with a registry alloc accepting whatever it likes, and have its own enclave hand root_key to any guest on genuine Azure TDX hardware: at block 0 the genesis window reads the forged policy, and a forged chain driven over the engine API passes the freshness bound too, its timestamps being freshly minted.

Compare block 0 against the manifest's eth.genesis_hash on every decision, and deny on mismatch. start_server already parses the manifest, so the hash threads into RegistryAdmission beside the registry address. At genesis the block the policy is read at is block 0 itself, so the pin is checked on it directly; past genesis it costs one eth_getBlockByNumber(earliest), which a forged chain with a progressing head otherwise slips past. The hash is never cached, so a host that restarts reth onto another genesis is caught on the next handshake. Every chain reth can serve is then rooted at the pinned genesis, and reth validates state transitions itself: reaching a policy the network never authorized needs the authority key, not a JSON edit.

The new denial is the responder's own fault and no retry fixes it, a class that did not exist before. Classify denials once rather than grow a second predicate: kind() is one exhaustive match onto RequesterVerdict, ResponderMisconfigured, or ResponderTransient; the retry loop asks the class whether to try again, and the wire layer maps class to code. A denial added later cannot inherit a class by omission — least of all the requester verdict, which tells a healthy joiner to stop asking.

The mocked unit tests deny a foreign genesis in both branches, and hold the denial as final and as taken before the registry is consulted.

The admission suite mints a genesis per test, so it renders the manifest from the node it just booted and writes it to the handoff path, moving that install out of the runner script and into the test that depends on it. A fourth scenario pins a genesis the node never had and asserts the responder answers unavailable without wrapping the key.

The evidence suite's reth stand-in serves the earliest tag as the fixture manifest's pinned genesis, read from the fixture itself so the stand-in chain and the manifest cannot drift apart.

SPEC.md section 11 gains the matching obligation: a responder MUST read the policy on the chain the manifest commits to, checked on every decision.