### PR TITLE
feat(attestation-service): serve evidence for the operator's deploy verification

### DIFF
--- a/bin/attestation-service/src/server.rs
+++ b/bin/attestation-service/src/server.rs
@@ -24,10 +24,12 @@ use jsonrpsee::{
 use secp256k1::PublicKey;
 use seismic_attestation::{
     NetworkId,
-    bindings::{binding64_from_digest32, tx_io_binding},
+    bindings::{binding64_from_digest32, deploy_verification_binding, tx_io_binding},
     generate_evidence,
 };
-use seismic_attestation_rpc::{AttestationRpcServer, TxIoAttestationResponse};
+use seismic_attestation_rpc::{
+    AttestationRpcServer, DeployVerificationResponse, TxIoAttestationResponse,
+};
 use seismic_custodian_ipc::{CustodianClient, IpcError};
 use std::{net::SocketAddr, path::PathBuf};
 use tracing::{info, warn};
@@ -135,6 +137,24 @@ impl AttestationRpcServer for AttestationService {
             epoch,
             evidence,
         })
+    }
+
+    /// Generate evidence for an operator's deploy verification of this node.
+    ///
+    /// The binding combines the caller's fresh `deployment_nonce` with this
+    /// service's own `network_id` — the caller picks nothing else, so the
+    /// method can't be used as an oracle to quote arbitrary transcripts.
+    async fn get_deploy_verification_evidence(
+        &self,
+        deployment_nonce: [u8; 32],
+    ) -> RpcResult<DeployVerificationResponse> {
+        let binding = deploy_verification_binding(&self.network_id, &deployment_nonce);
+        let evidence = generate_evidence(ATTESTATION_TYPE, binding64_from_digest32(binding))
+            .map_err(|error| {
+                internal_rpc_error("generating deploy-verification evidence", error)
+            })?;
+
+        Ok(DeployVerificationResponse { evidence })
     }
 }
 

--- a/bin/attestation-service/tests/evidence/evidence.rs
+++ b/bin/attestation-service/tests/evidence/evidence.rs
@@ -30,10 +30,12 @@ use crate::utils::{get_args, spawn_accepting_registry, spawn_custodian};
 use jsonrpsee::http_client::{HttpClient, HttpClientBuilder};
 use seismic_attestation::{
     AttestationType, NetworkId, NetworkManifestV1, SeismicMeasurementPolicy,
-    bindings::{binding64_from_digest32, tx_io_binding},
+    bindings::{binding64_from_digest32, deploy_verification_binding, tx_io_binding},
     verify_evidence_with_policy,
 };
