### PR TITLE
feat(attestation-service): act on the admission codes in the peer-fetch loop

### DIFF
--- a/bin/attestation-service/src/join.rs
+++ b/bin/attestation-service/src/join.rs
@@ -4,7 +4,8 @@
 //! kept it across a restart — has nothing to do here. A keyless one runs the
 //! requester side of the bootstrap handshake ([`crate::bootstrap`]) against its
 //! configured peers until one answers, and this module is the loop around that:
-//! which peer to ask and how long to wait before asking again.
+//! which peer to ask, what a refusal says about this node, and how long to wait
+//! before asking again.
 //!
 //! The counterpart is [`crate::server`], where this same process answers that
 //! handshake for the nodes joining after it.
@@ -13,18 +14,30 @@ use crate::{
     ATTESTATION_TYPE,
     admission::DangerouslyAdmitAnyAzureGuest,
     bootstrap::{RootKeyResponse, build_root_key_request, verify_root_key_response},
+    rpc_error::RootKeyRefusal,
 };
 use anyhow::Context as _;
-use jsonrpsee::http_client::HttpClientBuilder;
+use jsonrpsee::{core::ClientError, http_client::HttpClientBuilder};
 use secp256k1::PublicKey;
 use seismic_attestation::NetworkId;
 use seismic_attestation_rpc::AttestationRpcClient as _;
 use seismic_custodian_ipc::{CreateRootKeyBootstrapAttemptResult, CustodianClient};
 use std::{path::Path, time::Duration};
-use tracing::{info, warn};
+use tracing::{error, info, warn};
 
 /// Poll interval while waiting for the custodian socket to come up.
 const CUSTODIAN_RETRY_INTERVAL: Duration = Duration::from_secs(1);
+
+/// How long the peer loop waits between passes over the peer list while some
+/// peer may yet answer: one that is unreachable, restarting, or reading a chain
+/// it cannot decide on today can answer minutes from now.
+const PEER_CYCLE_INTERVAL: Duration = Duration::from_secs(30);
+
+/// How long it waits between passes once every peer has reached the same
+/// verdict on this node. Rotating peers buys nothing here — they all read the
+/// same evidence and the same on-chain policy — so the loop stops polling at
+/// join speed and just keeps the door open for the operator's fix.
+const REFUSED_CYCLE_INTERVAL: Duration = Duration::from_secs(5 * 60);
 
 /// Block until the local custodian holds the network root key.
 ///
@@ -91,6 +104,12 @@ async fn connect_custodian_when_ready(custodian_socket: &Path) -> CustodianClien
 /// the peer's response quote, and hand the still-wrapped key back to the
 /// custodian to open and install. A fresh attempt per try means a failed
 /// exchange leaks nothing reusable.
