### PR TITLE
fix(tdx-init): deliver founding enodes as reth --trusted-peers

### DIFF
--- a/bin/tdx-init/README.md
+++ b/bin/tdx-init/README.md
@@ -87,12 +87,20 @@ the manifest's `summit.namespace` (`src/summit_genesis.rs`). Written verbatim
 to `summit-genesis.toml`.
 
 `[network].bootnodes` is the network-wide devp2p bootnode list — the single
-source for the cohort's peer machines. It feeds reth verbatim (rendered into
-`reth-p2p.env`, see below) and, derived, the root-key fetch list the
-attestation service uses (`attestation.env`): `http://<bootnode host>:7878`
-per bootnode, with this node's own entry dropped. Deriving the peers instead
-of delivering a second list makes skew between the two unrepresentable — the
-bootnodes and the root-key peers are the same machines by construction.
+source for the cohort's peer machines. Dropping this node's own entry leaves
+the peer enodes, which three consumers read in two renderings:
+
+- **reth's `--bootnodes`** (rendered into `reth-p2p.env`, see below) seeds
+  discv5, where one live bootnode is enough for the DHT to flood the rest.
+  Bootstrap is one-shot per boot.
+- **reth's `--trusted-peers`** takes the same enodes. reth dials these directly
+  over RLPx with retry, so a lost discv5 round-trip costs latency instead of a
+  seat in the tx-gossip mesh.
+- **the attestation service's root-key fetch list** (`attestation.env`) takes
+  the same machines as `http://<host>:7878`.
+
+Rendering the lists instead of delivering three makes skew between them
+unrepresentable — all three name the same machines by construction.
 
 `[node].external_ip` is this VM's public IP — Azure NICs hold private
 addresses, so reth's NAT autodetection can't be trusted; it is also what
@@ -115,7 +123,7 @@ After validation, tdx-init writes:
 | `/run/seismic/conf/network-manifest.json` | verbatim manifest bytes | [`seismic-attestation-service`](../attestation-service) — hashes the file itself to derive `network_id` for attestation bindings |
 | `/run/seismic/conf/reth-genesis.json` | verbatim reth genesis bytes | `reth.service` (seismic-images) — passed to `seismic-reth node --chain` |
 | `/run/seismic/conf/summit-genesis.toml` | verbatim summit genesis bytes | `summit.service` (seismic-images) — passed to `summit --genesis-path` |
-| `/run/seismic/conf/reth-p2p.env` | `RETH_BOOTNODES_FLAG=...`, `RETH_NAT_FLAG=...` | `reth.service` (seismic-images) — loaded via `EnvironmentFile=`; each var holds a whole flag (`--bootnodes <csv>` / `--nat extip:<ip>`) or is empty, and the unit places the unquoted `$RETH_BOOTNODES_FLAG $RETH_NAT_FLAG` on the command line so empty vars drop out |
+| `/run/seismic/conf/reth-p2p.env` | `RETH_BOOTNODES_FLAG=...`, `RETH_TRUSTED_PEERS_FLAG=...`, `RETH_NAT_FLAG=...` | `reth.service` (seismic-images) — loaded via `EnvironmentFile=`; each var holds a whole flag (`--bootnodes <csv>` / `--trusted-peers <csv>` / `--nat extip:<ip>`) or is empty, and the unit places the unquoted `$RETH_*_FLAG` vars on the command line so empty ones drop out |
 
 Each downstream service reads its own native format (env-var pairs,
 either via systemd `EnvironmentFile=` or shell `source`); tdx-init is