-use seismic_attestation_rpc::{AttestationRpcClient as _, TxIoAttestationResponse};
+use seismic_attestation_rpc::{
+    AttestationRpcClient as _, DeployVerificationResponse, TxIoAttestationResponse,
+};
 use seismic_attestation_service::{
     api::NodeStatusRpcClient as _,
     utils::{init_tracing, is_sudo},
@@ -159,6 +161,66 @@ async fn test_tx_io_evidence_relying_party() {
         .await
         .is_err(),
         "tampered evidence verified successfully"
+    );
+
+    node.handle.abort();
+}
+
+/// The operator's deploy-verification path against a single genesis pair: the
+/// verifier sends a fresh `deployment_nonce`, recomputes the expected binding
+/// from its own manifest copy, and verifies the returned evidence; the same
+/// evidence must fail against another request's nonce and against another
+/// network's identity.
+#[serial_test::serial(attestation_evidence)]
+#[tokio::test]
+async fn test_deploy_verification_relying_party() {
+    init_tracing();
+    if !is_sudo() {
+        panic!("test_deploy_verification_relying_party: skipped (requires sudo privileges)");
+    }
+
+    let node = start_node("genesis node", 21, None).await;
+
+    let deployment_nonce = [0xD7u8; 32];
+    let response = get_deploy_verification_evidence(&node.client, deployment_nonce).await;
+
+    let network_id = NetworkId::from_manifest_bytes(EXPECTED_NETWORK_MANIFEST);
+    let expected_binding =
+        binding64_from_digest32(deploy_verification_binding(&network_id, &deployment_nonce));
+    verify_evidence_with_policy(
+        response.evidence.clone(),
+        expected_binding,
+        test_measurement_policy(),
+    )
+    .await
+    .expect("Verifier rejected valid deploy-verification evidence");
+
+    // A quote captured for one verification can't answer another: a different
+    // nonce derives a different binding.
+    let other_nonce_digest = deploy_verification_binding(&network_id, &[0xD8u8; 32]);
+    assert!(
+        verify_evidence_with_policy(
+            response.evidence.clone(),
+            binding64_from_digest32(other_nonce_digest),
+            test_measurement_policy(),
+        )
+        .await
+        .is_err(),
+        "evidence verified against another request's nonce"
+    );
+
+    // Nor can it pass for a node of a different network.
+    let other_network_digest =
+        deploy_verification_binding(&NetworkId::from_bytes([0xAB; 32]), &deployment_nonce);
+    assert!(
+        verify_evidence_with_policy(
+            response.evidence,
+            binding64_from_digest32(other_network_digest),
+            test_measurement_policy(),
+        )
+        .await
+        .is_err(),
+        "evidence verified against another network's binding"
     );
 
     node.handle.abort();
@@ -377,6 +439,29 @@ async fn get_tx_io_attestation_evidence(
                 assert!(
                     tokio::time::Instant::now() < deadline,
                     "Unable to get tx-io attestation evidence within {EVIDENCE_RPC_TIMEOUT:?}: {error}"
+                );
+            }
+        }
+        tokio::time::sleep(RETRY_INTERVAL).await;
+    }
+}
+
+async fn get_deploy_verification_evidence(
+    client: &HttpClient,
+    deployment_nonce: [u8; 32],
+) -> DeployVerificationResponse {
+    let deadline = tokio::time::Instant::now() + EVIDENCE_RPC_TIMEOUT;
+
+    loop {
+        match client
+            .get_deploy_verification_evidence(deployment_nonce)
+            .await
+        {
+            Ok(response) => return response,
+            Err(error) => {
+                assert!(
+                    tokio::time::Instant::now() < deadline,
+                    "Unable to get deploy-verification evidence within {EVIDENCE_RPC_TIMEOUT:?}: {error}"
                 );
             }
         }

--- a/crates/attestation-rpc/src/lib.rs
+++ b/crates/attestation-rpc/src/lib.rs
@@ -13,10 +13,13 @@ pub use seismic_attestation::AttestationExchangeMessage;
 /// Network-facing attestation evidence methods.
 ///
 /// Each method derives a purpose-specific evidence binding from its request
-/// inputs and the measured service's local state.
+/// inputs and the measured service's local state, and serves one kind of
+/// relying party, named in its doc.
 #[rpc(client, server)]
 pub trait AttestationRpc {
-    /// Attest this node's tx-io public key for `epoch`.
+    /// Attest this node's tx-io public key for `epoch`, for clients
+    /// authenticating the network's tx-io key before encrypting a TxSeismic
+    /// to it.
     ///
     /// The service derives `tx_io_binding(own_network_id, own_tx_io_pk, epoch)`.
     #[method(name = "getTxIoAttestationEvidence")]
@@ -25,7 +28,28 @@ pub trait AttestationRpc {
         epoch: u64,
     ) -> RpcResult<TxIoAttestationResponse>;
 
+    /// Attest this node for an operator verifying a freshly provisioned node
+    /// before relying on it — publishing its address, handing it to later
+    /// nodes as a bootnode, pointing tooling at it. The check protects only
+    /// those operator decisions: membership in the network itself is granted
+    /// by the network's own gates (the attested root-key handshake and its
+    /// admission policy), never by this check.
+    ///
+    /// The service derives
+    /// `deploy_verification_binding(own_network_id, deployment_nonce)`: the
+    /// caller contributes only freshness, and the method answers one fixed
+    /// question — a measured node holding the verifier's expected manifest is
+    /// live at this endpoint.
+    #[method(name = "getDeployVerificationEvidence")]
+    async fn get_deploy_verification_evidence(
+        &self,
+        deployment_nonce: [u8; 32],
+    ) -> RpcResult<DeployVerificationResponse>;
+
     /// Return the network root key wrapped to an attested booting peer.
+    ///
+    /// The caller is a joining node's own attestation service, acquiring the
+    /// network root key it does not yet hold from an existing node.
     ///
     /// The bodies remain opaque until `RootKeyRequest` and `RootKeyResponse`
     /// move into the planned bootstrap protocol crate. Keeping them opaque
@@ -44,5 +68,15 @@ pub struct TxIoAttestationResponse {
     pub epoch: u64,
     /// Complete backend evidence envelope. The relying client must verify this
     /// itself against its expected network, key, epoch, and measurement policy.
+    pub evidence: AttestationExchangeMessage,
+}
+
+/// Evidence answering an operator's deploy verification of one candidate node.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct DeployVerificationResponse {
+    /// Complete backend evidence envelope. The verifying operator must
+    /// recompute `deploy_verification_binding` from its own manifest's
+    /// `network_id` and the `deployment_nonce` it sent, then verify this
+    /// envelope against that binding and its measurement policy.
     pub evidence: AttestationExchangeMessage,
 }

--- a/crates/attestation/README.md
+++ b/crates/attestation/README.md
@@ -31,7 +31,7 @@ This crate is responsible for:
   - `tx_io_binding`,
   - `root_key_request_binding`,
   - `root_key_response_binding`,
-  - `deploy_preflight_binding`;
+  - `deploy_verification_binding`;
 - generating local evidence for a caller-supplied binding;
 - verifying remote evidence against an expected binding and a measurement policy;
 - exposing Seismic-typed verified outputs so callers do not mix provider-specific

--- a/crates/attestation/src/bindings.rs
+++ b/crates/attestation/src/bindings.rs
@@ -58,30 +58,23 @@ pub fn root_key_response_binding(
     hasher.finalize().into()
 }
 
-/// Binding for deploy-preflight verification of a candidate node.
+/// Binding for deploy verification of a candidate node.
 ///
-/// The deploy tool checks a freshly provisioned VM before wiring it into the
-/// network: it sends a fresh `deployment_nonce`, the node quotes over this
-/// binding using the `network_id` of the manifest it booted with, and the
-/// deploy tool recomputes the binding from its own copies of all three fields.
-/// A passing quote proves the node holds the expected manifest (right network,
-/// not a clone or wrong fork) and minted the evidence for this exact request
+/// An operator checks a freshly provisioned VM before relying on it: they
+/// send a fresh `deployment_nonce`, the node quotes over this binding using
+/// the `network_id` of the manifest it booted with, and the operator
+/// recomputes the binding from its own copies of both fields. A passing
+/// quote proves the node holds the expected manifest (right network, not a
+/// clone or wrong fork) and minted the evidence for this exact request
 /// (`deployment_nonce` is per-request, so captured quotes can't be replayed).
-///
-/// `context` identifies what is being preflighted, so an answer to one
-/// question can't be repurposed for another — e.g. a hash of the exact
-/// `node.toml` being POSTed to tdx-init, which makes the quote an attested
-/// acknowledgement of the delivered config.
-pub fn deploy_preflight_binding(
+pub fn deploy_verification_binding(
     network_id: &NetworkId,
     deployment_nonce: &[u8; 32],
-    context: &[u8],
 ) -> [u8; 32] {
     let mut hasher = Sha256::new();
     hasher.update(b"seismic-deploy-v1:");
     hasher.update(network_id.as_bytes());
     hasher.update(deployment_nonce);
-    hasher.update(context);
     hasher.finalize().into()
 }
 
@@ -163,12 +156,8 @@ mod tests {
             "2ac4df85ca3f07ca8f279bd6aea9db824e8481f776178e051439c92118782eee"
         );
         assert_eq!(
-            hex::encode(deploy_preflight_binding(
-                &network_id,
-                &[0x66; 32],
-                b"deploy-context"
-            )),
-            "780975fd8a3e5a2730261c967db281fc639360ecbc2f166fed1465f5dfae81d7"
+            hex::encode(deploy_verification_binding(&network_id, &[0x66; 32])),
+            "16a53bcb2d1421951a830a1308bca525b8ecfbf96fc89ad6152cdbfce4777eb9"
         );
         assert_eq!(
             hex::encode(founding_summit_keys_binding(

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -20,6 +20,13 @@ network/key/epoch binding, and verifies the complete evidence envelope
 through `seismic-attestation`; wrong bindings and malformed evidence are
 rejected.
 
+`test_deploy_verification_relying_party` runs an operator's deploy
+verification against a single genesis pair: the verifier sends a fresh
+`deployment_nonce`
+to `getDeployVerificationEvidence`, independently derives the expected
+network/nonce binding, and verifies the complete evidence envelope; bindings
+for another nonce or another network are rejected.
+
 `test_four_node_root_key_distribution` starts one genesis pair plus three
 joining pairs — two bootstrapping from the genesis node, one from an
 already-bootstrapped joiner — and checks that every join completes and all


### PR DESCRIPTION
Fixes SEI-181

An operator who has just provisioned a node holds only a liveness signal: :7878 opened. Everything they do next — publishing the node's address, handing it to later nodes as a bootnode — trusts that the endpoint is their node, and nothing yet proves it. A recycled IP, a clone, or a node booted with the wrong manifest all pass a port check, and the one evidence RPC already served is no help here: tx-io evidence is a deliberately timeless, cacheable document, so a replayed copy of it verifies perfectly at an impostor endpoint.

getDeployVerificationEvidence upgrades the signal to an attested one. The caller sends a fresh deployment_nonce; the service derives deploy_verification_binding(network_id, deployment_nonce) from its own manifest-derived identity and quotes over it. The verifier recomputes the binding from its own manifest copy and the nonce it sent, then verifies the envelope against its measurement policy. A passing quote proves a measured node holding the expected manifest minted evidence for this exact request. The caller contributes freshness and nothing else, so the method cannot be used as an oracle to quote transcripts of the caller's choosing.

The binding helper existed, tested but unused, as
deploy_preflight_binding(network_id, nonce, context). Both halves of that name change here. The context tail is dropped: this RPC is its only caller, the question it answers is fixed, and a future flow that needs to bind something else gets its own domain string rather than a context value — separate domains are what keep an answer to one question from passing as an answer to another. The digest is unchanged by the removal (SHA256(x || "") is SHA256(x)); the pinned vector moves only because the old one exercised a non-empty context. "Verification" replaces "preflight" because the check can only succeed after the node is fully up — a joiner binds :7878 only once the root-key handshake has completed — so what it precedes is the operator's reliance, not the node's flight. Membership itself is granted by that handshake and its admission policy, never by this check; the RPC guards the operator's own decisions.

The live-TEE suite gains test_deploy_verification_relying_party: the verifier's full path against a genesis pair, and rejection of the same evidence against another request's nonce and against another network's identity.

The deploy-side verifier that consumes this is SEI-183.