### PR TITLE
feat(attestation-service): report the admission chain status to the operator

### DIFF
--- a/bin/attestation-service/src/admission.rs
+++ b/bin/attestation-service/src/admission.rs
@@ -37,6 +37,7 @@
 //! window applies and no timestamp check bites. The pinned-genesis check
 //! bounds the second to the network's founding accepted set.
 
+use crate::api::AdmissionChainStatus;
 use alloy::{
     eips::{BlockId, BlockNumberOrTag},
     providers::{Provider, RootProvider},
@@ -58,7 +59,7 @@ use tracing::{info, warn};
 
 /// Why a bootstrap admission predicate denied a verified guest.
 #[derive(Debug, thiserror::Error)]
-pub enum AdmissionDenial {
+pub(crate) enum AdmissionDenial {
     #[error("only Azure TDX guests are admitted to the bootstrap; evidence is {0}")]
     UnsupportedAttestationType(AttestationType),
     #[error(transparent)]
@@ -106,7 +107,7 @@ pub enum AdmissionDenial {
 /// that identity accepted — because the remedies differ and each belongs to a
 /// different party.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum DenialKind {
+pub(crate) enum DenialKind {
     /// A verdict on the requester, reached before any identity was: nothing
     /// the network can appraise came out of its evidence. Its own operator
     /// investigates its attestation stack.
@@ -128,7 +129,7 @@ pub enum DenialKind {
 
 impl DenialKind {
     /// Whether retrying inside the handshake can change the answer.
-    pub fn is_retryable(self) -> bool {
+    pub(crate) fn is_retryable(self) -> bool {
         matches!(self, Self::ResponderTransient)
     }
 }
@@ -137,7 +138,7 @@ impl AdmissionDenial {
     /// Classify this denial. One exhaustive match, so a denial added later
     /// cannot inherit a class by omission — least of all a requester verdict,
     /// which tells a healthy joiner to stop asking.
-    pub fn kind(&self) -> DenialKind {
+    pub(crate) fn kind(&self) -> DenialKind {
         match self {
             // No admission ID came out of the evidence: a non-Azure
             // attestation type has no admission schema at all, and a PCR bank
@@ -184,7 +185,7 @@ const MAX_POLICY_AGE: Duration = Duration::from_secs(60);
 /// Responder-side admission: registry membership of the requester's
 /// admission ID, decided at fresh local chain state.
 #[derive(Clone)]
-pub struct RegistryAdmission {
+pub(crate) struct RegistryAdmission {
     registry: MeasurementRegistryInstance<RootProvider>,
     /// The genesis block `network_id` commits to, from the manifest's
     /// `eth.genesis_hash`. Every policy read is checked against it, so a
@@ -205,7 +206,7 @@ impl RegistryAdmission {
     /// manifest's `measurements.contracts.registry`), read over the node's
     /// local reth HTTP endpoint, on the chain whose genesis is
     /// `pinned_genesis` (the manifest's `eth.genesis_hash`).
-    pub fn new(reth_rpc_url: url::Url, registry: Address, pinned_genesis: B256) -> Self {
+    pub(crate) fn new(reth_rpc_url: url::Url, registry: Address, pinned_genesis: B256) -> Self {
         Self::with_provider(
             RootProvider::new_http(reth_rpc_url),
             registry,
@@ -225,7 +226,7 @@ impl RegistryAdmission {
     /// The same admission with a tighter policy-age bound. The admission
     /// integration suite injects seconds here, so the staleness denial is
     /// observable without waiting out the production bound.
-    pub fn with_max_policy_age(mut self, max_policy_age: Duration) -> Self {
+    pub(crate) fn with_max_policy_age(mut self, max_policy_age: Duration) -> Self {
         self.max_policy_age = max_policy_age;
         self
     }
@@ -304,6 +305,35 @@ impl RegistryAdmission {
             });
         }
         Ok(())
+    }
+
+    /// Local reth's genesis against the pin, for the operator-facing node
+    /// status ([`crate::api::NodeStatusRpc`]). A mismatch denies every join
+    /// with a class the wire deliberately does not name, so this is where the
+    /// operator who can repair it reads what is wrong.
+    ///
+    /// Strictly a read: it asks block 0 and nothing else, so it never advances
+    /// the genesis-window latch and can never change a decision. A reth that
+    /// does not answer reports as unreachable, never as a mismatch — the two
+    /// have different operator responses.
+    pub(crate) async fn chain_status(&self) -> AdmissionChainStatus {
+        let found = match self.block_by_tag(BlockNumberOrTag::Earliest).await {
+            Ok(genesis) => genesis.header.hash,
+            Err(denial) => {
+                return AdmissionChainStatus::RethUnreachable {
+                    error: denial.to_string(),
+                };
+            }
+        };
+        match self.check_pinned_genesis(found) {
+            Ok(()) => AdmissionChainStatus::Matches { genesis: found },
+            // Its only denial is the mismatch, and the pin it compared
+            // against is right here.
+            Err(_) => AdmissionChainStatus::GenesisMismatch {
+                expected: self.pinned_genesis,
+                found,
+            },
+        }
     }
 
     async fn block_by_tag(&self, tag: BlockNumberOrTag) -> Result<Block, AdmissionDenial> {
@@ -387,7 +417,7 @@ impl AdmissionPredicate for RegistryAdmission {
 /// responder against the network's pinned `tx_io_pk` commitment. Until that
 /// lands, a joiner talking to an attacker-chosen "responder" enclave gets no
 /// measurement guarantee beyond genuine Azure TDX hardware.
-pub struct DangerouslyAdmitAnyAzureGuest;
+pub(crate) struct DangerouslyAdmitAnyAzureGuest;
 
 impl AdmissionPredicate for DangerouslyAdmitAnyAzureGuest {
     async fn admit(
@@ -808,6 +838,57 @@ mod tests {
         assert!(
             error.to_string().contains("network_id commits to"),
             "{error}"
+        );
+    }
+
+    // The operator-facing status read (`chain_status`) must tell the three
+    // cases apart that carry different operator responses: this node serves
+    // the pinned chain, it serves another one, or reth has not answered.
+
+    #[tokio::test]
+    async fn chain_status_reports_the_pinned_genesis() {
+        let asserter = Asserter::new();
+        asserter.push_success(&rpc_block(0, 1_000));
+        let admission = mocked_registry(&asserter);
+
+        assert_eq!(
+            admission.chain_status().await,
+            AdmissionChainStatus::Matches {
+                genesis: PINNED_GENESIS
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn chain_status_reports_a_foreign_genesis_with_both_halves() {
+        // One response and no more: the status is a single block-0 read, so it
+        // cannot advance the genesis-window latch or touch the registry.
+        let asserter = Asserter::new();
+        asserter.push_success(&foreign_block(0, now_millis()));
+        let admission = mocked_registry(&asserter);
+
+        // Both hashes, because the operator's next move is comparing the chain
+        // its reth booted from against the one the manifest names.
+        assert_eq!(
+            admission.chain_status().await,
+            AdmissionChainStatus::GenesisMismatch {
+                expected: PINNED_GENESIS,
+                found: foreign_block(0, 0).header.hash,
+            }
+        );
+        assert!(!admission.chain_has_advanced.load(Ordering::Relaxed));
+    }
+
+    #[tokio::test]
+    async fn unreachable_reth_reports_unknown_not_a_mismatch() {
+        let asserter = Asserter::new();
+        asserter.push_failure_msg("connection refused");
+        let admission = mocked_registry(&asserter);
+
+        let status = admission.chain_status().await;
+        assert!(
+            matches!(status, AdmissionChainStatus::RethUnreachable { .. }),
+            "{status:?}"
         );
     }
 

--- a/bin/attestation-service/src/api.rs
+++ b/bin/attestation-service/src/api.rs
@@ -1,9 +1,17 @@
+use alloy_primitives::B256;
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
 use serde::{Deserialize, Serialize};
 
-/// Operator-facing status surface of the attestation service: liveness plus
-/// first-boot progress. Consumers speak raw JSON-RPC over HTTP (the deploy
-/// CLI, health probes); the generated Rust client exists for tests.
+/// Operator-facing status surface of the attestation service:
+///
+/// - liveness of the service itself,
+/// - first-boot disk-provisioning progress,
+/// - whether admission is reading this network's chain.
+///
+/// Each answers a question only this node's operator acts on, which is what
+/// separates them from the peer-facing methods. Consumers speak raw JSON-RPC
+/// over HTTP (the deploy CLI, health probes); the generated Rust client exists
+/// for tests.
 #[rpc(client, server)]
 pub trait NodeStatusRpc {
     /// Health check endpoint that returns "OK" if service is running
@@ -21,6 +29,16 @@ pub trait NodeStatusRpc {
     /// this.
     #[method(name = "getLuksProvisioningStatus")]
     async fn get_luks_provisioning_status(&self) -> RpcResult<LuksProvisioningStatus>;
+
+    /// Report whether this node's admission gate is reading the chain its
+    /// network manifest commits to.
+    ///
+    /// Admission denies every join while local reth serves a foreign genesis,
+    /// and the only party who can repair that is this node's operator — a
+    /// requester cannot. So the detail is reported here, where operators
+    /// already look, rather than in the answer a refused joiner gets.
+    #[method(name = "getAdmissionChainStatus")]
+    async fn get_admission_chain_status(&self) -> RpcResult<AdmissionChainStatus>;
 }
 
 // TODO: this is intentionally scoped to just the first-boot LUKS wipe - the one
@@ -60,4 +78,30 @@ pub enum LuksProvisioningStatus {
     /// or a perms/IO issue, NOT evidence the wipe finished. The consumer should
     /// surface a warning and keep polling, never treat this as "done".
     Unknown,
+}
+
+/// Local reth's genesis block against the one this node's network manifest
+/// pins (`eth.genesis_hash`) — the precondition every admission decision
+/// re-checks before it reads the on-chain policy.
+///
+/// Computed per call, never cached or checked at startup: reth comes up after
+/// this service, so this must be able to answer `Matches` later without a
+/// restart. Every field is public network data — the pin is in the manifest
+/// and block 0 is served on the node's public `/rpc` — so an unauthenticated
+/// caller learns nothing here it could not compute itself.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "state", rename_all = "snake_case")]
+pub enum AdmissionChainStatus {
+    /// Local reth serves the pinned genesis: admission is deciding joins on
+    /// this network's chain, by the live policy it carries.
+    Matches { genesis: B256 },
+    /// Local reth serves some other chain, so this node admits nobody until an
+    /// operator boots it from this network's genesis. Terminal — waiting
+    /// changes nothing, and a re-provision is the fix.
+    GenesisMismatch { expected: B256, found: B256 },
+    /// Local reth did not answer, so which chain it serves is unknown — not
+    /// evidence of a mismatch. Expected during the boot tail (reth starts
+    /// after this service) and across a reth restart; `error` carries this
+    /// node's own failed query.
+    RethUnreachable { error: String },
 }

--- a/bin/attestation-service/src/server.rs
+++ b/bin/attestation-service/src/server.rs
@@ -8,7 +8,7 @@
 use crate::{
     ATTESTATION_TYPE, Args,
     admission::RegistryAdmission,
-    api::{LuksProvisioningStatus, NodeStatusRpcServer},
+    api::{AdmissionChainStatus, LuksProvisioningStatus, NodeStatusRpcServer},
     bootstrap::{RootKeyRequest, answer_root_key_request},
     join::ensure_root_key_present,
     network::{NETWORK_MANIFEST_PATH, load_manifest},
@@ -79,6 +79,14 @@ impl NodeStatusRpcServer for AttestationService {
     /// [`crate::luks_status`].
     async fn get_luks_provisioning_status(&self) -> RpcResult<LuksProvisioningStatus> {
         Ok(crate::luks_status::read())
+    }
+
+    /// Report whether local reth serves the genesis this node's manifest pins,
+    /// the precondition every admission decision has. Asked on demand, so a
+    /// node whose reth is still coming up answers unreachable now and matches
+    /// later. See [`crate::admission`].
+    async fn get_admission_chain_status(&self) -> RpcResult<AdmissionChainStatus> {
+        Ok(self.admission.chain_status().await)
     }
 }
 

--- a/bin/attestation-service/tests/admission.rs
+++ b/bin/attestation-service/tests/admission.rs
@@ -19,7 +19,8 @@
 //! - an unreachable (`-32003`) or **stale** (`-32003`, via a tightened
 //!   policy-age bound) local reth fails closed;
 //! - a local reth serving a chain the manifest does not commit to fails closed
-//!   (`-32003`), exercising the pinned `eth.genesis_hash` end to end.
+//!   (`-32003`) and names both chains on the operator-facing node status,
+//!   exercising the pinned `eth.genesis_hash` end to end.
 //!
 //! The genesis is generated at runtime, not committed: evidence carries the
 //! runner's real PCRs, so the seeded policy is compiled either from the
@@ -70,7 +71,7 @@ use seismic_attestation::{
 use seismic_attestation_rpc::AttestationRpcClient as _;
 use seismic_attestation_service::{
     Args,
-    api::NodeStatusRpcClient as _,
+    api::{AdmissionChainStatus, NodeStatusRpcClient as _},
     bootstrap::build_root_key_request,
     rpc_error::RootKeyRefusal,
     utils::{init_tracing, is_sudo},
@@ -215,6 +216,18 @@ async fn test_accepted_tuple_wraps_once_then_deprecation_applies_live() {
             .expect("responder still serving after the denial"),
         "OK"
     );
+    // A denial on the requester's identity says nothing about this node's own
+    // chain, which is the pinned one throughout.
+    assert_eq!(
+        responder
+            .client
+            .get_admission_chain_status()
+            .await
+            .expect("responder serves its admission chain status"),
+        AdmissionChainStatus::Matches {
+            genesis: genesis_hash(&provider).await
+        }
+    );
     responder.handle.abort();
 }
 
@@ -320,6 +333,28 @@ async fn test_foreign_pinned_genesis_fails_closed() {
         RootKeyRefusal::ResponderUnavailable
     );
     assert_eq!(responder.wrap_count.load(Ordering::SeqCst), 0);
+    // The joiner is told only that this responder could not decide; the
+    // operator who can repair it is told which two chains disagree, on the
+    // status surface, while `healthCheck` still reports the service itself up.
+    assert_eq!(
+        responder
+            .client
+            .health_check()
+            .await
+            .expect("responder still serving"),
+        "OK"
+    );
+    assert_eq!(
+        responder
+            .client
+            .get_admission_chain_status()
+            .await
+            .expect("responder serves its admission chain status"),
+        AdmissionChainStatus::GenesisMismatch {
+            expected: FOREIGN_GENESIS,
+            found: genesis_hash(&provider).await,
+        }
+    );
     responder.handle.abort();
 }
 
@@ -555,12 +590,19 @@ async fn wait_for_rpc(node: &RethNode) -> RootProvider {
 /// file's bytes, so callers must hash the returned bytes rather than
 /// re-serialize the manifest.
 async fn install_network_manifest(provider: &RootProvider) -> Vec<u8> {
-    let genesis = provider
+    install_manifest_pinning(genesis_hash(provider).await)
+}
+
+/// The block-0 hash the live dev node serves: the chain a status read finds,
+/// whether or not the installed manifest pins it.
+async fn genesis_hash(provider: &RootProvider) -> B256 {
+    provider
         .get_block_by_number(alloy::eips::BlockNumberOrTag::Earliest)
         .await
         .expect("genesis query")
-        .expect("dev node serves block 0");
-    install_manifest_pinning(genesis.header.hash)
+        .expect("dev node serves block 0")
+        .header
+        .hash
 }
 
 /// Render the manifest that pins `genesis_hash`, drop it at the service's


### PR DESCRIPTION
Fixes SEI-279.

getAdmissionChainStatus joins the node-status surface: local reth's genesis block against the manifest's eth.genesis_hash pin, the precondition every admission decision re-checks before reading the on-chain policy. Three answers, because they carry different operator responses:

- matches, with the genesis hash
- genesis_mismatch, with both hashes — the operator's next move is comparing the chain reth booted from against the one the manifest names
- reth_unreachable, with this node's own failed query — expected during the boot tail and across a reth restart, never evidence of a mismatch

The refused joiner keeps getting the class the wire deliberately does not detail: a mismatch denies every join, but only this node's operator can repair it, so the two halves are reported where operators already look rather than in the refusal. The read is strict — one block-0 query, so it never advances the genesis-window latch and cannot change a decision. It is computed per call, never cached: reth comes up after this service, so a node answers unreachable now and matches later without a restart. Every field is public network data (the pin is in the manifest, block 0 on the public /rpc), so an unauthenticated caller learns nothing it could not compute itself.

The admission module's items also stop being public API: everything main wires up (RegistryAdmission, AdmissionDenial, DenialKind, DangerouslyAdmitAnyAzureGuest) is now pub(crate), leaving the RPC traits as the crate's surface.

Unit tests cover the three answers and that the mismatch read leaves the genesis-window latch untouched; the admission integration suite asserts the status on both live denials — a requester-identity denial still reports matches, and a foreign pinned genesis names both chains while healthCheck stays OK.