--- a/bin/tdx-init/src/config.rs
+++ b/bin/tdx-init/src/config.rs
@@ -93,11 +93,12 @@ pub struct NetworkConfig {
     pub summit_genesis_base64: String,
 
     /// Network-wide devp2p bootnodes, as `enode://<128 hex pubkey>@host:port`
-    /// URLs — the single source for the cohort's peer machines. Feeds reth
-    /// verbatim (`reth-p2p.env`'s `RETH_BOOTNODES_FLAG`) and, derived, the
-    /// attestation service's root-key fetch list (`attestation.env`:
-    /// `http://<host>:7878` per bootnode, this node's own entry dropped);
-    /// validation and derivation live in `src/peers.rs`. The field is required,
+    /// URLs — the single source for the cohort's peer machines. With this
+    /// node's own entry dropped, they feed both of reth's devp2p flags
+    /// (`reth-p2p.env`'s `RETH_BOOTNODES_FLAG` and `RETH_TRUSTED_PEERS_FLAG`)
+    /// and, as `http://<host>:7878`, the attestation service's root-key fetch
+    /// list (`attestation.env`); the rendering lives in `src/peers.rs`, which
+    /// also documents why reth gets the list twice. The field is required,
     /// but an empty list is valid on the genesis node only — it has no peers
     /// to dial and mints `root_key` itself; a non-genesis POST with no usable
     /// bootnode is rejected with `400`.

--- a/bin/tdx-init/src/peers.rs
+++ b/bin/tdx-init/src/peers.rs
@@ -1,13 +1,19 @@
-//! POST-time validation of the peer inputs and derivation of the root-key
-//! fetch peers.
+//! POST-time validation of the peer inputs and derivation of the per-consumer
+//! peer lists.
 //!
 //! `[network].bootnodes` is the single source for the cohort's peer machines.
-//! It feeds two consumers: reth verbatim (rendered into `reth-p2p.env` by the
-//! writer module) and — derived here — the attestation service's root-key
-//! fetch list (`http://<bootnode host>:7878`, this node's own entry dropped).
-//! Bootnodes and root-key peers are the same machines by construction, so
-//! deriving one list from the other makes skew between them unrepresentable,
-//! and the `http://…:7878` convention is rendered in exactly one place.
+//! It feeds three consumers, in two renderings:
+//!
+//! - reth's `--bootnodes` and `--trusted-peers` both take the peer enodes, for
+//!   different jobs: trusted peers are how the node reaches the cohort,
+//!   bootnodes are how it reaches everyone the cohort list cannot name (the
+//!   writer module renders both into `reth-p2p.env`).
+//! - the attestation service's root-key fetch list takes the same machines as
+//!   `http://<host>:7878`.
+//!
+//! Both renderings drop this node's own entry and come from one pass over the
+//! input, so skew between them is unrepresentable and the `http://…:7878`
+//! convention lives in exactly one place.
 //!
 //! Validation is structural, so a malformed enode or IP fails the deploy POST
 //! with `400` rather than surfacing when reth parses its flags at boot and
@@ -18,7 +24,7 @@
 use crate::config::NodeConfig;
 use crate::error::{Result, TdxInitError};
 use std::net::IpAddr;
-use tracing::info;
+use tracing::{info, warn};
 
 /// Number of hex chars in an enode node id: the 64-byte secp256k1 public key
 /// (uncompressed, without the 0x04 prefix), hex-encoded.
@@ -29,27 +35,53 @@ const ENODE_ID_HEX_LEN: usize = 128;
 /// crate — the constant can't be imported).
 const ROOT_KEY_PEER_PORT: u16 = 7878;
 
-/// Validate the peer inputs from the POSTed config and derive the root-key
-/// fetch peer URLs from the bootnodes: `external_ip` must parse as an IP
-/// address and every bootnode must be a well-formed `enode://` URL. The
-/// node's own enode (host == `external_ip`) is dropped — after the founding
-/// ceremony the persisted bootnode set includes every founding node, this one
-/// included — and a non-genesis node must end up with at least one peer, or
-/// it has no source for `root_key`.
-pub fn validate_and_derive_peers(node: &NodeConfig, bootnodes: &[String]) -> Result<Vec<String>> {
+/// The cohort as this node's consumers need it: two renderings of the same
+/// machines, built in one pass from `[network].bootnodes` so they cannot
+/// disagree about who the cohort is. This node's own entry is dropped from
+/// both — nothing here is a list this node uses to reach itself.
+#[derive(Debug)]
+pub struct PeerLists {
+    /// The other founding nodes' enodes, in the order given. Both of reth's
+    /// devp2p flags take this list (`reth-p2p.env`'s `RETH_BOOTNODES_FLAG` and
+    /// `RETH_TRUSTED_PEERS_FLAG`), because they do different jobs with it:
+    /// `--trusted-peers` is how the node reaches *the cohort* — direct RLPx
+    /// dials, retried, exempt from reputation slashing — while `--bootnodes`
+    /// seeds discv5, which is how it reaches everyone the list cannot name.
+    /// Membership on this plane is open, so later joiners are exactly the peers
+    /// no founding-era list could have held.
+    pub peer_enodes: Vec<String>,
+    /// Where the attestation service fetches `root_key` when the local
+    /// custodian starts without one (`attestation.env`'s
+    /// `SEISMIC_ROOT_KEY_PEERS`): `http://<host>:7878` per peer host, deduped
+    /// by URL, since one host serves one root key however many enodes it runs.
+    pub root_key_urls: Vec<String>,
+}
+
+/// Validate the peer inputs from the POSTed config and render this node's peer
+/// lists from the bootnodes: `external_ip` must parse as an IP address and
+/// every bootnode must be a well-formed `enode://` URL. The node's own enode
+/// (host == `external_ip`) is dropped — after the founding ceremony the
+/// persisted bootnode set includes every founding node, this one included, and
+/// a node has no reason to reach itself. A non-genesis node must end up with at
+/// least one peer, or it has no source for `root_key`.
+pub fn validate_and_derive_peers(node: &NodeConfig, bootnodes: &[String]) -> Result<PeerLists> {
     let external_ip = parse_external_ip(&node.external_ip)?;
-    let mut peers = Vec::new();
+    let mut derived = PeerLists {
+        peer_enodes: Vec::new(),
+        root_key_urls: Vec::new(),
+    };
     for enode in bootnodes {
         let host = parse_enode_host(enode)?;
         if is_self(host, external_ip) {
             continue;
         }
+        derived.peer_enodes.push(enode.clone());
         let peer = format!("http://{host}:{ROOT_KEY_PEER_PORT}");
-        if !peers.contains(&peer) {
-            peers.push(peer);
+        if !derived.root_key_urls.contains(&peer) {
+            derived.root_key_urls.push(peer);
         }
     }
-    if !node.genesis_node && peers.is_empty() {
+    if !node.genesis_node && derived.root_key_urls.is_empty() {
         return Err(TdxInitError::InvalidPeers(
             "non-genesis node has no source for root_key: [network].bootnodes \
              must name at least one machine other than this node"
@@ -57,12 +89,24 @@ pub fn validate_and_derive_peers(node: &NodeConfig, bootnodes: &[String]) -> Res
         ));
     }
     info!(
-        "peer config valid: {} bootnode(s), {} derived root-key peer(s), external_ip={}",
+        "peer config valid: {} bootnode(s), {} peer enode(s), {} root-key peer(s), external_ip={}",
         bootnodes.len(),
-        peers.len(),
+        derived.peer_enodes.len(),
+        derived.root_key_urls.len(),
         node.external_ip,
     );
-    Ok(peers)
+    // Only a genesis node reaches this empty (a joiner without peers already
+    // failed above), and its two readings look identical from here: correct at
+    // founding, a stale peer list on any boot after joiners arrived.
+    if derived.peer_enodes.is_empty() {
+        warn!(
+            "[network].bootnodes names no machine other than this node: reth starts with \
+             neither bootnodes nor trusted peers, so this node joins no gossip mesh. \
+             Expected for the genesis node at founding; on a later boot it means the \
+             delivered peer list is stale."
+        );
+    }
+    Ok(derived)
 }
 
 /// Check that `enode` matches `enode://<128 hex pubkey>@host:port` and return
@@ -144,7 +188,8 @@ mod tests {
             &node("203.0.113.7", false),
             &[enode("10.0.0.1:30303"), enode("10.0.0.2:30303")],
         )
-        .unwrap();
+        .unwrap()
+        .root_key_urls;
         assert_eq!(peers, vec!["http://10.0.0.1:7878", "http://10.0.0.2:7878"]);
     }
 
@@ -154,7 +199,8 @@ mod tests {
             &node("10.0.0.1", false),
             &[enode("10.0.0.1:30303"), enode("10.0.0.2:30303")],
         )
-        .unwrap();
+        .unwrap()
+        .root_key_urls;
         assert_eq!(peers, vec!["http://10.0.0.2:7878"]);
     }
 
@@ -169,7 +215,8 @@ mod tests {
                 enode("10.0.0.2:30303"),
             ],
         )
-        .unwrap();
+        .unwrap()
+        .root_key_urls;
         assert_eq!(peers, vec!["http://10.0.0.2:7878"]);
     }
 
