### PR TITLE
chore: move the pinned toolchain to 1.95.0

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -3,4 +3,4 @@
 # image build installs, so a local `cargo build` and the image build agree:
 # https://github.com/SeismicSystems/seismic-images/blob/seismic/modules/seismic/mkosi.build
 [toolchain]
-channel = "1.91.1"
+channel = "1.95.0"


### PR DESCRIPTION
Part of SEI-309

summit pins 1.95.0, and the TDX image installs a single rustup toolchain for every repo it builds, ignoring per-repo toolchain files. Once that image carries a summit expecting 1.95, an older compiler builds newer code — the direction Rust makes no promise about. The reverse, older code on a newer compiler, is what its backwards-compatibility guarantee covers, so the versions converge upward rather than down.

This repo moves first. Its CI is the only one that denies warnings, and it finishes in minutes, so a new rustc or clippy lint fails here in a short loop instead of hours into an image build. The workspace builds clean at 1.95.0 under `RUSTFLAGS="-D warnings"`; nothing here needed a fix.

The image installs 1.95.0 in the same workstream, which is what keeps the comment above this pin true.