### PR TITLE
feat(tdx-init): deliver summit's advertised consensus address

### DIFF
--- a/bin/tdx-init/README.md
+++ b/bin/tdx-init/README.md
@@ -39,7 +39,7 @@ summit_genesis_base64 = "bmFtZXNwYWNlID0gInNlaXNtaWM..."
 bootnodes = ["enode://<128 hex pubkey>@host:port"]  # the cohort's peers; [] only on the genesis node
 
 [node]                               # this node only
-external_ip = "203.0.113.7"          # this VM's public IP (reth --nat extip:)
+external_ip = "203.0.113.7"          # this VM's public IP (reth --nat extip:, summit --ip)
 genesis_node = false                 # optional (default false); true on exactly one VM per network
 
 [node.domain]
@@ -104,12 +104,15 @@ unrepresentable — all three name the same machines by construction.
 
 `[node].external_ip` is this VM's public IP — Azure NICs hold private
 addresses, so reth's NAT autodetection can't be trusted; it is also what
-identifies the node's own enode in the bootnode set. Both fields are
-validated structurally at POST time (`src/peers.rs`): each bootnode must be
-`enode://<128 hex pubkey>@host:port`, `external_ip` must parse as an IP address, and
-a node with `genesis_node = false` must end up with at least one root-key
-peer; a bad value fails the deploy with `400`. `bootnodes = []` is valid only
-on the genesis node (nothing to dial; it mints `root_key` itself).
+identifies the node's own enode in the bootnode set, and the address summit
+advertises for consensus (`summit.env`, below). Both planes advertise the one
+delivered address, which is what keeps them agreed on where this machine is.
+Both fields are validated structurally at POST time (`src/peers.rs`): each
+bootnode must be `enode://<128 hex pubkey>@host:port`, `external_ip` must
+parse as an IP address, and a node with `genesis_node = false` must end up
+with at least one root-key peer; a bad value fails the deploy with `400`.
+`bootnodes = []` is valid only on the genesis node (nothing to dial; it mints
+`root_key` itself).
 
 ## Per-service outputs
 
@@ -123,7 +126,8 @@ After validation, tdx-init writes:
 | `/run/seismic/conf/network-manifest.json` | verbatim manifest bytes | [`seismic-attestation-service`](../attestation-service) — hashes the file itself to derive `network_id` for attestation bindings |
 | `/run/seismic/conf/reth-genesis.json` | verbatim reth genesis bytes | `reth.service` (seismic-images) — passed to `seismic-reth node --chain` |
 | `/run/seismic/conf/summit-genesis.toml` | verbatim summit genesis bytes | `summit.service` (seismic-images) — passed to `summit --genesis-path` |
-| `/run/seismic/conf/reth-p2p.env` | `RETH_BOOTNODES_FLAG=...`, `RETH_TRUSTED_PEERS_FLAG=...`, `RETH_NAT_FLAG=...` | `reth.service` (seismic-images) — loaded via `EnvironmentFile=`; each var holds a whole flag (`--bootnodes <csv>` / `--trusted-peers <csv>` / `--nat extip:<ip>`) or is empty, and the unit places the unquoted `$RETH_*_FLAG` vars on the command line so empty ones drop out |
+| `/run/seismic/conf/summit.env` | `SUMMIT_ADVERTISED_ADDR=<ip>:<consensus port>` | `summit.service` (seismic-images) — loaded via `EnvironmentFile=`; spliced into `summit --ip` as the consensus address this node signs and gossips to the cohort. Derived from `[node].external_ip`, the same address reth advertises via `--nat extip` |
+| `/run/seismic/conf/reth-p2p.env` | `RETH_BOOTNODES_FLAG=...`, `RETH_TRUSTED_PEERS_FLAG=...`, `RETH_NAT_FLAG=...` | `reth.service` (seismic-images) — loaded via `EnvironmentFile=`; each var holds a whole flag (`--bootnodes <csv>` / `--trusted-peers <csv>` / `--nat extip:<ip>`) or is empty, and the unit places the unquoted `$RETH_*_FLAG` vars on the command line so empty ones drop out. The peer flags are derived from `[network].bootnodes`, the NAT flag from `[node].external_ip` |
 
 Each downstream service reads its own native format (env-var pairs,
 either via systemd `EnvironmentFile=` or shell `source`); tdx-init is

--- a/bin/tdx-init/src/peers.rs
+++ b/bin/tdx-init/src/peers.rs
@@ -15,6 +15,10 @@
 //! input, so skew between them is unrepresentable and the `http://…:7878`
 //! convention lives in exactly one place.
 //!
+//! `[node].external_ip` is validated here too, as the address this machine is
+//! reached at: it decides which bootnode entry names this node itself, and it
+//! is the address summit advertises for consensus (`summit_advertised_addr`).
+//!
 //! Validation is structural, so a malformed enode or IP fails the deploy POST
 //! with `400` rather than surfacing when reth parses its flags at boot and
 //! crash-loops — likewise a non-genesis node left with no usable bootnode,
@@ -23,7 +27,7 @@
 
 use crate::config::NodeConfig;
 use crate::error::{Result, TdxInitError};