@@ -177,7 +224,8 @@ mod tests {
     fn keeps_bracketed_ipv6_peer_hosts() {
         let peers =
             validate_and_derive_peers(&node("10.0.0.1", false), &[enode("[2001:db8::1]:30303")])
-                .unwrap();
+                .unwrap()
+                .root_key_urls;
         assert_eq!(peers, vec!["http://[2001:db8::1]:7878"]);
     }
 
@@ -187,26 +235,50 @@ mod tests {
             &node("10.0.0.1", false),
             &[enode("node2.example.com:30303")],
         )
-        .unwrap();
+        .unwrap()
+        .root_key_urls;
         assert_eq!(peers, vec!["http://node2.example.com:7878"]);
     }
 
     #[test]
     fn dedupes_repeated_hosts() {
+        // Two enodes on one host collapse to a single root-key URL, but both
+        // stay peer enodes: reth keys peers by node id, not by address.
         let mut second = enode("10.0.0.2:30303");
         second = second.replacen('a', "b", 1);
-        let peers =
-            validate_and_derive_peers(&node("10.0.0.1", false), &[enode("10.0.0.2:30303"), second])
-                .unwrap();
-        assert_eq!(peers, vec!["http://10.0.0.2:7878"]);
+        let derived = validate_and_derive_peers(
+            &node("10.0.0.1", false),
+            &[enode("10.0.0.2:30303"), second.clone()],
+        )
+        .unwrap();
+        assert_eq!(derived.root_key_urls, vec!["http://10.0.0.2:7878"]);
+        assert_eq!(derived.peer_enodes, vec![enode("10.0.0.2:30303"), second]);
+    }
+
+    #[test]
+    fn keeps_peer_enodes_in_order_without_self() {
+        let derived = validate_and_derive_peers(
+            &node("10.0.0.1", false),
+            &[
+                enode("10.0.0.1:30303"),
+                enode("10.0.0.2:30303"),
+                enode("node3.example.com:30303"),
+            ],
+        )
+        .unwrap();
+        assert_eq!(
+            derived.peer_enodes,
+            vec![enode("10.0.0.2:30303"), enode("node3.example.com:30303")]
+        );
     }
 
     #[test]
     fn genesis_node_may_have_no_bootnodes() {
         // The greenfield genesis node has no peers to dial and mints
         // root_key itself.
-        let peers = validate_and_derive_peers(&node("10.0.0.1", true), &[]).unwrap();
-        assert!(peers.is_empty());
+        let derived = validate_and_derive_peers(&node("10.0.0.1", true), &[]).unwrap();
+        assert!(derived.root_key_urls.is_empty());
+        assert!(derived.peer_enodes.is_empty());
     }
 
     #[test]

