### PR TITLE
refactor(attestation)!: verify only attested evidence

### DIFF
--- a/bin/attestation-service/examples/capture_measurements.rs
+++ b/bin/attestation-service/examples/capture_measurements.rs
@@ -51,7 +51,7 @@ use seismic_attestation::{
     AttestationType, NetworkId, SeismicMeasurementPolicy, VerifiedSeismicAttestation,
     VerifyOptions,
     bindings::{binding64_from_digest32, tx_io_binding},
-    verify_evidence_with_policy_and_options,
+    verify_evidence_with_policy,
 };
 use seismic_attestation_rpc::AttestationRpcClient;
 use std::collections::BTreeMap;
@@ -151,7 +151,7 @@ async fn main() -> anyhow::Result<()> {
     };
 
     println!("Verifying evidence...");
-    let verified = verify_evidence_with_policy_and_options(
+    let verified = verify_evidence_with_policy(
         response.evidence,
         expected_binding,
         policy,

--- a/bin/attestation-service/src/admission.rs
+++ b/bin/attestation-service/src/admission.rs
@@ -442,7 +442,9 @@ mod tests {
     use super::*;
     use alloy::{rpc::client::RpcClient, transports::mock::Asserter};
     use alloy_primitives::{Bytes, b256};
-    use seismic_attestation::{AzureGuestMeasurements, VerifiedAzureAttestation};
+    use seismic_attestation::{
+        AzureGuestMeasurements, TdxMeasurements, VerifiedAzureAttestation, VerifiedTdxAttestation,
+    };
     use std::collections::HashMap;
 
     // The golden Azure v1 vector pinned in `seismic-measurement-admission`:
@@ -457,6 +459,21 @@ mod tests {
         VerifiedSeismicAttestation::AzureTdx(VerifiedAzureAttestation {
             binding: [0u8; 64],
             guest_measurements: AzureGuestMeasurements { pcrs },
+        })
+    }
+
+    /// A verified guest of the one attested type no bootstrap predicate has
+    /// an admission schema for.
+    fn verified_dcap() -> VerifiedSeismicAttestation {
+        VerifiedSeismicAttestation::DcapTdx(VerifiedTdxAttestation {
+            binding: [0u8; 64],
+            measurements: TdxMeasurements {
+                mrtd: [0u8; 48],
+                rtmr0: [0u8; 48],
+                rtmr1: [0u8; 48],
+                rtmr2: [0u8; 48],
+                rtmr3: [0u8; 48],
+            },
         })
     }
 
@@ -607,11 +624,10 @@ mod tests {
 
     #[test]
     fn non_azure_attestation_fails_closed() {
-        let verified = VerifiedSeismicAttestation::NoAttestation { binding: [0u8; 64] };
         assert!(matches!(
-            azure_admission_id(&verified),
+            azure_admission_id(&verified_dcap()),
             Err(AdmissionDenial::UnsupportedAttestationType(
-                AttestationType::None
+                AttestationType::DcapTdx
             ))
         ));
     }
@@ -915,7 +931,7 @@ mod tests {
             .expect("any Azure guest is admitted by the temporary predicate");
 
         DangerouslyAdmitAnyAzureGuest
-            .admit(&VerifiedSeismicAttestation::NoAttestation { binding: [0u8; 64] })
+            .admit(&verified_dcap())
             .await
             .expect_err("non-Azure attestation types are denied even by the temporary predicate");
     }

--- a/bin/attestation-service/src/rpc_error.rs
+++ b/bin/attestation-service/src/rpc_error.rs
@@ -181,11 +181,16 @@ fn verification_failure_kind(error: &AttestationError) -> Option<DenialKind> {
             Some(denial.downcast_ref::<AdmissionDenial>()?.kind())
         }
         AttestationError::Backend(backend) => backend_failure_kind(backend),
+        // The requester sent evidence that attests nothing, so no identity
+        // came out of it. Same verdict as a quote that fails to verify: its
+        // operator fixes the attestation stack, and the network never saw an
+        // identity to accept or reject.
+        AttestationError::Unattested => Some(DenialKind::RequesterEvidenceUnusable),
         // This service's own policy document and the backend's measurement
         // output: neither party's problem, and no verdict either way.
-        AttestationError::PolicyFormat(_)
-        | AttestationError::MissingMeasurements { .. }
-        | AttestationError::MeasurementTypeMismatch { .. } => None,
+        AttestationError::PolicyFormat(_) | AttestationError::MeasurementTypeMismatch { .. } => {
+            None
+        }
     }
 }
 
@@ -372,8 +377,12 @@ mod tests {
     fn requester_verdicts_split_evidence_from_identity() {
         assert_eq!(
             refusal_of(denial_error(AdmissionDenial::UnsupportedAttestationType(
-                seismic_attestation::AttestationType::None
+                seismic_attestation::AttestationType::DcapTdx
             ))),
+            Some(RootKeyRefusal::RequesterEvidenceUnusable)
+        );
+        assert_eq!(
+            refusal_of(verify_error(AttestationError::Unattested)),
             Some(RootKeyRefusal::RequesterEvidenceUnusable)
         );
 
@@ -433,8 +442,9 @@ mod tests {
             // An unnamed backend variant must not reach a verdict.
             backend_error(BackendAttestationError::MeasurementsNotAccepted),
             // This responder's own plumbing.
-            verify_error(AttestationError::MissingMeasurements {
+            verify_error(AttestationError::MeasurementTypeMismatch {
                 attestation_type: seismic_attestation::AttestationType::AzureTdx,
+                measurements: Box::new(seismic_attestation::MultiMeasurements::NoAttestation),
             }),
             AnswerError::WrapRootKey {
                 source: seismic_custodian_ipc::IpcError::Denied("WrapRootKey".into()),

--- a/bin/attestation-service/tests/admission.rs
+++ b/bin/attestation-service/tests/admission.rs
@@ -66,7 +66,7 @@ use alloy_primitives::{Address, B256, address, keccak256};
 use jsonrpsee::http_client::{HttpClient, HttpClientBuilder};
 use seismic_attestation::{
     AttestationType, NetworkId, SeismicMeasurementPolicy, VerifiedSeismicAttestation,
-    generate_evidence, verify_evidence_with_policy,
+    VerifyOptions, generate_evidence, verify_evidence_with_policy,
 };
 use seismic_attestation_rpc::AttestationRpcClient as _;
 use seismic_attestation_service::{
@@ -369,6 +369,7 @@ async fn observed_pcrs() -> HashMap<u32, [u8; 32]> {
         evidence,
         binding,
         SeismicMeasurementPolicy::dangerously_accept_any_for_testing(AttestationType::AzureTdx),
+        VerifyOptions::default(),
     )
     .await
     .expect("verifying our own quote");

--- a/bin/attestation-service/tests/evidence/evidence.rs
+++ b/bin/attestation-service/tests/evidence/evidence.rs
@@ -29,7 +29,7 @@ use std::{
 use crate::utils::{get_args, spawn_accepting_registry, spawn_custodian};
 use jsonrpsee::http_client::{HttpClient, HttpClientBuilder};
 use seismic_attestation::{
-    AttestationType, NetworkId, NetworkManifestV1, SeismicMeasurementPolicy,
+    AttestationType, NetworkId, NetworkManifestV1, SeismicMeasurementPolicy, VerifyOptions,
     bindings::{binding64_from_digest32, deploy_verification_binding, tx_io_binding},
     verify_evidence_with_policy,
 };
@@ -122,6 +122,7 @@ async fn test_tx_io_evidence_relying_party() {
         response.evidence.clone(),
         expected_binding,
         test_measurement_policy(),
+        VerifyOptions::default(),
     )
     .await
     .expect("Relying client rejected valid tx-io evidence");
@@ -136,6 +137,7 @@ async fn test_tx_io_evidence_relying_party() {
             response.evidence.clone(),
             binding64_from_digest32(wrong_epoch_digest),
             test_measurement_policy(),
+            VerifyOptions::default(),
         )
         .await
         .is_err(),
@@ -157,6 +159,7 @@ async fn test_tx_io_evidence_relying_party() {
             tampered_evidence,
             expected_binding,
             test_measurement_policy(),
+            VerifyOptions::default(),
         )
         .await
         .is_err(),
@@ -191,6 +194,7 @@ async fn test_deploy_verification_relying_party() {
         response.evidence.clone(),
         expected_binding,
         test_measurement_policy(),
+        VerifyOptions::default(),
     )
     .await
     .expect("Verifier rejected valid deploy-verification evidence");
@@ -203,6 +207,7 @@ async fn test_deploy_verification_relying_party() {
             response.evidence.clone(),
             binding64_from_digest32(other_nonce_digest),
             test_measurement_policy(),
+            VerifyOptions::default(),
         )
         .await
         .is_err(),
@@ -217,6 +222,7 @@ async fn test_deploy_verification_relying_party() {
             response.evidence,
             binding64_from_digest32(other_network_digest),
             test_measurement_policy(),
+            VerifyOptions::default(),
         )
         .await
         .is_err(),

--- a/bin/verify-quote/src/main.rs
+++ b/bin/verify-quote/src/main.rs
@@ -48,7 +48,7 @@ use seismic_attestation::{
     bindings::{
         binding64_from_digest32, deploy_verification_binding, founding_summit_keys_binding,
     },
-    verify_evidence_with_policy_and_options,
+    verify_evidence_with_policy,
 };
 use seismic_attestation_rpc::AttestationRpcClient as _;
 use serde::Deserialize;
@@ -323,7 +323,7 @@ async fn verify_azure(
         evidence.attestation_type().as_str(),
     );
 
-    let verified = verify_evidence_with_policy_and_options(
+    let verified = verify_evidence_with_policy(
         evidence,
         binding,
         policy,

--- a/crates/attestation/Cargo.toml
+++ b/crates/attestation/Cargo.toml
@@ -36,4 +36,6 @@ az-tdx-vtpm.workspace = true
 az-cvm-vtpm.workspace = true
 dcap-rs.workspace = true
 clap.workspace = true
+
+[dev-dependencies]
 tokio.workspace = true

--- a/crates/attestation/examples/azure_vtpm_roundtrip.rs
+++ b/crates/attestation/examples/azure_vtpm_roundtrip.rs
@@ -43,8 +43,7 @@ use clap::{Args as ClapArgs, Parser, Subcommand};
 #[cfg(target_os = "linux")]
 use seismic_attestation::{
     AttestationExchangeMessage, AttestationType, SeismicMeasurementPolicy,
-    VerifiedSeismicAttestation, VerifyOptions, generate_evidence,
-    verify_evidence_with_policy_and_options,
+    VerifiedSeismicAttestation, VerifyOptions, generate_evidence, verify_evidence_with_policy,
 };
 
 #[cfg(target_os = "linux")]
@@ -254,7 +253,7 @@ async fn verify_exchange_message(
     policy: SeismicMeasurementPolicy,
     backend: BackendArgs,
 ) -> anyhow::Result<VerifiedSeismicAttestation> {
-    let verified = verify_evidence_with_policy_and_options(
+    let verified = verify_evidence_with_policy(
         evidence,
         binding,
         policy,

--- a/crates/attestation/src/lib.rs
+++ b/crates/attestation/src/lib.rs
@@ -95,21 +95,6 @@ pub async fn verify_evidence_with_policy(
     evidence: AttestationExchangeMessage,
     expected_binding: [u8; 64],
     policy: SeismicMeasurementPolicy,
-) -> Result<VerifiedSeismicAttestation, AttestationError> {
-    verify_evidence_with_policy_and_options(
-        evidence,
-        expected_binding,
-        policy,
-        VerifyOptions::default(),
-    )
-    .await
-}
-
-/// Same as [`verify_evidence_with_policy`], with backend operational options.
-pub async fn verify_evidence_with_policy_and_options(
-    evidence: AttestationExchangeMessage,
-    expected_binding: [u8; 64],
-    policy: SeismicMeasurementPolicy,
     options: VerifyOptions,
 ) -> Result<VerifiedSeismicAttestation, AttestationError> {
     verify_with_backend_policy(
@@ -177,7 +162,12 @@ async fn verify_with_backend_policy(
 
     let measurements = verifier
         .verify_attestation(evidence, expected_binding)
-        .await?;
+        .await?
+        // The verifier accepts evidence that declares no attestation when its
+        // policy names no attested platform, and reports that as `None`. Every
+        // Seismic relying party appraises a TEE node, so unattested evidence is
+        // refused here, before any admission predicate sees it.
+        .ok_or(AttestationError::Unattested)?;
 
     VerifiedSeismicAttestation::from_backend(attestation_type, expected_binding, measurements)
 }
@@ -192,9 +182,7 @@ async fn verify_with_backend_policy(
 /// guest is *allowed* — for example, membership of its derived admission ID in
 /// the on-chain `MeasurementRegistry`. Predicates own the entire appraisal,
 /// including which attestation types they admit: a predicate must deny
-/// [`VerifiedSeismicAttestation`] variants it does not appraise, in particular
-/// [`VerifiedSeismicAttestation::NoAttestation`], whose cryptographic
-/// verification is vacuous.
+/// [`VerifiedSeismicAttestation`] variants it does not appraise.
 pub trait AdmissionPredicate {
     /// Appraise verified measurements; any `Err` denies admission.
     fn admit(
@@ -261,27 +249,30 @@ pub struct VerifyOptions {
 
 /// Generic verified Seismic attestation output.
 ///
-/// Provider-specific measurements stay in provider-specific variants so callers
-/// cannot accidentally combine, for example, `dcap-tdx` with Azure PCRs.
+/// Every variant carries verified measurements from an attested platform.
+/// Provider-specific measurements stay in provider-specific variants so
+/// callers cannot accidentally combine, for example, `dcap-tdx` with Azure
+/// PCRs.
+///
+/// The variants mirror the verifier's [`MultiMeasurements`] paired with the
+/// [`AttestationType`] that produced them; `from_backend` is the one place
+/// the two are matched up, and a platform not mirrored here fails there as
+/// [`AttestationError::MeasurementTypeMismatch`].
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum VerifiedSeismicAttestation {
     AzureTdx(VerifiedAzureAttestation),
     DcapTdx(VerifiedTdxAttestation),
     GcpTdx(VerifiedTdxAttestation),
-    NoAttestation { binding: [u8; 64] },
 }
 
 impl VerifiedSeismicAttestation {
     fn from_backend(
         attestation_type: AttestationType,
         binding: [u8; 64],
-        measurements: Option<MultiMeasurements>,
+        measurements: MultiMeasurements,
     ) -> Result<Self, AttestationError> {
         match (attestation_type, measurements) {
-            (AttestationType::None, None | Some(MultiMeasurements::NoAttestation)) => {
-                Ok(Self::NoAttestation { binding })
-            }
-            (AttestationType::AzureTdx, Some(MultiMeasurements::Azure(pcrs))) => {
+            (AttestationType::AzureTdx, MultiMeasurements::Azure(pcrs)) => {
                 Ok(Self::AzureTdx(VerifiedAzureAttestation {
                     binding,
                     guest_measurements: AzureGuestMeasurements {
@@ -289,27 +280,22 @@ impl VerifiedSeismicAttestation {
                     },
                 }))
             }
-            (AttestationType::DcapTdx, Some(MultiMeasurements::Dcap(measurements))) => {
+            (AttestationType::DcapTdx, MultiMeasurements::Dcap(measurements)) => {
                 Ok(Self::DcapTdx(VerifiedTdxAttestation {
                     binding,
                     measurements: measurements.into(),
                 }))
             }
-            (AttestationType::GcpTdx, Some(MultiMeasurements::Dcap(measurements))) => {
+            (AttestationType::GcpTdx, MultiMeasurements::Dcap(measurements)) => {
                 Ok(Self::GcpTdx(VerifiedTdxAttestation {
                     binding,
                     measurements: measurements.into(),
                 }))
             }
-            (attestation_type, None) => {
-                Err(AttestationError::MissingMeasurements { attestation_type })
-            }
-            (attestation_type, Some(measurements)) => {
-                Err(AttestationError::MeasurementTypeMismatch {
-                    attestation_type,
-                    measurements: Box::new(measurements),
-                })
-            }
+            (attestation_type, measurements) => Err(AttestationError::MeasurementTypeMismatch {
+                attestation_type,
+                measurements: Box::new(measurements),
+            }),
         }
     }
 
@@ -318,7 +304,6 @@ impl VerifiedSeismicAttestation {
             Self::AzureTdx(_) => AttestationType::AzureTdx,
             Self::DcapTdx(_) => AttestationType::DcapTdx,
             Self::GcpTdx(_) => AttestationType::GcpTdx,
-            Self::NoAttestation { .. } => AttestationType::None,
         }
     }
 
@@ -326,7 +311,6 @@ impl VerifiedSeismicAttestation {
         match self {
             Self::AzureTdx(verified) => &verified.binding,
             Self::DcapTdx(verified) | Self::GcpTdx(verified) => &verified.binding,
-            Self::NoAttestation { binding } => binding,
         }
     }
 }
@@ -388,8 +372,8 @@ pub enum AttestationError {
     AdmissionDenied(#[source] Box<dyn std::error::Error + Send + Sync>),
     #[error("measurement policy format error: {0}")]
     PolicyFormat(#[from] MeasurementFormatError),
-    #[error("attestation backend returned no measurements for {attestation_type}")]
-    MissingMeasurements { attestation_type: AttestationType },
+    #[error("evidence declares no attestation; only attested evidence is verified")]
+    Unattested,
     #[error("backend returned measurements inconsistent with {attestation_type}: {measurements:?}")]
     MeasurementTypeMismatch {
         attestation_type: AttestationType,
@@ -474,7 +458,7 @@ mod tests {
         let verified = VerifiedSeismicAttestation::from_backend(
             AttestationType::AzureTdx,
             binding,
-            Some(MultiMeasurements::Azure(HashMap::from([(4, pcr4)]))),
+            MultiMeasurements::Azure(HashMap::from([(4, pcr4)])),
         )
         .unwrap();
 
@@ -495,10 +479,8 @@ mod tests {
         let verified = VerifiedSeismicAttestation::from_backend(
             AttestationType::DcapTdx,
             binding,
-            Some(MultiMeasurements::Dcap(
-                attestation::measurements::DcapMeasurements::new(
-                    mrtd, [0u8; 48], [1u8; 48], [2u8; 48], [3u8; 48],
-                ),
+            MultiMeasurements::Dcap(attestation::measurements::DcapMeasurements::new(
+                mrtd, [0u8; 48], [1u8; 48], [2u8; 48], [3u8; 48],
             )),
         )
         .unwrap();
@@ -522,17 +504,44 @@ mod tests {
         }
     }
 
-    #[test]
-    fn represents_verified_no_attestation() {
-        let binding = [9u8; 64];
-        let verified =
-            VerifiedSeismicAttestation::from_backend(AttestationType::None, binding, None).unwrap();
+    /// A peer that declares no attestation gets a backend policy for `none`,
+    /// which the backend accepts; the refusal has to be this crate's.
+    #[tokio::test]
+    async fn unattested_evidence_is_refused_before_admission() {
+        struct AdmitEverything;
+        impl AdmissionPredicate for AdmitEverything {
+            async fn admit(
+                &self,
+                _verified: &VerifiedSeismicAttestation,
+            ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+                Ok(())
+            }
+        }
 
-        assert_eq!(verified.attestation_type(), AttestationType::None);
-        assert_eq!(verified.binding(), &binding);
-        assert_eq!(
-            verified,
-            VerifiedSeismicAttestation::NoAttestation { binding }
+        let result = verify_evidence_with_predicate(
+            AttestationExchangeMessage::without_attestation(),
+            [0u8; 64],
+            &AdmitEverything,
+        )
+        .await;
+
+        assert!(matches!(result, Err(AttestationError::Unattested)));
+    }
+
+    #[test]
+    fn rejects_measurements_inconsistent_with_attestation_type() {
+        let result = VerifiedSeismicAttestation::from_backend(
+            AttestationType::AzureTdx,
+            [9u8; 64],
+            MultiMeasurements::NoAttestation,
         );
+
+        assert!(matches!(
+            result,
+            Err(AttestationError::MeasurementTypeMismatch {
+                attestation_type: AttestationType::AzureTdx,
+                ..
+            })
+        ));
     }
 }


### PR DESCRIPTION
Fixes SEI-396.

The verifier returns Ok(None) for evidence that declares attestation_type: none when its policy names no attested platform. seismic-attestation passed that through as a reachable success: VerifiedSeismicAttestation::NoAttestation, verified measurements that measure nothing. Every Seismic relying party appraises a TEE node, so that outcome is never wanted, and modelling it cost an Option in the crate's own signatures.

It was reachable only through verify_evidence_with_predicate, which builds its policy from the peer's own claimed type: a peer claiming `none` got a policy for `none`, and the verifier accepted. Both admission predicates happened to reject the variant, but nothing enforced it — a future predicate written to appraise measurements would have admitted an unattested peer, since NoAttestation carries none to fail on.

verify_with_backend_policy now refuses a None result with AttestationError::Unattested before any predicate runs. That makes the rest unreachable, so it goes: the NoAttestation variant, the Option on from_backend, and AttestationError::MissingMeasurements. A test drives `none` evidence through the predicate path with an admit-everything predicate and asserts the refusal.

The `none`-claiming joiner's refusal moves from the admission layer to the verification layer; its wire error stays
RootKeyRefusal::RequesterEvidenceUnusable, now by an explicit Unattested arm in rpc_error pinned by test rather than by placement. The admission tests that used NoAttestation as their non-Azure case use DcapTdx, a type a predicate can actually receive.

verify_evidence_with_policy also absorbs its _and_options twin and takes VerifyOptions directly. Running without TDX hardware stays the verifier's `mock` feature, which produces real DcapTdx evidence against a mock root.