### PR TITLE
chore: pin a root rust-toolchain.toml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           components: rustfmt
       - name: Check formatting
-        run: cargo fmt --all --check
+        run: cargo +nightly fmt --all --check
 
   build:
     runs-on: ubuntu-latest

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,6 @@
+# The deployed binaries in bin/ ship inside the TDX image, and the image
+# measurement depends on the compiler that produced them. Pin the toolchain the
+# image build installs, so a local `cargo build` and the image build agree:
+# https://github.com/SeismicSystems/seismic-images/blob/seismic/modules/seismic/mkosi.build
+[toolchain]
+channel = "1.91.1"


### PR DESCRIPTION
The deployed binaries in bin/ ship inside the TDX image, and the image measurement depends on the compiler that produced them. Pin the toolchain the image build installs (1.91.1), so a local `cargo build` and the image build agree.

Channel only, no components: the image build installs the toolchain with a minimal profile, and locally rustup's default profile already carries rustfmt and clippy.

A toolchain file beats `rustup default`, so the fmt job would otherwise silently run the pinned rustfmt while still paying for the nightly install. Make its intent explicit with `cargo +nightly fmt`.