-use std::net::IpAddr;
+use std::net::{IpAddr, SocketAddr};
 use tracing::{info, warn};
 
 /// Number of hex chars in an enode node id: the 64-byte secp256k1 public key
@@ -34,6 +38,17 @@ const ENODE_ID_HEX_LEN: usize = 128;
 /// (`DEFAULT_ENDPOINT_PORT` in `bin/attestation-service`, which is a binary
 /// crate — the constant can't be imported).
 const ROOT_KEY_PEER_PORT: u16 = 7878;
+
+// TODO: delete this constant and emit the bare IP once
+// https://github.com/SeismicSystems/summit/pull/455 is merged and the image's
+// summit pin carries it. summit's `--ip` then takes an address without a port
+// and pairs it with its own `--port`, so `summit_advertised_addr` returns the
+// validated `IpAddr`, `summit.env` carries a host, and neither the port nor the
+// IPv6 bracketing it forces has to live here.
+/// Port summit accepts consensus connections on. Must equal the `--port` its
+/// systemd unit passes, since the two halves of `summit_advertised_addr` are
+/// what the node listens on and what it tells the cohort to dial.
+const SUMMIT_CONSENSUS_PORT: u16 = 18551;
 
 /// The cohort as this node's consumers need it: two renderings of the same
 /// machines, built in one pass from `[network].bootnodes` so they cannot
@@ -141,6 +156,28 @@ fn parse_enode_host(enode: &str) -> Result<&str> {
         ))
     })?;
     Ok(host)
+}
+
+/// The consensus address this node advertises to the cohort (`summit.env`'s
+/// `SUMMIT_ADVERTISED_ADDR`, spliced into summit's `--ip`): `external_ip` at
+/// the consensus port.
+///
+/// An address is not part of validator identity — summit's genesis carries the
+/// founding cohort's addresses outside its config digest, and a validator's
+/// consensus-state record holds none at all. Each node instead signs its own
+/// address and gossips that record, so this value is what the whole cohort
+/// dials this node on. Delivering it keeps that declaration sourced from the
+/// operator's descriptor, the same field reth advertises via `--nat extip`: a
+/// joining node has no genesis entry to read its address from, and would
+/// otherwise resolve one by asking public IP-echo services. It also keeps a
+/// founding node truthful across an address change, which its founding-era
+/// genesis entry cannot follow.
+///
+/// A `SocketAddr` rather than a formatted string: its `Display` brackets IPv6,
+/// which is the form summit parses.
+pub fn summit_advertised_addr(node: &NodeConfig) -> Result<SocketAddr> {
+    let external_ip = parse_external_ip(&node.external_ip)?;
+    Ok(SocketAddr::new(external_ip, SUMMIT_CONSENSUS_PORT))
 }
 
 /// Check that `external_ip` parses as an IPv4 or IPv6 address.
@@ -360,6 +397,26 @@ mod tests {
         let err = validate_and_derive_peers(&node("not.an.ip", true), &[enode("10.0.0.1:30303")])
             .unwrap_err();
         assert!(matches!(err, TdxInitError::InvalidPeers(_)));
+        assert!(err.to_string().contains("valid IP"), "{err}");
+    }
+
+    #[test]
+    fn advertises_external_ip_at_the_consensus_port() {
+        let addr = summit_advertised_addr(&node("203.0.113.7", false)).unwrap();
+        assert_eq!(addr.to_string(), "203.0.113.7:18551");
+    }
+
+    #[test]
+    fn advertises_ipv6_bracketed() {
+        // The address is handed to summit as text and parsed there as a socket
+        // address, so an IPv6 host has to arrive bracketed.
+        let addr = summit_advertised_addr(&node("2001:db8::7", false)).unwrap();
+        assert_eq!(addr.to_string(), "[2001:db8::7]:18551");
+    }
+
+    #[test]
+    fn advertised_addr_rejects_invalid_external_ip() {
+        let err = summit_advertised_addr(&node("not.an.ip", false)).unwrap_err();
         assert!(err.to_string().contains("valid IP"), "{err}");
     }
 }

--- a/bin/tdx-init/src/writer.rs
+++ b/bin/tdx-init/src/writer.rs
@@ -1,5 +1,6 @@
 use crate::config::InitConfig;
 use crate::error::Result;
+use std::net::SocketAddr;
 use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
 use tokio::fs;