--- a/bin/tdx-init/src/writer.rs
+++ b/bin/tdx-init/src/writer.rs
@@ -18,14 +18,12 @@ pub const DEFAULT_FILE_MODE: u32 = 0o644;
 /// files under `conf_dir`. Each downstream service reads its own file in
 /// its native format (env-var pairs for clap-based and bash consumers);
 /// tdx-init is the schema translator.
+///
+/// Every input is validated before the first byte is written, so a bad config
+/// leaves no `conf_dir` and no partially populated set of files behind. The
+/// second half is then pure filesystem work that can only fail on I/O.
 pub async fn write_service_configs(conf_dir: &Path, config: &InitConfig) -> Result<()> {
-    fs::create_dir_all(conf_dir).await?;
-    let root_key_peers =
-        crate::peers::validate_and_derive_peers(&config.node, &config.network.bootnodes)?;
-    write_domain_env(conf_dir, config).await?;
-    write_custodian_env(conf_dir, config).await?;
-    write_attestation_svc_env(conf_dir, &root_key_peers).await?;
-    write_reth_p2p_env(conf_dir, config).await?;
+    let peers = crate::peers::validate_and_derive_peers(&config.node, &config.network.bootnodes)?;
     let manifest = crate::manifest::decode_and_validate(&config.network.manifest_base64)?;
     let genesis = crate::reth_genesis::decode_and_validate(
         &config.network.reth_genesis_base64,
@@ -35,6 +33,12 @@ pub async fn write_service_configs(conf_dir: &Path, config: &InitConfig) -> Resu
         &config.network.summit_genesis_base64,
         &manifest.namespace,
     )?;
+
+    fs::create_dir_all(conf_dir).await?;
+    write_domain_env(conf_dir, config).await?;
+    write_custodian_env(conf_dir, config).await?;
+    write_attestation_svc_env(conf_dir, &peers.root_key_urls).await?;
+    write_reth_p2p_env(conf_dir, &peers.peer_enodes, &config.node.external_ip).await?;
     write_network_manifest(conf_dir, &manifest).await?;
     write_reth_genesis(conf_dir, &genesis).await?;
     write_summit_genesis(conf_dir, &summit_genesis).await?;
@@ -87,9 +91,9 @@ async fn write_domain_env(conf_dir: &Path, config: &InitConfig) -> Result<()> {
     Ok(())
 }
 
-/// The custodian's unit loads this via `EnvironmentFile=`; the binary reads
-/// `SEISMIC_CUSTODIAN_GENESIS_NODE` (whether to generate a fresh root key)
-/// through clap `env=`.
+/// The custodian's systemd unit loads this via `EnvironmentFile=`; the binary
+/// reads `SEISMIC_CUSTODIAN_GENESIS_NODE` (whether to generate a fresh root
+/// key) through clap `env=`.
 async fn write_custodian_env(conf_dir: &Path, config: &InitConfig) -> Result<()> {
     let path = conf_dir.join("custodian.env");
     let content = format!(
@@ -101,10 +105,10 @@ async fn write_custodian_env(conf_dir: &Path, config: &InitConfig) -> Result<()>
     Ok(())
 }
 
-/// The attestation service's unit loads this via `EnvironmentFile=`; the
-/// binary reads `SEISMIC_ROOT_KEY_PEERS` (where to fetch the root key when the
-/// local custodian starts without one) through clap `env=`. The peer list is
-/// not a config field: it is derived from `[network].bootnodes` in
+/// The attestation service's systemd unit loads this via `EnvironmentFile=`;
+/// the binary reads `SEISMIC_ROOT_KEY_PEERS` (where to fetch the root key when
+/// the local custodian starts without one) through clap `env=`. The peer list
+/// is not a config field: it is derived from `[network].bootnodes` in
 /// `crate::peers`.
 async fn write_attestation_svc_env(conf_dir: &Path, root_key_peers: &[String]) -> Result<()> {
     let path = conf_dir.join("attestation.env");
@@ -114,27 +118,41 @@ async fn write_attestation_svc_env(conf_dir: &Path, root_key_peers: &[String]) -
     Ok(())
 }
 
-/// reth's unit loads this via `EnvironmentFile=` and puts the *unquoted*
-/// `$RETH_BOOTNODES_FLAG $RETH_NAT_FLAG` on reth's command line. Each var holds
-/// a whole flag: systemd word-splits an unquoted expansion, so a populated var
-/// expands to argv entries while an empty one drops out entirely. Emitting the
-/// flag name inside the var (rather than a bare value) is what lets the genesis
-/// node's empty bootnode list vanish instead of passing `--bootnodes ""`, which
-/// reth rejects. `RETH_NAT_FLAG` is always populated (external_ip is required);
-/// `RETH_BOOTNODES_FLAG` is empty only when there are no bootnodes. Values may
-/// contain a space; systemd EnvironmentFile keeps everything after `=` verbatim
-/// (no quoting needed), matching the other env files here.
+/// reth's systemd unit loads this via `EnvironmentFile=` and puts the
+/// *unquoted* `$RETH_BOOTNODES_FLAG $RETH_TRUSTED_PEERS_FLAG $RETH_NAT_FLAG`
+/// on reth's command line. Each var holds a whole flag: systemd word-splits an
+/// unquoted expansion, so a populated var expands to argv entries while an
+/// empty one drops out entirely. Emitting the flag name inside the var (rather
+/// than a bare value) is what lets the genesis node's empty bootnode list
+/// vanish instead of passing `--bootnodes ""`, which reth rejects.
+/// `RETH_NAT_FLAG` is always populated (external_ip is required); the two peer
+/// flags are empty together, on a node whose cohort names no other machine.
+/// Values may contain a space; systemd EnvironmentFile keeps everything after
+/// `=` verbatim (no quoting needed), matching the other env files here.
 ///
-/// Inputs are validated in `crate::peers` at POST time.
-async fn write_reth_p2p_env(conf_dir: &Path, config: &InitConfig) -> Result<()> {
+/// One enode list fills both peer flags — see `crate::peers::PeerLists` for
+/// why reth gets it twice, and for the POST-time validation behind it.
+async fn write_reth_p2p_env(
+    conf_dir: &Path,
+    peer_enodes: &[String],
+    external_ip: &str,
+) -> Result<()> {
     let path = conf_dir.join("reth-p2p.env");
-    let bootnodes_flag = if config.network.bootnodes.is_empty() {
-        String::new()
+    let (bootnodes_flag, trusted_peers_flag) = if peer_enodes.is_empty() {
+        (String::new(), String::new())
     } else {
-        format!("--bootnodes {}", config.network.bootnodes.join(","))
+        let csv = peer_enodes.join(",");
+        (
+            format!("--bootnodes {csv}"),
+            format!("--trusted-peers {csv}"),
+        )
     };
-    let nat_flag = format!("--nat extip:{}", config.node.external_ip);
-    let content = format!("RETH_BOOTNODES_FLAG={bootnodes_flag}\nRETH_NAT_FLAG={nat_flag}\n");
+    let nat_flag = format!("--nat extip:{external_ip}");
+    let content = format!(
+        "RETH_BOOTNODES_FLAG={bootnodes_flag}\n\
+         RETH_TRUSTED_PEERS_FLAG={trusted_peers_flag}\n\
+         RETH_NAT_FLAG={nat_flag}\n"
+    );
     write_with_mode(&path, &content, DEFAULT_FILE_MODE).await?;
     info!("wrote {}", path.display());
     Ok(())
@@ -228,9 +246,10 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn drops_own_enode_from_peers_but_not_from_reth_bootnodes() {
-        // The persisted founding bootnode set includes this node's own enode;
-        // reth gets the full set while the root-key fetch skips self.
+    async fn drops_own_enode_from_every_rendered_list() {
+        // The persisted founding bootnode set includes this node's own enode.
+        // Nothing this node uses to reach others should name itself, so it is
+        // absent from both reth flags and from the root-key fetch list.
         let tmp = TempDir::new().unwrap();
         let mut cfg = sample_config(false);
         cfg.network.bootnodes = vec![enode("203.0.113.1:30303"), enode("10.0.0.2:30303")];
@@ -241,8 +260,14 @@ mod tests {
         assert_eq!(attestation, "SEISMIC_ROOT_KEY_PEERS=http://10.0.0.2:7878\n");
 
         let p2p = std::fs::read_to_string(tmp.path().join("reth-p2p.env")).unwrap();
-        assert!(p2p.contains("203.0.113.1:30303"), "{p2p}");
-        assert!(p2p.contains("10.0.0.2:30303"), "{p2p}");
+        assert!(!p2p.contains("203.0.113.1:30303"), "{p2p}");
+        let id = "a".repeat(128);
+        assert_eq!(
+            p2p,
+            format!(
+                "RETH_BOOTNODES_FLAG=--bootnodes enode://{id}@10.0.0.2:30303\nRETH_TRUSTED_PEERS_FLAG=--trusted-peers enode://{id}@10.0.0.2:30303\nRETH_NAT_FLAG=--nat extip:203.0.113.1\n"
+            )
+        );
     }
 
     #[tokio::test]
@@ -252,6 +277,23 @@ mod tests {
 
         let err = write_service_configs(tmp.path(), &cfg).await.unwrap_err();
         assert!(matches!(err, crate::error::TdxInitError::InvalidPeers(_)));
+    }
+
+    #[tokio::test]
+    async fn a_rejected_config_writes_nothing() {
+        // Validation runs to completion before any file is written, so a
+        // failure in the last-validated artifact still leaves an empty conf
+        // dir rather than a set of files the boot chain would go on to read.
+        let tmp = TempDir::new().unwrap();
+        let mut cfg = sample_config(true);
+        cfg.network.summit_genesis_base64 = "not base64".to_string();
+
+        let err = write_service_configs(tmp.path(), &cfg).await.unwrap_err();
+        assert!(matches!(
+            err,
+            crate::error::TdxInitError::InvalidSummitGenesis(_)
+        ));
+        assert_eq!(std::fs::read_dir(tmp.path()).unwrap().count(), 0);
     }
 
     #[tokio::test]
@@ -268,16 +310,17 @@ mod tests {
         assert_eq!(
             p2p,
             format!(
-                "RETH_BOOTNODES_FLAG=--bootnodes enode://{id}@10.0.0.1:30303,enode://{id}@10.0.0.2:30303\nRETH_NAT_FLAG=--nat extip:203.0.113.7\n"
+                "RETH_BOOTNODES_FLAG=--bootnodes enode://{id}@10.0.0.1:30303,enode://{id}@10.0.0.2:30303\nRETH_TRUSTED_PEERS_FLAG=--trusted-peers enode://{id}@10.0.0.1:30303,enode://{id}@10.0.0.2:30303\nRETH_NAT_FLAG=--nat extip:203.0.113.7\n"
             )
         );
     }
 
     #[tokio::test]
     async fn writes_reth_p2p_env_without_bootnodes() {
-        // The genesis node has no bootnodes: RETH_BOOTNODES_FLAG is empty so
-        // reth.service's unquoted expansion drops it, while RETH_NAT_FLAG is
-        // still populated from the (required) external_ip.
+        // The lone genesis node has no bootnodes: RETH_BOOTNODES_FLAG and
+        // RETH_TRUSTED_PEERS_FLAG are empty so reth.service's unquoted
+        // expansion drops them, while RETH_NAT_FLAG is still populated from the
+        // (required) external_ip.
         let tmp = TempDir::new().unwrap();
         let cfg = sample_config(true);
 
@@ -286,7 +329,7 @@ mod tests {
         let p2p = std::fs::read_to_string(tmp.path().join("reth-p2p.env")).unwrap();
         assert_eq!(
             p2p,
-            "RETH_BOOTNODES_FLAG=\nRETH_NAT_FLAG=--nat extip:203.0.113.1\n"
+            "RETH_BOOTNODES_FLAG=\nRETH_TRUSTED_PEERS_FLAG=\nRETH_NAT_FLAG=--nat extip:203.0.113.1\n"
         );
     }
 


### PR DESCRIPTION
discv5 bootstrap is one-shot. reth resolves a bare enode:// with a live UDP round-trip at startup; if a bootnode's :30303 is momentarily unreachable, the request fails, is logged at debug, and is never re-tried, so a joiner can silently sit outside the tx-gossip mesh. The conf dir is tmpfs, so every boot re-runs that one-shot bootstrap.

Hand the same enodes to --trusted-peers as well. reth dials trusted peers directly over RLPx with retry and exempts them from reputation slashing, so a dropped packet costs latency instead of a seat in the mesh. Both flags come from one PeerLists built in a single pass over [network].bootnodes, so they cannot disagree about who the cohort is. reth.service in seismic-images splices $RETH_TRUSTED_PEERS_FLAG alongside the bootnodes flag.

This node's own enode is now dropped from --bootnodes too, not just from the derived lists: nothing a node uses to reach others should name itself, and a self bootnode only buys a pointless request_enr to its own socket. The two flags are therefore byte-identical, which is why one field feeds both -- they do different jobs with the same input. --trusted-peers is how the node reaches the cohort; --bootnodes seeds discv5, which is how it reaches peers no founding-era list can name.

Also in this crate:

- write_service_configs validates every input before writing anything, so a bad config no longer leaves four env files and a conf dir behind (summit genesis is validated last, so this was reachable).
- warn when the peer list names no machine other than this node: correct for the genesis node at founding, a stale peer list on any later boot.