### PR TITLE
feat(attestation-service): attribute answer failures and split the requester verdict

### DIFF
--- a/bin/attestation-service/src/admission.rs
+++ b/bin/attestation-service/src/admission.rs
@@ -100,11 +100,21 @@ pub enum AdmissionDenial {
 /// Whose problem a denial is, and whether time alone can change it. Both
 /// consumers of a denial read this: the retry loop below asks whether to try
 /// again, and the wire layer asks what to tell the requester.
+///
+/// The two requester verdicts answer the two questions a handshake asks of the
+/// requester in order — did a usable identity come out of its evidence, and is
+/// that identity accepted — because the remedies differ and each belongs to a
+/// different party.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DenialKind {
-    /// A verdict on the requester: its evidence was appraised and refused, and
-    /// the same image asking again gets the same answer.
-    RequesterVerdict,
+    /// A verdict on the requester, reached before any identity was: nothing
+    /// the network can appraise came out of its evidence. Its own operator
+    /// investigates its attestation stack.
+    RequesterEvidenceUnusable,
+    /// A verdict on the requester's identity: the evidence yielded an
+    /// admission ID, and the network does not accept it. Its own operator
+    /// launches a guest whose admission ID the registry accepts.
+    RequesterIdentityNotAccepted,
     /// The responder cannot decide, and no waiting changes that: it reads a
     /// chain the network manifest does not commit to until an operator gives
     /// it the right one. The requester's evidence is not what failed, so its
@@ -125,13 +135,17 @@ impl DenialKind {
 
 impl AdmissionDenial {
     /// Classify this denial. One exhaustive match, so a denial added later
-    /// cannot inherit a class by omission — least of all the requester
-    /// verdict, which tells a healthy joiner to stop asking.
+    /// cannot inherit a class by omission — least of all a requester verdict,
+    /// which tells a healthy joiner to stop asking.
     pub fn kind(&self) -> DenialKind {
         match self {
-            Self::UnsupportedAttestationType(_)
-            | Self::MissingPcr(_)
-            | Self::RegistryNotAccepted(_) => DenialKind::RequesterVerdict,
+            // No admission ID came out of the evidence: a non-Azure
+            // attestation type has no admission schema at all, and a PCR bank
+            // missing a schema register yields no identity to appraise.
+            Self::UnsupportedAttestationType(_) | Self::MissingPcr(_) => {
+                DenialKind::RequesterEvidenceUnusable
+            }
+            Self::RegistryNotAccepted(_) => DenialKind::RequesterIdentityNotAccepted,
             Self::ChainGenesisMismatch { .. } => DenialKind::ResponderMisconfigured,
             Self::RegistryQueryFailed { .. }
             | Self::ChainQueryFailed { .. }

--- a/bin/attestation-service/src/bootstrap.rs
+++ b/bin/attestation-service/src/bootstrap.rs
@@ -56,11 +56,11 @@ use anyhow::{Context, Result};
 use rand::{TryRngCore as _, rngs::OsRng};
 use secp256k1::PublicKey;
 use seismic_attestation::{
-    AdmissionPredicate, AttestationExchangeMessage, AttestationType, NetworkId,
+    AdmissionPredicate, AttestationError, AttestationExchangeMessage, AttestationType, NetworkId,
     bindings::{binding64_from_digest32, root_key_request_binding, root_key_response_binding},
     generate_evidence, verify_evidence_with_predicate,
 };
-use seismic_custodian_ipc::CustodianClient;
+use seismic_custodian_ipc::{CustodianClient, IpcError};
 use serde::{Deserialize, Serialize};
 
 /// The requester's half of the handshake: a fresh nonce + ephemeral pubkey,
@@ -121,6 +121,40 @@ pub fn build_root_key_request(
     })
 }
 
+/// Why a responder could not answer a root-key request: one variant per step of
+/// [`answer_root_key_request`], because which step failed is what says whose
+/// problem the failure is. Only the first appraises the requester; the rest is
+/// this responder's own machinery. Verifying the requester's evidence and
+/// minting this node's own both surface an [`AttestationError`], and the step
+/// they came from is the only thing that separates them.
+#[derive(Debug, thiserror::Error)]
+pub enum AnswerError {
+    /// The requester's evidence failed verification, or the admission predicate
+    /// denied the verified guest.
+    #[error("verifying requester attestation evidence: {source}")]
+    VerifyRequester {
+        #[source]
+        source: AttestationError,
+    },
+    /// The custodian would not wrap the root key.
+    #[error("wrapping root key for peer: {source}")]
+    WrapRootKey {
+        #[source]
+        source: IpcError,
+    },
+    #[error("custodian returned an invalid responder ephemeral key: {source}")]
+    ResponderEphemeralKey {
+        #[source]
+        source: secp256k1::Error,
+    },
+    /// This responder could not attest its own half of the exchange.
+    #[error("generating responder attestation evidence: {source}")]
+    GenerateResponderEvidence {
+        #[source]
+        source: AttestationError,
+    },
+}
+
 /// Responder step: verify the requester's evidence, have the custodian wrap
 /// the root key for it, and attest the response.
 ///
@@ -137,7 +171,7 @@ pub async fn answer_root_key_request(
     custodian: &mut CustodianClient,
     admission: &impl AdmissionPredicate,
     attestation_type: AttestationType,
-) -> Result<RootKeyResponse> {
+) -> Result<RootKeyResponse, AnswerError> {
     // 1. Verify the requester's quote and appraise its measurements,
     //    recomputing the expected binding from *our* network_id + the
     //    request's claimed fields.
@@ -149,7 +183,7 @@ pub async fn answer_root_key_request(
         admission,
     )
     .await
-    .context("verifying requester attestation evidence")?;
+    .map_err(|source| AnswerError::VerifyRequester { source })?;
 
     // 2. Verification succeeded: authorize the custodian to wrap the root key
     //    to the requester's attested ephemeral key, with the verified request
@@ -158,9 +192,9 @@ pub async fn answer_root_key_request(
     let wrap = custodian
         .wrap_root_key(expected, request.eph_pk_b.serialize())
         .await
-        .context("wrapping root key for peer")?;
+        .map_err(|source| AnswerError::WrapRootKey { source })?;
     let eph_pk_a = PublicKey::from_slice(&wrap.responder_eph_pk)
-        .context("custodian returned an invalid responder ephemeral key")?;
+        .map_err(|source| AnswerError::ResponderEphemeralKey { source })?;
 
     // 3. Attest over the response transcript, committing to the ciphertext.
     let binding = root_key_response_binding(
@@ -170,7 +204,7 @@ pub async fn answer_root_key_request(
         &wrap.wrapped,
     );
     let evidence = generate_evidence(attestation_type, binding64_from_digest32(binding))
-        .context("generating responder attestation evidence")?;
+        .map_err(|source| AnswerError::GenerateResponderEvidence { source })?;
 
     Ok(RootKeyResponse {
         eph_pk_a,

--- a/bin/attestation-service/src/rpc_error.rs
+++ b/bin/attestation-service/src/rpc_error.rs
@@ -1,22 +1,47 @@
 //! The service's JSON-RPC error contract.
 //!
-//! Four codes reach a caller, and a joining node in another process decides
-//! what to do next from the code alone: whether its own evidence was refused,
-//! or whether this responder simply could not answer. Every message is a
-//! stable constant — an unauthenticated caller learns the outcome and nothing
-//! about why — so the failure detail lives in this responder's log instead.
+//! Five codes reach a caller, and a joining node in another process decides
+//! what to do next from the code alone: whether its evidence yielded no
+//! appraisable identity, whether that identity is not accepted, or whether this
+//! responder could not answer. Every message is a stable constant — an
+//! unauthenticated caller learns the outcome and nothing about why — so the
+//! failure detail lives in this responder's log instead.
+//!
+//! The two denials are terminal, read by the joiner's operator as *your*
+//! configuration is wrong, so each is only sent when this responder positively
+//! attributed the failure. Anything it cannot attribute answers as an internal
+//! error, blaming neither party.
+//!
+//! Both requester-facing boundaries are checkable by the caller anyway: DCAP
+//! verification is local and offline, and the accepted set is a public
+//! `isAccepted` view on a public chain. Naming which of the two it hit hands a
+//! caller nothing it could not determine for itself.
 
-use crate::admission::{AdmissionDenial, DenialKind};
+use crate::{
+    admission::{AdmissionDenial, DenialKind},
+    bootstrap::AnswerError,
+};
 use jsonrpsee::types::{ErrorCode, ErrorObjectOwned};
+use seismic_attestation::{
+    AttestationError, BackendAttestationError, DcapVerificationError, MaaError,
+};
 use std::fmt::Debug;
 use tracing::{error, warn};
 
-/// Terminal verdict: the requester does not get the key, and retrying with
-/// the same image cannot change the answer.
-pub const ROOT_KEY_REQUEST_DENIED_CODE: i32 = -32001;
-/// The responder could not decide, because its own chain or registry read
-/// produced no usable answer. The requester's evidence is not what failed:
-/// worth retrying — against another peer, or this responder later.
+/// Terminal verdict on the requester's evidence: no identity the network can
+/// appraise came out of it, so retrying with the same image cannot change the
+/// answer. This code sends a joiner's operator to inspect its own attestation
+/// stack, so only a failure attributed to the evidence is answered with it.
+pub const ROOT_KEY_EVIDENCE_DENIED_CODE: i32 = -32001;
+/// Terminal verdict on the requester's identity: its evidence verified and
+/// yielded an admission ID the network does not accept. Nothing is wrong with
+/// its attestation stack — this code sends a joiner's operator to launch a
+/// guest whose admission ID the registry accepts.
+pub const ROOT_KEY_IDENTITY_DENIED_CODE: i32 = -32003;
+/// The responder could not decide, because its own chain, registry read, or
+/// collateral infrastructure produced no usable answer. The requester's
+/// evidence is not what failed: worth retrying — against another peer, or this
+/// responder later.
 pub const ROOT_KEY_ADMISSION_UNAVAILABLE_CODE: i32 = -32002;
 
 pub(crate) fn invalid_root_key_request_rpc_error(error: impl Debug) -> ErrorObjectOwned {
@@ -37,11 +62,20 @@ pub(crate) fn internal_rpc_error(operation: &'static str, error: impl Debug) -> 
     )
 }
 
-pub(crate) fn root_key_request_denied_rpc_error(error: impl Debug) -> ErrorObjectOwned {
-    warn!(?error, "root-key request denied");
+pub(crate) fn root_key_evidence_denied_rpc_error(error: impl Debug) -> ErrorObjectOwned {
+    warn!(?error, "root-key evidence denied");
     ErrorObjectOwned::owned(
-        ROOT_KEY_REQUEST_DENIED_CODE,
-        "Root-key request denied",
+        ROOT_KEY_EVIDENCE_DENIED_CODE,
+        "Root-key evidence denied",
+        None::<()>,
+    )
+}
+
+pub(crate) fn root_key_identity_denied_rpc_error(error: impl Debug) -> ErrorObjectOwned {
+    warn!(?error, "root-key admission identity denied");
+    ErrorObjectOwned::owned(
+        ROOT_KEY_IDENTITY_DENIED_CODE,
+        "Root-key admission identity denied",
         None::<()>,
     )
 }
@@ -56,26 +90,129 @@ pub(crate) fn root_key_admission_unavailable_rpc_error(error: impl Debug) -> Err
 }
 
 /// Route a failed root-key answer to its wire error, by what the failure says
-/// about the two parties (see [`DenialKind`]). The two codes carry the two
-/// moves open to a requester: change something about itself, or ask someone
-/// else. Either way the message is a stable constant; failure detail stays in
-/// the responder's log.
-pub(crate) fn root_key_answer_rpc_error(error: anyhow::Error) -> ErrorObjectOwned {
-    let kind = error
-        .chain()
-        .find_map(|cause| cause.downcast_ref::<AdmissionDenial>())
-        .map(AdmissionDenial::kind);
-    match kind {
+/// about the two parties (see [`DenialKind`]). Each code carries one move: fix
+/// your attestation stack, get your identity accepted, or ask someone else. The
+/// message is a stable constant either way; failure detail stays in the
+/// responder's log.
+///
+/// A failure neither party can be held to answers as an internal error, the
+/// same code this service already returns when its own custodian call fails.
+/// Both denials are terminal — a joiner's operator reads them as *your*
+/// configuration is wrong — so a responder that cannot attribute its own
+/// failure must not reach for one: it would be telling a healthy joiner to stop
+/// asking on no evidence at all, the very thing the attribution below exists to
+/// prevent. Unattributed means neither side is blamed, and the joiner's move is
+/// the same as for an unavailable responder: another peer.
+pub(crate) fn root_key_answer_rpc_error(error: AnswerError) -> ErrorObjectOwned {
+    match answer_failure_kind(&error) {
         Some(DenialKind::ResponderMisconfigured | DenialKind::ResponderTransient) => {
             root_key_admission_unavailable_rpc_error(error)
         }
-        // A verdict on the requester, and every failure that carries no typed
-        // denial — evidence verification among them, whatever its cause.
-        // TODO: attribute evidence failures the way admission denials are.
-        // Verification fetches collateral over the network, so a fetch this
-        // responder could not complete is its own fault, yet it reaches the
-        // requester here as a terminal verdict on evidence that was fine.
-        Some(DenialKind::RequesterVerdict) | None => root_key_request_denied_rpc_error(error),
+        Some(DenialKind::RequesterIdentityNotAccepted) => root_key_identity_denied_rpc_error(error),
+        Some(DenialKind::RequesterEvidenceUnusable) => root_key_evidence_denied_rpc_error(error),
+        None => internal_rpc_error("answering the root-key request", error),
+    }
+}
+
+/// What a failed answer says about the two parties. One arm per handshake step,
+/// so a verdict can only come from the step that actually appraised the
+/// requester; everything the responder does for itself blames nobody.
+fn answer_failure_kind(error: &AnswerError) -> Option<DenialKind> {
+    match error {
+        AnswerError::VerifyRequester { source } => verification_failure_kind(source),
+        AnswerError::WrapRootKey { .. }
+        | AnswerError::ResponderEphemeralKey { .. }
+        | AnswerError::GenerateResponderEvidence { .. } => None,
+    }
+}
+
+/// Attribute a failure of verifying the requester's evidence.
+fn verification_failure_kind(error: &AttestationError) -> Option<DenialKind> {
+    match error {
+        // The predicate's denial is typed, but it travels boxed: predicates are
+        // caller-owned, so `AdmissionPredicate` cannot name their error. This is
+        // the one place a downcast is the only way through, and a denial that is
+        // not ours is one we cannot classify.
+        AttestationError::AdmissionDenied(denial) => {
+            Some(denial.downcast_ref::<AdmissionDenial>()?.kind())
+        }
+        AttestationError::Backend(backend) => backend_failure_kind(backend),
+        // This service's own policy document and the backend's measurement
+        // output: neither party's problem, and no verdict either way.
+        AttestationError::PolicyFormat(_)
+        | AttestationError::MissingMeasurements { .. }
+        | AttestationError::MeasurementTypeMismatch { .. } => None,
+    }
+}
+
+/// Attribute a backend verification failure, descending into the enum. The
+/// backend mixes both parties: most of it is pure computation over the bytes the
+/// requester supplied, but collateral fetching is the responder's own
+/// infrastructure. A responder whose PCCS is unreachable, or one deployed
+/// without one, must not answer a healthy joiner with a terminal verdict.
+///
+/// The enum is upstream's and can grow, so both sides are named explicitly and
+/// anything else stays unattributed: an upstream bump can only ever widen the
+/// unattributed set, never silently move a caller onto a verdict. Two variants
+/// need a descent of their own — the Azure verifier funnels every Azure TDX
+/// outcome through `MaaError`, and the DCAP layer reports a collateral-cache
+/// failure a further level down.
+fn backend_failure_kind(backend: &BackendAttestationError) -> Option<DenialKind> {
+    match backend {
+        // Collateral could not be fetched, its cache erred, or the attestation
+        // provider did: nothing here appraised the requester's evidence.
+        BackendAttestationError::Reqwest(_)
+        | BackendAttestationError::Pccs(_)
+        | BackendAttestationError::AttestationProvider(_)
+        | BackendAttestationError::Maa(
+            MaaError::Reqwest(_) | MaaError::DcapVerification(DcapVerificationError::Pccs(_)),
+        ) => Some(DenialKind::ResponderTransient),
+        // Deployed without a collateral source, pointed at a provider URL it
+        // cannot use, or unable to read its own platform metadata.
+        BackendAttestationError::NoPccs
+        | BackendAttestationError::AttestationProviderUrl(_)
+        | BackendAttestationError::PlatformMetadata(_) => Some(DenialKind::ResponderMisconfigured),
+        // Offline appraisal of the evidence itself, whose verdict no collateral
+        // source or configuration could change: the quote and its DCAP chain,
+        // the vTPM quote and the AK certificate chain binding it, the transcript
+        // binding recomputed from this responder's own view, and the shape of
+        // the HCL report the identity has to be read out of.
+        BackendAttestationError::NoCertificate
+        | BackendAttestationError::X509Parse(_)
+        | BackendAttestationError::X509(_)
+        | BackendAttestationError::AttestationTypeNotAccepted
+        | BackendAttestationError::AttestationGivenWhenNoneExpected
+        | BackendAttestationError::DcapVerification(
+            DcapVerificationError::DcapQvl(_)
+            | DcapVerificationError::InputMismatch
+            | DcapVerificationError::SgxNotSupported,
+        )
+        | BackendAttestationError::Maa(
+            MaaError::DcapVerification(
+                DcapVerificationError::DcapQvl(_)
+                | DcapVerificationError::InputMismatch
+                | DcapVerificationError::SgxNotSupported,
+            )
+            | MaaError::Hcl(_)
+            | MaaError::AzureAttestationPayloadTooLarge { .. }
+            | MaaError::TpmQuoteVerify(_)
+            | MaaError::TdReportInputMismatch
+            | MaaError::ClaimsUserDataInputMismatch
+            | MaaError::ClaimsUserDataBadLength
+            | MaaError::ClaimsMissingUserData
+            | MaaError::ClaimsMissingHCLAkPub
+            | MaaError::AkFromClaimsNotEqualAkFromHcl
+            | MaaError::AkFromClaimsNotEqualAkFromCertificate
+            | MaaError::WebPki(_)
+            | MaaError::X509Parse(_)
+            | MaaError::X509(_)
+            | MaaError::Pem(_)
+            | MaaError::NotRsa
+            | MaaError::JwkParse
+            | MaaError::JwkConversion
+            | MaaError::CannotExtractMeasurementsFromQuote,
+        ) => Some(DenialKind::RequesterEvidenceUnusable),
+        _ => None,
     }
 }
 
@@ -89,9 +226,9 @@ mod tests {
         assert_eq!(invalid.code(), ErrorCode::InvalidParams.code());
         assert_eq!(invalid.message(), "Invalid root-key request");
 
-        let denied = root_key_request_denied_rpc_error("private verifier detail");
-        assert_eq!(denied.code(), ROOT_KEY_REQUEST_DENIED_CODE);
-        assert_eq!(denied.message(), "Root-key request denied");
+        let denied = root_key_evidence_denied_rpc_error("private verifier detail");
+        assert_eq!(denied.code(), ROOT_KEY_EVIDENCE_DENIED_CODE);
+        assert_eq!(denied.message(), "Root-key evidence denied");
 
         let unavailable = root_key_admission_unavailable_rpc_error("private chain detail");
         assert_eq!(unavailable.code(), ROOT_KEY_ADMISSION_UNAVAILABLE_CODE);
@@ -100,49 +237,142 @@ mod tests {
             "Root-key admission temporarily unavailable"
         );
 
+        let identity = root_key_identity_denied_rpc_error("private admission ID");
+        assert_eq!(identity.code(), ROOT_KEY_IDENTITY_DENIED_CODE);
+        assert_eq!(identity.message(), "Root-key admission identity denied");
+
         let internal = internal_rpc_error("generating evidence", "private backend detail");
         assert_eq!(internal.code(), ErrorCode::InternalError.code());
         assert_eq!(internal.message(), "Internal error");
 
-        for error in [invalid, denied, unavailable, internal] {
+        for error in [invalid, denied, identity, unavailable, internal] {
             assert!(!error.to_string().contains("private"));
         }
     }
 
+    /// A failure of the one step that appraises the requester.
+    fn verify_error(source: AttestationError) -> AnswerError {
+        AnswerError::VerifyRequester { source }
+    }
+
+    fn backend_error(backend: BackendAttestationError) -> AnswerError {
+        verify_error(AttestationError::Backend(backend))
+    }
+
+    /// A denial the predicate raised, boxed the way `AdmissionPredicate`
+    /// delivers it.
+    fn denial_error(denial: AdmissionDenial) -> AnswerError {
+        verify_error(AttestationError::AdmissionDenied(Box::new(denial)))
+    }
+
     #[test]
-    fn responder_faults_map_to_unavailable_others_to_denied() {
-        use seismic_attestation::AttestationError;
-
-        // The nesting a real handshake produces: the bootstrap wraps the
-        // attestation error in anyhow context, which carries the typed
-        // denial as a source.
-        let handshake_error = |denial: AdmissionDenial| {
-            anyhow::Error::new(AttestationError::AdmissionDenied(Box::new(denial)))
-                .context("verifying requester attestation evidence")
-        };
-
+    fn responder_chain_faults_map_to_unavailable() {
         let unavailable =
-            root_key_answer_rpc_error(handshake_error(AdmissionDenial::ChainRegressedToGenesis));
+            root_key_answer_rpc_error(denial_error(AdmissionDenial::ChainRegressedToGenesis));
         assert_eq!(unavailable.code(), ROOT_KEY_ADMISSION_UNAVAILABLE_CODE);
 
         // A responder on the wrong chain is unavailable rather than denying,
         // even though waiting cannot fix it: the requester's move is to ask
         // another peer, and its evidence is not what failed.
         let wrong_chain =
-            root_key_answer_rpc_error(handshake_error(AdmissionDenial::ChainGenesisMismatch {
+            root_key_answer_rpc_error(denial_error(AdmissionDenial::ChainGenesisMismatch {
                 expected: alloy_primitives::B256::repeat_byte(0xb0),
                 found: alloy_primitives::B256::repeat_byte(0xef),
             }));
         assert_eq!(wrong_chain.code(), ROOT_KEY_ADMISSION_UNAVAILABLE_CODE);
+    }
 
-        let verdict = root_key_answer_rpc_error(handshake_error(
+    /// The requester's two verdicts answer two different questions, so they
+    /// travel on two different codes.
+    #[test]
+    fn requester_verdicts_split_evidence_from_identity() {
+        let unusable = root_key_answer_rpc_error(denial_error(
+            AdmissionDenial::UnsupportedAttestationType(seismic_attestation::AttestationType::None),
+        ));
+        assert_eq!(unusable.code(), ROOT_KEY_EVIDENCE_DENIED_CODE);
+
+        let identity = root_key_answer_rpc_error(denial_error(
             AdmissionDenial::RegistryNotAccepted(alloy_primitives::B256::ZERO.into()),
         ));
-        assert_eq!(verdict.code(), ROOT_KEY_REQUEST_DENIED_CODE);
+        assert_eq!(identity.code(), ROOT_KEY_IDENTITY_DENIED_CODE);
+    }
 
-        // Failures with no admission denial in the chain (e.g. quote
-        // verification) stay on the denied verdict.
-        let other = root_key_answer_rpc_error(anyhow::anyhow!("quote verification failed"));
-        assert_eq!(other.code(), ROOT_KEY_REQUEST_DENIED_CODE);
+    /// A responder that cannot obtain collateral has appraised nothing, so it
+    /// answers as unavailable — the joiner's move is another peer, not a new
+    /// image.
+    #[test]
+    fn collateral_infrastructure_faults_map_to_unavailable() {
+        let no_pccs = root_key_answer_rpc_error(backend_error(BackendAttestationError::NoPccs));
+        assert_eq!(no_pccs.code(), ROOT_KEY_ADMISSION_UNAVAILABLE_CODE);
+
+        let provider = root_key_answer_rpc_error(backend_error(
+            BackendAttestationError::AttestationProvider("502 Bad Gateway".into()),
+        ));
+        assert_eq!(provider.code(), ROOT_KEY_ADMISSION_UNAVAILABLE_CODE);
+
+        let provider_url = root_key_answer_rpc_error(backend_error(
+            BackendAttestationError::AttestationProviderUrl("not a URL".into()),
+        ));
+        assert_eq!(provider_url.code(), ROOT_KEY_ADMISSION_UNAVAILABLE_CODE);
+    }
+
+    /// Offline appraisal of the evidence is the requester's to answer for, and
+    /// the Azure funnel is where the production path reports it.
+    #[test]
+    fn offline_evidence_failures_are_denied_on_the_evidence() {
+        let binding = root_key_answer_rpc_error(backend_error(BackendAttestationError::Maa(
+            MaaError::TdReportInputMismatch,
+        )));
+        assert_eq!(binding.code(), ROOT_KEY_EVIDENCE_DENIED_CODE);
+
+        let dcap = root_key_answer_rpc_error(backend_error(BackendAttestationError::Maa(
+            MaaError::DcapVerification(DcapVerificationError::InputMismatch),
+        )));
+        assert_eq!(dcap.code(), ROOT_KEY_EVIDENCE_DENIED_CODE);
+
+        let no_certificate =
+            root_key_answer_rpc_error(backend_error(BackendAttestationError::NoCertificate));
+        assert_eq!(no_certificate.code(), ROOT_KEY_EVIDENCE_DENIED_CODE);
+    }
+
+    /// Neither denial is reachable by omission. A failure this responder cannot
+    /// pin on either party blames nobody: a terminal verdict would tell a
+    /// healthy joiner to stop asking on no evidence at all.
+    #[test]
+    fn unattributed_failures_blame_neither_party() {
+        let unnamed_backend = root_key_answer_rpc_error(backend_error(
+            BackendAttestationError::MeasurementsNotAccepted,
+        ));
+        assert_eq!(
+            unnamed_backend.code(),
+            ErrorCode::InternalError.code(),
+            "an unnamed backend variant must not reach a verdict"
+        );
+
+        let own_plumbing =
+            root_key_answer_rpc_error(verify_error(AttestationError::MissingMeasurements {
+                attestation_type: seismic_attestation::AttestationType::AzureTdx,
+            }));
+        assert_eq!(own_plumbing.code(), ErrorCode::InternalError.code());
+
+        let custodian = root_key_answer_rpc_error(AnswerError::WrapRootKey {
+            source: seismic_custodian_ipc::IpcError::Denied("WrapRootKey".into()),
+        });
+        assert_eq!(custodian.code(), ErrorCode::InternalError.code());
+    }
+
+    /// The step is what attributes, not the error inside it: the very variant
+    /// that makes a *verification* failure the responder's collateral problem
+    /// says nothing about either party when this responder was minting its own
+    /// evidence.
+    #[test]
+    fn the_same_backend_error_attributes_by_step() {
+        let verifying = root_key_answer_rpc_error(backend_error(BackendAttestationError::NoPccs));
+        assert_eq!(verifying.code(), ROOT_KEY_ADMISSION_UNAVAILABLE_CODE);
+
+        let generating = root_key_answer_rpc_error(AnswerError::GenerateResponderEvidence {
+            source: AttestationError::Backend(BackendAttestationError::NoPccs),
+        });
+        assert_eq!(generating.code(), ErrorCode::InternalError.code());
     }
 }

--- a/bin/attestation-service/tests/admission.rs
+++ b/bin/attestation-service/tests/admission.rs
@@ -12,9 +12,10 @@
 //!
 //! - an **accepted** tuple authorizes exactly one root-key wrap (a real
 //!   joiner service completes its bootstrap);
-//! - a **deprecated** tuple is denied (`-32001`) by the same still-running
-//!   responder — the policy is read live from the chain, never cached;
-//! - an **unknown** tuple is denied (`-32001`);
+//! - a **deprecated** tuple is denied on its identity (`-32003`) by the same
+//!   still-running responder — the policy is read live from the chain, never
+//!   cached;
+//! - an **unknown** tuple is denied on its identity (`-32003`);
 //! - an unreachable (`-32002`) or **stale** (`-32002`, via a tightened
 //!   policy-age bound) local reth fails closed;
 //! - a local reth serving a chain the manifest does not commit to fails closed
@@ -71,7 +72,7 @@ use seismic_attestation_service::{
     Args,
     api::NodeStatusRpcClient as _,
     bootstrap::build_root_key_request,
-    rpc_error::{ROOT_KEY_ADMISSION_UNAVAILABLE_CODE, ROOT_KEY_REQUEST_DENIED_CODE},
+    rpc_error::{ROOT_KEY_ADMISSION_UNAVAILABLE_CODE, ROOT_KEY_IDENTITY_DENIED_CODE},
     utils::{init_tracing, is_sudo},
 };
 use seismic_custodian::Custodian;
@@ -197,7 +198,7 @@ async fn test_accepted_tuple_wraps_once_then_deprecation_applies_live() {
     // Same responder process, no restart: the live chain read alone flips
     // the verdict, and the denied handshake never reaches the custodian.
     let denied = request_root_key(&responder.url, &manifest).await;
-    assert_eq!(denial_code(denied), ROOT_KEY_REQUEST_DENIED_CODE);
+    assert_eq!(denial_code(denied), ROOT_KEY_IDENTITY_DENIED_CODE);
     assert_eq!(
         responder.wrap_count.load(Ordering::SeqCst),
         1,
@@ -234,7 +235,7 @@ async fn test_unknown_tuple_is_denied_and_reth_outage_fails_closed() {
 
     let responder = start_service("responder", 32, None, &node.http_url, None).await;
     let denied = request_root_key(&responder.url, &manifest).await;
-    assert_eq!(denial_code(denied), ROOT_KEY_REQUEST_DENIED_CODE);
+    assert_eq!(denial_code(denied), ROOT_KEY_IDENTITY_DENIED_CODE);
     assert_eq!(responder.wrap_count.load(Ordering::SeqCst), 0);
 
     node.stop();

--- a/crates/attestation/src/lib.rs
+++ b/crates/attestation/src/lib.rs
@@ -36,6 +36,14 @@ pub use seismic_network_manifest::{ManifestError, NetworkId, NetworkManifestV1};
 
 /// Backend measurement types returned after successful verification.
 pub use attestation::measurements::{DcapMeasurementRegister, MultiMeasurements};
+/// The backend error enum [`AttestationError::Backend`] wraps, and the two
+/// nested enums a caller has to descend into to tell a verdict on the evidence
+/// apart from its own collateral infrastructure failing: the Azure verifier
+/// funnels every Azure TDX outcome through `MaaError`, and the DCAP layer
+/// reports a collateral-cache failure as `DcapVerificationError::Pccs`.
+pub use attestation::{
+    AttestationError as BackendAttestationError, azure::MaaError, dcap::DcapVerificationError,
+};
 /// Backend evidence envelope and attestation-type enum used on the wire.
 pub use attestation::{AttestationExchangeMessage, AttestationType};
 


### PR DESCRIPTION
Type the responder's answer path as `AnswerError`, one variant per handshake step, and classify each into `DenialKind`. `RequesterVerdict` splits into `RequesterEvidenceUnusable` and `RequesterIdentityNotAccepted`, carried by -32001 and -32003; collateral and provider failures answer -32002 instead of a terminal denial; anything unattributed answers an internal error rather than blaming either party.