@@ -24,6 +25,7 @@ pub const DEFAULT_FILE_MODE: u32 = 0o644;
 /// second half is then pure filesystem work that can only fail on I/O.
 pub async fn write_service_configs(conf_dir: &Path, config: &InitConfig) -> Result<()> {
     let peers = crate::peers::validate_and_derive_peers(&config.node, &config.network.bootnodes)?;
+    let summit_addr = crate::peers::summit_advertised_addr(&config.node)?;
     let manifest = crate::manifest::decode_and_validate(&config.network.manifest_base64)?;
     let genesis = crate::reth_genesis::decode_and_validate(
         &config.network.reth_genesis_base64,
@@ -39,6 +41,7 @@ pub async fn write_service_configs(conf_dir: &Path, config: &InitConfig) -> Resu
     write_custodian_env(conf_dir, config).await?;
     write_attestation_svc_env(conf_dir, &peers.root_key_urls).await?;
     write_reth_p2p_env(conf_dir, &peers.peer_enodes, &config.node.external_ip).await?;
+    write_summit_env(conf_dir, summit_addr).await?;
     write_network_manifest(conf_dir, &manifest).await?;
     write_reth_genesis(conf_dir, &genesis).await?;
     write_summit_genesis(conf_dir, &summit_genesis).await?;
@@ -155,6 +158,23 @@ async fn write_reth_p2p_env(
     );
     write_with_mode(&path, &content, DEFAULT_FILE_MODE).await?;
     info!("wrote {}", path.display());
+    Ok(())
+}
+
+/// summit's systemd unit loads this via `EnvironmentFile=` and splices
+/// `SUMMIT_ADVERTISED_ADDR` into `--ip`, as a quoted expansion: it is always
+/// populated (external_ip is required), so it needs none of the empty-var
+/// disappearing act `reth-p2p.env` above depends on.
+///
+/// A complete `<ip>:<port>` rather than a host the unit appends a port to —
+/// summit parses the value as one socket address, and IPv6 makes composing it
+/// textually a bracketing trap. See `crate::peers::summit_advertised_addr` for
+/// what the address means to the cohort.
+async fn write_summit_env(conf_dir: &Path, advertised_addr: SocketAddr) -> Result<()> {
+    let path = conf_dir.join("summit.env");
+    let content = format!("SUMMIT_ADVERTISED_ADDR={advertised_addr}\n");
+    write_with_mode(&path, &content, DEFAULT_FILE_MODE).await?;
+    info!("wrote {} (advertising {advertised_addr})", path.display());
     Ok(())
 }
 
@@ -334,6 +354,36 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn writes_summit_env() {
+        let tmp = TempDir::new().unwrap();
+        let mut cfg = sample_config(false);
+        cfg.network.bootnodes = vec![enode("10.0.0.2:30303")];
+        cfg.node.external_ip = "203.0.113.7".to_string();
+
+        write_service_configs(tmp.path(), &cfg).await.unwrap();
+
+        let env = std::fs::read_to_string(tmp.path().join("summit.env")).unwrap();
+        assert_eq!(env, "SUMMIT_ADVERTISED_ADDR=203.0.113.7:18551\n");
+    }
+
+    #[tokio::test]
+    async fn writes_summit_env_bracketing_ipv6() {
+        // summit parses the value as a SocketAddr, which requires the brackets
+        // an IPv6 external_ip does not carry. Appending ":<port>" to the bare
+        // address would emit a value it rejects, so the address is formatted as
+        // a SocketAddr rather than composed textually.
+        let tmp = TempDir::new().unwrap();
+        let mut cfg = sample_config(false);
+        cfg.network.bootnodes = vec![enode("[2001:db8::2]:30303")];
+        cfg.node.external_ip = "2001:db8::7".to_string();
+
+        write_service_configs(tmp.path(), &cfg).await.unwrap();
+
+        let env = std::fs::read_to_string(tmp.path().join("summit.env")).unwrap();
+        assert_eq!(env, "SUMMIT_ADVERTISED_ADDR=[2001:db8::7]:18551\n");
+    }
+
+    #[tokio::test]
     async fn writes_network_manifest_verbatim() {
         let tmp = TempDir::new().unwrap();
         let mut cfg = sample_config(true);
@@ -395,6 +445,7 @@ mod tests {
             "custodian.env",
             "attestation.env",
             "reth-p2p.env",
+            "summit.env",
         ] {
             let meta = std::fs::metadata(tmp.path().join(name)).unwrap();
             let mode = meta.permissions().mode() & 0o777;


### PR DESCRIPTION
Write summit.env with SUMMIT_ADVERTISED_ADDR, this node's external_ip at the consensus port, for summit's unit to splice into --ip.

An address is not part of validator identity in summit: its genesis carries the founding cohort's addresses outside the config digest, and a validator's consensus-state record holds none at all. Each node instead signs its own address and gossips that record, so the address a node declares is what the whole cohort dials it on. Nothing was delivering that declaration, which leaves it to summit's fallbacks: a founding node reads its own genesis entry, but a node joining an existing network has no entry there and resolves its address by asking public IP-echo services, then signs and gossips whatever they return.

Sourcing it from [node].external_ip is what keeps the two planes agreeing on where the machine is — the same field reth advertises via --nat extip, so no second delivered address can skew from it. It also keeps a founding node truthful across an address change, which its founding-era genesis entry cannot follow (those entries are deliberately outside the config digest, so IP churn never re-founds a network).

The value is a SocketAddr rather than a textually composed string: its Display brackets IPv6, which is the form summit parses. Composing "<external_ip>:<port>" would emit 2001:db8::7:18551 for an IPv6 node, which summit rejects at startup.

The consensus port is named here until summit takes --ip as a bare address and pairs it with its own --port
(https://github.com/SeismicSystems/summit/pull/455); the constant carries a TODO to drop it and the bracketing along with it.