+///
+/// Every refusal is read for what it says about this node (see
+/// [`RootKeyRefusal`]), which sets what the operator is told and how long the
+/// next pass waits. The loop never gives up either way: a policy update can accept
+/// this node minutes later, and an operator repairing a peer makes that peer
+/// answerable again.
 async fn fetch_root_key_from_peers(
     custodian_socket: &Path,
     peers: &[String],
@@ -98,25 +117,93 @@ async fn fetch_root_key_from_peers(
 ) {
     info!("Starting root key fetching from peers");
     loop {
+        let mut refusals = Vec::with_capacity(peers.len());
         for peer in peers {
             match try_fetch_root_key_from_peer(custodian_socket, peer, network_id).await {
                 Ok(()) => {
                     info!("Key received from {peer} and installed in the custodian");
                     return;
                 }
-                Err(e) => {
+                Err(error) => {
+                    // The refusal names itself and the error carries the
+                    // responder's own words; what to do about it is decided
+                    // once the cycle ends, where the whole peer list has
+                    // answered.
+                    let refusal = peer_refusal(&error);
                     warn!(
-                        "Peer({peer}) did not give us the key. Trying next peer... Reason: \n{e:?}\n"
+                        ?refusal,
+                        "Peer({peer}) did not give us the key; trying next peer\n{error:?}\n"
                     );
-                    continue;
+                    refusals.push(refusal);
                 }
             }
         }
 
-        warn!(
-            "Cycled through all provided peers and did not receive root_key. Sleeping for 30 seconds and trying again"
-        );
-        tokio::time::sleep(Duration::from_secs(30)).await;
+        // Only a refusal that names *this node* is a conclusion about it. Peers
+        // that all failed to decide agreed on nothing but their own trouble,
+        // and peers that disagreed leave the question open either way.
+        let remedy = match unanimous_refusal(&refusals) {
+            Some(RootKeyRefusal::RequesterEvidenceUnusable) => Some(
+                "this node's own attestation stack yields no admissible identity; \
+                 inspect it before this node can join",
+            ),
+            Some(RootKeyRefusal::RequesterIdentityNotAccepted) => Some(
+                "this node's admission ID is not in the network's accepted set; \
+                 have it accepted in the MeasurementRegistry, or boot an image \
+                 whose ID already is",
+            ),
+            Some(RootKeyRefusal::ResponderUnavailable) | None => None,
+        };
+
+        let interval = match remedy {
+            Some(remedy) => {
+                error!(
+                    "Every peer refused this node for the same reason, so the problem is \
+                     this node's and not the peers': {remedy}. Still asking every {}s, \
+                     in case the accepted set changes.",
+                    REFUSED_CYCLE_INTERVAL.as_secs()
+                );
+                REFUSED_CYCLE_INTERVAL
+            }
+            None => {
+                warn!(
+                    "Cycled through all provided peers and did not receive root_key. \
+                     Sleeping for {}s and trying again",
+                    PEER_CYCLE_INTERVAL.as_secs()
+                );
+                PEER_CYCLE_INTERVAL
+            }
+        };
+        tokio::time::sleep(interval).await;
+    }
+}
+
+/// The refusal a full pass over the peer list agreed on, if it agreed on one:
+/// `Some` only when every peer refused, and refused for the same reason.
+///
+/// Unanimity is what lets the caller read a requester refusal as this node's
+/// own standing. One peer that is unreachable, broken, or of a different mind
+/// is a peer that may be the wrong one, and telling an operator its image is
+/// rejected on that say-so sends it after a fault it does not have. Peers that
+/// disagree leave the loop asking rather than picking a side.
+fn unanimous_refusal(refusals: &[Option<RootKeyRefusal>]) -> Option<RootKeyRefusal> {
+    let first = (*refusals.first()?)?;
+    refusals
+        .iter()
+        .all(|refusal| *refusal == Some(first))
+        .then_some(first)
+}
+
+/// The refusal a peer sent back, if that is what ended this attempt.
+///
+/// A peer's answer reaches us as a JSON-RPC error object carrying one of the
+/// codes in [`crate::rpc_error`]. Everything else the attempt can fail on — an
+/// unreachable peer, a response we cannot verify, our own custodian — is not
+/// the peer refusing and says nothing about this node.
+fn peer_refusal(error: &anyhow::Error) -> Option<RootKeyRefusal> {
+    match error.downcast_ref::<ClientError>()? {
+        ClientError::Call(refusal) => RootKeyRefusal::from_code(refusal.code()),
+        _ => None,
     }
 }
 
@@ -170,4 +257,89 @@ async fn try_fetch_root_key_from_peer(
         .await
         .context("installing root key in the custodian")?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use jsonrpsee::types::{ErrorCode, ErrorObjectOwned};
+
+    const NOT_ACCEPTED: Option<RootKeyRefusal> = Some(RootKeyRefusal::RequesterIdentityNotAccepted);
+    const NO_IDENTITY: Option<RootKeyRefusal> = Some(RootKeyRefusal::RequesterEvidenceUnusable);
+    const UNAVAILABLE: Option<RootKeyRefusal> = Some(RootKeyRefusal::ResponderUnavailable);
+
+    /// An answer that came back with `code`, shaped the way the client
+    /// surfaces a peer's JSON-RPC error object.
+    fn answered(code: i32) -> anyhow::Error {
+        ClientError::Call(ErrorObjectOwned::owned(code, "refused", None::<()>)).into()
+    }
+
+    /// Peers all saying the same thing is the one case a cycle can conclude
+    /// on, and the refusal travels intact so the operator is sent to the right
+    /// place.
+    #[test]
+    fn a_unanimous_cycle_reports_what_the_peers_agreed_on() {
+        assert_eq!(
+            unanimous_refusal(&[NOT_ACCEPTED, NOT_ACCEPTED, NOT_ACCEPTED]),
+            NOT_ACCEPTED
+        );
+        assert_eq!(unanimous_refusal(&[NO_IDENTITY]), NO_IDENTITY);
+        // Agreement that no peer could decide is agreement about the peers,
+        // and the loop reads it as no conclusion about this node.
+        assert_eq!(unanimous_refusal(&[UNAVAILABLE, UNAVAILABLE]), UNAVAILABLE);
+    }
+
+    /// One peer that answered anything else is enough to withhold the
+    /// conclusion: it may be the peer that is wrong, and a node told its image
+    /// is rejected goes looking for a fault it does not have.
+    #[test]
+    fn one_dissenting_peer_withholds_the_conclusion() {
+        assert_eq!(unanimous_refusal(&[NOT_ACCEPTED, UNAVAILABLE]), None);
+        assert_eq!(unanimous_refusal(&[NOT_ACCEPTED, None]), None);
+        assert_eq!(unanimous_refusal(&[None, NOT_ACCEPTED]), None);
+        assert_eq!(unanimous_refusal(&[NOT_ACCEPTED, NO_IDENTITY]), None);
+    }
+
+    /// A cycle nobody answered agreed on nothing, and a cycle with nothing in
+    /// it agreed on less.
+    #[test]
+    fn a_cycle_without_refusals_concludes_nothing() {
+        assert_eq!(unanimous_refusal(&[None, None]), None);
+        assert_eq!(unanimous_refusal(&[]), None);
+    }
+
+    /// Each wire code the responder can send arrives as the refusal it stands
+    /// for.
+    #[test]
+    fn the_wire_codes_arrive_as_refusals() {
+        for refusal in [NOT_ACCEPTED, NO_IDENTITY, UNAVAILABLE] {
+            let code = refusal.expect("a refusal under test").code();
+            assert_eq!(peer_refusal(&answered(code)), refusal);
+        }
+    }
+
+    /// Only a peer that refused says anything about this node. A peer we never
+    /// reached, one that failed on its own plumbing, and our own custodian all
+    /// leave its standing unsaid — so a cycle of them can never conclude the
+    /// node is rejected.
+    #[test]
+    fn only_a_refusal_carries_a_verdict() {
+        assert_eq!(
+            peer_refusal(&answered(ErrorCode::InternalError.code())),
+            None
+        );
+        assert_eq!(
+            peer_refusal(&answered(ErrorCode::InvalidParams.code())),
+            None
+        );
+        assert_eq!(
+            peer_refusal(&ClientError::RequestTimeout.into()),
+            None,
+            "an unanswered request is not a refusal"
+        );
+        assert_eq!(
+            peer_refusal(&anyhow::anyhow!("connecting to custodian")),
+            None
+        );
+    }
 }

--- a/bin/attestation-service/src/rpc_error.rs
+++ b/bin/attestation-service/src/rpc_error.rs
@@ -28,21 +28,89 @@ use seismic_attestation::{
 use std::fmt::Debug;
 use tracing::{error, warn};
 
-/// Terminal verdict on the requester's evidence: no identity the network can
-/// appraise came out of it, so retrying with the same image cannot change the
-/// answer. This code sends a joiner's operator to inspect its own attestation
-/// stack, so only a failure attributed to the evidence is answered with it.
-pub const ROOT_KEY_EVIDENCE_DENIED_CODE: i32 = -32001;
-/// Terminal verdict on the requester's identity: its evidence verified and
-/// yielded an admission ID the network does not accept. Nothing is wrong with
-/// its attestation stack — this code sends a joiner's operator to launch a
-/// guest whose admission ID the registry accepts.
-pub const ROOT_KEY_IDENTITY_DENIED_CODE: i32 = -32003;
-/// The responder could not decide, because its own chain, registry read, or
-/// collateral infrastructure produced no usable answer. The requester's
-/// evidence is not what failed: worth retrying — against another peer, or this
-/// responder later.
-pub const ROOT_KEY_ADMISSION_UNAVAILABLE_CODE: i32 = -32002;
+/// A refused root-key answer, in the one type both sides of the handshake
+/// hold it in: the responder builds its wire error from a value of this type,
+/// and the joiner reads one back out of the code that arrives.
+///
+/// This is [`DenialKind`] as a stranger may see it. It keeps that same split by
+/// party, and collapses the responder's own half — a peer that is
+/// misconfigured and one that is merely lagging leave a requester the same
+/// move, and which of the two it is belongs in that peer's log, not in an
+/// answer to an unauthenticated caller.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RootKeyRefusal {
+    /// Terminal verdict on the requester's evidence: no identity the network
+    /// can appraise came out of it, so retrying with the same image cannot
+    /// change the answer. It sends a joiner's operator to inspect its own
+    /// attestation stack, so only a failure attributed to the evidence is
+    /// answered with it.
+    RequesterEvidenceUnusable,
+    /// Terminal verdict on the requester's identity: its evidence verified and
+    /// yielded an admission ID the network does not accept. Nothing is wrong
+    /// with its attestation stack — this sends a joiner's operator to launch a
+    /// guest whose admission ID the registry accepts.
+    RequesterIdentityNotAccepted,
+    /// The responder could not decide, because its own chain, registry read, or
+    /// collateral infrastructure produced no usable answer. The requester's
+    /// evidence is not what failed: worth retrying — against another peer, or
+    /// this responder later.
+    ResponderUnavailable,
+}
+
+impl RootKeyRefusal {
+    /// Every refusal this contract defines. [`Self::from_code`] reads this
+    /// list, so a variant left out of it is one no joiner can read back.
+    const ALL: [Self; 3] = [
+        Self::RequesterEvidenceUnusable,
+        Self::RequesterIdentityNotAccepted,
+        Self::ResponderUnavailable,
+    ];
+
+    /// The JSON-RPC error code this refusal travels as. The three run in the
+    /// order the handshake reaches them: what the requester's evidence
+    /// yielded, then whether that identity is accepted, then whether this
+    /// responder could decide at all.
+    pub const fn code(self) -> i32 {
+        match self {
+            Self::RequesterEvidenceUnusable => -32001,
+            Self::RequesterIdentityNotAccepted => -32002,
+            Self::ResponderUnavailable => -32003,
+        }
+    }
+
+    /// The message that travels with it: a stable constant, so an
+    /// unauthenticated caller learns the outcome and nothing about why. Paired
+    /// with the code here, where the two cannot drift apart.
+    pub const fn message(self) -> &'static str {
+        match self {
+            Self::RequesterEvidenceUnusable => "Root-key evidence denied",
+            Self::RequesterIdentityNotAccepted => "Root-key admission identity denied",
+            Self::ResponderUnavailable => "Root-key admission temporarily unavailable",
+        }
+    }
+
+    /// Read a refusal back off a JSON-RPC error code.
+    ///
+    /// `None` for every other code — an internal error, an invalid request, or
+    /// a code this service does not define. Those leave the requester exactly
+    /// where an unattributed failure does: nothing said about it, and the same
+    /// move as for an unavailable responder.
+    pub fn from_code(code: i32) -> Option<Self> {
+        Self::ALL.into_iter().find(|refusal| refusal.code() == code)
+    }
+}
+
+impl From<DenialKind> for RootKeyRefusal {
+    fn from(kind: DenialKind) -> Self {
+        match kind {
+            DenialKind::RequesterEvidenceUnusable => Self::RequesterEvidenceUnusable,
+            DenialKind::RequesterIdentityNotAccepted => Self::RequesterIdentityNotAccepted,
+            DenialKind::ResponderMisconfigured | DenialKind::ResponderTransient => {
+                Self::ResponderUnavailable
+            }
+        }
+    }
+}
 
 pub(crate) fn invalid_root_key_request_rpc_error(error: impl Debug) -> ErrorObjectOwned {
     warn!(?error, "invalid root-key request");
@@ -62,37 +130,17 @@ pub(crate) fn internal_rpc_error(operation: &'static str, error: impl Debug) -> 
     )
 }
 
-pub(crate) fn root_key_evidence_denied_rpc_error(error: impl Debug) -> ErrorObjectOwned {
-    warn!(?error, "root-key evidence denied");
-    ErrorObjectOwned::owned(
-        ROOT_KEY_EVIDENCE_DENIED_CODE,
-        "Root-key evidence denied",
-        None::<()>,
-    )
-}
-
-pub(crate) fn root_key_identity_denied_rpc_error(error: impl Debug) -> ErrorObjectOwned {
-    warn!(?error, "root-key admission identity denied");
-    ErrorObjectOwned::owned(
-        ROOT_KEY_IDENTITY_DENIED_CODE,
-        "Root-key admission identity denied",
-        None::<()>,
-    )
-}
-
-pub(crate) fn root_key_admission_unavailable_rpc_error(error: impl Debug) -> ErrorObjectOwned {
-    warn!(?error, "root-key admission temporarily unavailable");
-    ErrorObjectOwned::owned(
-        ROOT_KEY_ADMISSION_UNAVAILABLE_CODE,
-        "Root-key admission temporarily unavailable",
-        None::<()>,
-    )
+/// Answer with `refusal`, keeping the detail that produced it in this
+/// responder's log.
+fn refusal_rpc_error(refusal: RootKeyRefusal, error: impl Debug) -> ErrorObjectOwned {
+    warn!(?error, ?refusal, "refusing the root-key request");
+    ErrorObjectOwned::owned(refusal.code(), refusal.message(), None::<()>)
 }
 
 /// Route a failed root-key answer to its wire error, by what the failure says
-/// about the two parties (see [`DenialKind`]). Each code carries one move: fix
-/// your attestation stack, get your identity accepted, or ask someone else. The
-/// message is a stable constant either way; failure detail stays in the
+/// about the two parties (see [`DenialKind`]). Each refusal carries one move:
+/// fix your attestation stack, get your identity accepted, or ask someone else.
+/// The message is a stable constant either way; failure detail stays in the
 /// responder's log.
 ///
 /// A failure neither party can be held to answers as an internal error, the
@@ -104,12 +152,8 @@ pub(crate) fn root_key_admission_unavailable_rpc_error(error: impl Debug) -> Err
 /// prevent. Unattributed means neither side is blamed, and the joiner's move is
 /// the same as for an unavailable responder: another peer.
 pub(crate) fn root_key_answer_rpc_error(error: AnswerError) -> ErrorObjectOwned {
-    match answer_failure_kind(&error) {
-        Some(DenialKind::ResponderMisconfigured | DenialKind::ResponderTransient) => {
-            root_key_admission_unavailable_rpc_error(error)
-        }
-        Some(DenialKind::RequesterIdentityNotAccepted) => root_key_identity_denied_rpc_error(error),
-        Some(DenialKind::RequesterEvidenceUnusable) => root_key_evidence_denied_rpc_error(error),
+    match answer_failure_kind(&error).map(RootKeyRefusal::from) {
+        Some(refusal) => refusal_rpc_error(refusal, error),
         None => internal_rpc_error("answering the root-key request", error),
     }
 }
@@ -220,32 +264,63 @@ fn backend_failure_kind(backend: &BackendAttestationError) -> Option<DenialKind>
 mod tests {
     use super::*;
 
+    /// The numbers and messages a peer of any version reads. Pinned as
+    /// literals: this is the wire, so changing one has to be a deliberate edit
+    /// to this list, not a side effect of renaming a variant.
+    #[test]
+    fn the_wire_form_of_every_refusal_is_fixed() {
+        let wire = [
+            (
+                RootKeyRefusal::RequesterEvidenceUnusable,
+                -32001,
+                "Root-key evidence denied",
+            ),
+            (
+                RootKeyRefusal::RequesterIdentityNotAccepted,
+                -32002,
+                "Root-key admission identity denied",
+            ),
+            (
+                RootKeyRefusal::ResponderUnavailable,
+                -32003,
+                "Root-key admission temporarily unavailable",
+            ),
+        ];
+
+        assert_eq!(
+            wire.len(),
+            RootKeyRefusal::ALL.len(),
+            "a refusal the contract defines is missing its wire form here"
+        );
+        for (refusal, code, message) in wire {
+            assert_eq!(refusal.code(), code);
+            assert_eq!(refusal.message(), message);
+            assert_eq!(RootKeyRefusal::from_code(code), Some(refusal));
+        }
+        assert_eq!(
+            RootKeyRefusal::from_code(ErrorCode::InternalError.code()),
+            None
+        );
+    }
+
     #[test]
     fn rpc_errors_expose_only_stable_messages() {
         let invalid = invalid_root_key_request_rpc_error("private parser detail");
         assert_eq!(invalid.code(), ErrorCode::InvalidParams.code());
         assert_eq!(invalid.message(), "Invalid root-key request");
 
-        let denied = root_key_evidence_denied_rpc_error("private verifier detail");
-        assert_eq!(denied.code(), ROOT_KEY_EVIDENCE_DENIED_CODE);
-        assert_eq!(denied.message(), "Root-key evidence denied");
-
-        let unavailable = root_key_admission_unavailable_rpc_error("private chain detail");
-        assert_eq!(unavailable.code(), ROOT_KEY_ADMISSION_UNAVAILABLE_CODE);
-        assert_eq!(
-            unavailable.message(),
-            "Root-key admission temporarily unavailable"
-        );
-
-        let identity = root_key_identity_denied_rpc_error("private admission ID");
-        assert_eq!(identity.code(), ROOT_KEY_IDENTITY_DENIED_CODE);
-        assert_eq!(identity.message(), "Root-key admission identity denied");
-
         let internal = internal_rpc_error("generating evidence", "private backend detail");
         assert_eq!(internal.code(), ErrorCode::InternalError.code());
         assert_eq!(internal.message(), "Internal error");
 
-        for error in [invalid, denied, identity, unavailable, internal] {
+        let refused =
+            RootKeyRefusal::ALL.map(|refusal| refusal_rpc_error(refusal, "private denial detail"));
+        for (error, refusal) in refused.iter().zip(RootKeyRefusal::ALL) {
+            assert_eq!(error.code(), refusal.code());
+            assert_eq!(error.message(), refusal.message());
+        }
+
+        for error in refused.into_iter().chain([invalid, internal]) {
             assert!(!error.to_string().contains("private"));
         }
     }
@@ -265,36 +340,49 @@ mod tests {
         verify_error(AttestationError::AdmissionDenied(Box::new(denial)))
     }
 
+    /// What a joiner takes away from a failed answer: the responder's error
+    /// put on the wire and read back off it, so every case below asserts on
+    /// the round trip rather than on a number.
+    fn refusal_of(error: AnswerError) -> Option<RootKeyRefusal> {
+        RootKeyRefusal::from_code(root_key_answer_rpc_error(error).code())
+    }
+
     #[test]
     fn responder_chain_faults_map_to_unavailable() {
-        let unavailable =
-            root_key_answer_rpc_error(denial_error(AdmissionDenial::ChainRegressedToGenesis));
-        assert_eq!(unavailable.code(), ROOT_KEY_ADMISSION_UNAVAILABLE_CODE);
+        assert_eq!(
+            refusal_of(denial_error(AdmissionDenial::ChainRegressedToGenesis)),
+            Some(RootKeyRefusal::ResponderUnavailable)
+        );
 
         // A responder on the wrong chain is unavailable rather than denying,
         // even though waiting cannot fix it: the requester's move is to ask
         // another peer, and its evidence is not what failed.
-        let wrong_chain =
-            root_key_answer_rpc_error(denial_error(AdmissionDenial::ChainGenesisMismatch {
+        assert_eq!(
+            refusal_of(denial_error(AdmissionDenial::ChainGenesisMismatch {
                 expected: alloy_primitives::B256::repeat_byte(0xb0),
                 found: alloy_primitives::B256::repeat_byte(0xef),
-            }));
-        assert_eq!(wrong_chain.code(), ROOT_KEY_ADMISSION_UNAVAILABLE_CODE);
+            })),
+            Some(RootKeyRefusal::ResponderUnavailable)
+        );
     }
 
     /// The requester's two verdicts answer two different questions, so they
-    /// travel on two different codes.
+    /// travel as two different refusals.
     #[test]
     fn requester_verdicts_split_evidence_from_identity() {
-        let unusable = root_key_answer_rpc_error(denial_error(
-            AdmissionDenial::UnsupportedAttestationType(seismic_attestation::AttestationType::None),
-        ));
-        assert_eq!(unusable.code(), ROOT_KEY_EVIDENCE_DENIED_CODE);
+        assert_eq!(
+            refusal_of(denial_error(AdmissionDenial::UnsupportedAttestationType(
+                seismic_attestation::AttestationType::None
+            ))),
+            Some(RootKeyRefusal::RequesterEvidenceUnusable)
+        );
 
-        let identity = root_key_answer_rpc_error(denial_error(
-            AdmissionDenial::RegistryNotAccepted(alloy_primitives::B256::ZERO.into()),
-        ));
-        assert_eq!(identity.code(), ROOT_KEY_IDENTITY_DENIED_CODE);
+        assert_eq!(
+            refusal_of(denial_error(AdmissionDenial::RegistryNotAccepted(
+                alloy_primitives::B256::ZERO.into()
+            ))),
+            Some(RootKeyRefusal::RequesterIdentityNotAccepted)
+        );
     }
 
     /// A responder that cannot obtain collateral has appraised nothing, so it
@@ -302,37 +390,38 @@ mod tests {
     /// image.
     #[test]
     fn collateral_infrastructure_faults_map_to_unavailable() {
-        let no_pccs = root_key_answer_rpc_error(backend_error(BackendAttestationError::NoPccs));
-        assert_eq!(no_pccs.code(), ROOT_KEY_ADMISSION_UNAVAILABLE_CODE);
-
-        let provider = root_key_answer_rpc_error(backend_error(
+        let faults = [
+            BackendAttestationError::NoPccs,
             BackendAttestationError::AttestationProvider("502 Bad Gateway".into()),
-        ));
-        assert_eq!(provider.code(), ROOT_KEY_ADMISSION_UNAVAILABLE_CODE);
-
-        let provider_url = root_key_answer_rpc_error(backend_error(
             BackendAttestationError::AttestationProviderUrl("not a URL".into()),
-        ));
-        assert_eq!(provider_url.code(), ROOT_KEY_ADMISSION_UNAVAILABLE_CODE);
+        ];
+
+        for fault in faults {
+            assert_eq!(
+                refusal_of(backend_error(fault)),
+                Some(RootKeyRefusal::ResponderUnavailable)
+            );
+        }
     }
 
     /// Offline appraisal of the evidence is the requester's to answer for, and
     /// the Azure funnel is where the production path reports it.
     #[test]
     fn offline_evidence_failures_are_denied_on_the_evidence() {
-        let binding = root_key_answer_rpc_error(backend_error(BackendAttestationError::Maa(
-            MaaError::TdReportInputMismatch,
-        )));
-        assert_eq!(binding.code(), ROOT_KEY_EVIDENCE_DENIED_CODE);
+        let failures = [
+            BackendAttestationError::Maa(MaaError::TdReportInputMismatch),
+            BackendAttestationError::Maa(MaaError::DcapVerification(
+                DcapVerificationError::InputMismatch,
+            )),
+            BackendAttestationError::NoCertificate,
+        ];
 
-        let dcap = root_key_answer_rpc_error(backend_error(BackendAttestationError::Maa(
-            MaaError::DcapVerification(DcapVerificationError::InputMismatch),
-        )));
-        assert_eq!(dcap.code(), ROOT_KEY_EVIDENCE_DENIED_CODE);
-
-        let no_certificate =
-            root_key_answer_rpc_error(backend_error(BackendAttestationError::NoCertificate));
-        assert_eq!(no_certificate.code(), ROOT_KEY_EVIDENCE_DENIED_CODE);
+        for failure in failures {
+            assert_eq!(
+                refusal_of(backend_error(failure)),
+                Some(RootKeyRefusal::RequesterEvidenceUnusable)
+            );
+        }
     }
 
     /// Neither denial is reachable by omission. A failure this responder cannot
@@ -340,25 +429,27 @@ mod tests {
     /// healthy joiner to stop asking on no evidence at all.
     #[test]
     fn unattributed_failures_blame_neither_party() {
-        let unnamed_backend = root_key_answer_rpc_error(backend_error(
-            BackendAttestationError::MeasurementsNotAccepted,
-        ));
-        assert_eq!(
-            unnamed_backend.code(),
-            ErrorCode::InternalError.code(),
-            "an unnamed backend variant must not reach a verdict"
-        );
-
-        let own_plumbing =
-            root_key_answer_rpc_error(verify_error(AttestationError::MissingMeasurements {
+        let unattributed = [
+            // An unnamed backend variant must not reach a verdict.
+            backend_error(BackendAttestationError::MeasurementsNotAccepted),
+            // This responder's own plumbing.
+            verify_error(AttestationError::MissingMeasurements {
                 attestation_type: seismic_attestation::AttestationType::AzureTdx,
-            }));
-        assert_eq!(own_plumbing.code(), ErrorCode::InternalError.code());
+            }),
+            AnswerError::WrapRootKey {
+                source: seismic_custodian_ipc::IpcError::Denied("WrapRootKey".into()),
+            },
+        ];
 
-        let custodian = root_key_answer_rpc_error(AnswerError::WrapRootKey {
-            source: seismic_custodian_ipc::IpcError::Denied("WrapRootKey".into()),
-        });
-        assert_eq!(custodian.code(), ErrorCode::InternalError.code());
+        for error in unattributed {
+            let answer = root_key_answer_rpc_error(error);
+            assert_eq!(answer.code(), ErrorCode::InternalError.code());
+            assert_eq!(
+                RootKeyRefusal::from_code(answer.code()),
+                None,
+                "an unattributed failure must not arrive as a refusal"
+            );
+        }
     }
 
     /// The step is what attributes, not the error inside it: the very variant
@@ -367,8 +458,10 @@ mod tests {
     /// evidence.
     #[test]
     fn the_same_backend_error_attributes_by_step() {
-        let verifying = root_key_answer_rpc_error(backend_error(BackendAttestationError::NoPccs));
-        assert_eq!(verifying.code(), ROOT_KEY_ADMISSION_UNAVAILABLE_CODE);
+        assert_eq!(
+            refusal_of(backend_error(BackendAttestationError::NoPccs)),
+            Some(RootKeyRefusal::ResponderUnavailable)
+        );
 
         let generating = root_key_answer_rpc_error(AnswerError::GenerateResponderEvidence {
             source: AttestationError::Backend(BackendAttestationError::NoPccs),

--- a/bin/attestation-service/tests/admission.rs
+++ b/bin/attestation-service/tests/admission.rs
@@ -12,14 +12,14 @@
 //!
 //! - an **accepted** tuple authorizes exactly one root-key wrap (a real
 //!   joiner service completes its bootstrap);
-//! - a **deprecated** tuple is denied on its identity (`-32003`) by the same
+//! - a **deprecated** tuple is denied on its identity (`-32002`) by the same
 //!   still-running responder — the policy is read live from the chain, never
 //!   cached;
-//! - an **unknown** tuple is denied on its identity (`-32003`);
-//! - an unreachable (`-32002`) or **stale** (`-32002`, via a tightened
+//! - an **unknown** tuple is denied on its identity (`-32002`);
+//! - an unreachable (`-32003`) or **stale** (`-32003`, via a tightened
 //!   policy-age bound) local reth fails closed;
 //! - a local reth serving a chain the manifest does not commit to fails closed
-//!   (`-32002`), exercising the pinned `eth.genesis_hash` end to end.
+//!   (`-32003`), exercising the pinned `eth.genesis_hash` end to end.
 //!
 //! The genesis is generated at runtime, not committed: evidence carries the
 //! runner's real PCRs, so the seeded policy is compiled either from the
@@ -72,7 +72,7 @@ use seismic_attestation_service::{
     Args,
     api::NodeStatusRpcClient as _,
     bootstrap::build_root_key_request,
-    rpc_error::{ROOT_KEY_ADMISSION_UNAVAILABLE_CODE, ROOT_KEY_IDENTITY_DENIED_CODE},
+    rpc_error::RootKeyRefusal,
     utils::{init_tracing, is_sudo},
 };
 use seismic_custodian::Custodian;
@@ -198,7 +198,10 @@ async fn test_accepted_tuple_wraps_once_then_deprecation_applies_live() {
     // Same responder process, no restart: the live chain read alone flips
     // the verdict, and the denied handshake never reaches the custodian.
     let denied = request_root_key(&responder.url, &manifest).await;
-    assert_eq!(denial_code(denied), ROOT_KEY_IDENTITY_DENIED_CODE);
+    assert_eq!(
+        denial_refusal(denied),
+        RootKeyRefusal::RequesterIdentityNotAccepted
+    );
     assert_eq!(
         responder.wrap_count.load(Ordering::SeqCst),
         1,
@@ -235,14 +238,17 @@ async fn test_unknown_tuple_is_denied_and_reth_outage_fails_closed() {
 
     let responder = start_service("responder", 32, None, &node.http_url, None).await;
     let denied = request_root_key(&responder.url, &manifest).await;
-    assert_eq!(denial_code(denied), ROOT_KEY_IDENTITY_DENIED_CODE);
+    assert_eq!(
+        denial_refusal(denied),
+        RootKeyRefusal::RequesterIdentityNotAccepted
+    );
     assert_eq!(responder.wrap_count.load(Ordering::SeqCst), 0);
 
     node.stop();
     let unavailable = request_root_key(&responder.url, &manifest).await;
     assert_eq!(
-        denial_code(unavailable),
-        ROOT_KEY_ADMISSION_UNAVAILABLE_CODE
+        denial_refusal(unavailable),
+        RootKeyRefusal::ResponderUnavailable
     );
     assert_eq!(responder.wrap_count.load(Ordering::SeqCst), 0);
     responder.handle.abort();
@@ -281,7 +287,7 @@ async fn test_stale_policy_view_fails_closed() {
     wait_finalized_older_than(&provider, STALE_MAX_POLICY_AGE * 3).await;
 
     let stale = request_root_key(&responder.url, &manifest).await;
-    assert_eq!(denial_code(stale), ROOT_KEY_ADMISSION_UNAVAILABLE_CODE);
+    assert_eq!(denial_refusal(stale), RootKeyRefusal::ResponderUnavailable);
     assert_eq!(responder.wrap_count.load(Ordering::SeqCst), 0);
     responder.handle.abort();
 }
@@ -310,8 +316,8 @@ async fn test_foreign_pinned_genesis_fails_closed() {
     let responder = start_service("responder", 34, None, &node.http_url, None).await;
     let unavailable = request_root_key(&responder.url, &manifest).await;
     assert_eq!(
-        denial_code(unavailable),
-        ROOT_KEY_ADMISSION_UNAVAILABLE_CODE
+        denial_refusal(unavailable),
+        RootKeyRefusal::ResponderUnavailable
     );
     assert_eq!(responder.wrap_count.load(Ordering::SeqCst), 0);
     responder.handle.abort();
@@ -772,9 +778,17 @@ async fn request_root_key(
 }
 
 /// The JSON-RPC error code a failed handshake surfaced.
-fn denial_code(result: Result<Vec<u8>, jsonrpsee::core::client::Error>) -> i32 {
+/// The refusal a denied handshake came back with, read off the wire the way a
+/// joining node reads it.
+fn denial_refusal(result: Result<Vec<u8>, jsonrpsee::core::client::Error>) -> RootKeyRefusal {
     match result {
-        Err(jsonrpsee::core::client::Error::Call(error)) => error.code(),
+        Err(jsonrpsee::core::client::Error::Call(error)) => RootKeyRefusal::from_code(error.code())
+            .unwrap_or_else(|| {
+                panic!(
+                    "handshake must be refused with a root-key code, got {}",
+                    error.code()
+                )
+            }),
         Ok(_) => panic!("handshake must be denied, but a wrapped root key came back"),
         Err(other) => panic!("handshake must fail with a JSON-RPC call error, got: {other}"),
     }


### PR DESCRIPTION
Fixes SEI-280

The responder splits its refusals carefully — the requester's evidence, the requester's identity, its own inability to decide — and the joiner consumed none of it. fetch_root_key_from_peers matched Ok/Err, warned the same line for every failure, moved to the next peer, and slept 30s after each full cycle, forever.

Read the code back. RootKeyRefusal is the wire contract as one type: the responder builds its error object from a value of it, the joiner reads one back out of the code that arrives, and the code and its message are paired in one place where they cannot drift. It is DenialKind as a stranger may see it — the same split by party, with the responder's own half collapsed, since a misconfigured peer and a lagging one leave a requester the same move, and which of the two it is belongs in that peer's log rather than in an answer to an unauthenticated caller.

The loop concludes only on unanimity. It records each peer's refusal, and when every peer refused for the same reason, and that reason names this node, it logs the operator's remedy at error and drops to a five-minute cadence: rotating peers buys nothing when they all read the same evidence against the same on-chain policy. One peer that is unreachable, broken, or of a different mind withholds the conclusion, so a single bad peer cannot tell an operator its image is rejected. Anything short of unanimity keeps the 30-second cycle, and neither path ever exits — a policy update can accept this node minutes later, and an operator repairing a peer makes that peer answerable again.

Per-peer logs carry the refusal as a field rather than prose. The responder's own code and message already sit in the error beside it, and what to do about a refusal is only decidable once the whole list has answered.

The identity and unavailable codes swap, so the two requester verdicts sit adjacent at -32001 and -32002 and the responder's own at -32003, which is the order the handshake reaches them. -32002 therefore changes meaning: a responder answering unavailable today reads as denying an identity to a joiner on this build. Deployments are re-founded whole, so no mixed pair should outlive a rollout; if one does, the joiner misreads a busy peer as a rejection, says so, and slows to the five-minute cadence until that peer upgrades.

Nothing rides in the error object's data field, and the module doc says why: the only hint worth carrying there is a retry time, and no failure has one to give — a stale finalized view knows how stale it is, not when the next finalized block lands, and a misconfigured responder waits on its operator.

The admission suite asserts on refusals instead of hand-written code numbers, leaving the wire form pinned in exactly one test.

Node status is untouched: the server binds only after this loop returns, so nothing serves that surface while the loop runs, and telling the two cases apart there needs a startup change of its own.