### PR TITLE
refactor(attestation)!: drop the Azure outdated-TCB override

### DIFF
--- a/bin/attestation-service/examples/capture_measurements.rs
+++ b/bin/attestation-service/examples/capture_measurements.rs
@@ -104,10 +104,6 @@ struct Cli {
     /// Optional PCCS URL for DCAP collateral.
     #[arg(long)]
     pccs_url: Option<String>,
-
-    /// Allow the Azure outdated-TCB override path.
-    #[arg(long)]
-    override_azure_outdated_tcb: bool,
 }
 
 #[tokio::main]
@@ -157,8 +153,7 @@ async fn main() -> anyhow::Result<()> {
         policy,
         VerifyOptions {
             pccs_url: args.pccs_url,
-            dump_dcap_quotes: false,
-            override_azure_outdated_tcb: args.override_azure_outdated_tcb,
+            ..Default::default()
         },
     )
     .await?;

--- a/bin/verify-quote/src/main.rs
+++ b/bin/verify-quote/src/main.rs
@@ -128,10 +128,6 @@ struct CommonArgs {
     /// Optional PCCS URL for DCAP collateral, instead of the backend default.
     #[arg(long, value_name = "URL")]
     pccs_url: Option<String>,
-
-    /// Allow the backend's Azure outdated-TCB override path.
-    #[arg(long)]
-    override_azure_outdated_tcb: bool,
 }
 
 #[derive(Debug, Args)]
@@ -330,7 +326,6 @@ async fn verify_azure(
         VerifyOptions {
             pccs_url: common.pccs_url.clone(),
             dump_dcap_quotes: false,
-            override_azure_outdated_tcb: common.override_azure_outdated_tcb,
         },
     )
     .await?;

--- a/crates/attestation/examples/azure_vtpm_roundtrip.rs
+++ b/crates/attestation/examples/azure_vtpm_roundtrip.rs
@@ -137,13 +137,6 @@ struct BackendArgs {
     /// backend uses its default DCAP collateral path.
     #[arg(long)]
     pccs_url: Option<String>,
-
-    /// Allow the Azure outdated-TCB override path.
-    ///
-    /// This exists as a workaround for some Azure v6 TCB collateral. Leave false
-    /// unless you are specifically testing that environment.
-    #[arg(long)]
-    override_azure_outdated_tcb: bool,
 }
 
 #[cfg(target_os = "linux")]
@@ -259,8 +252,7 @@ async fn verify_exchange_message(
         policy,
         VerifyOptions {
             pccs_url: backend.pccs_url,
-            dump_dcap_quotes: false,
-            override_azure_outdated_tcb: backend.override_azure_outdated_tcb,
+            ..Default::default()
         },
     )
     .await?;

--- a/crates/attestation/src/lib.rs
+++ b/crates/attestation/src/lib.rs
@@ -157,7 +157,13 @@ async fn verify_with_backend_policy(
         backend_policy,
         options.pccs_url,
         options.dump_dcap_quotes,
-        options.override_azure_outdated_tcb,
+        // The backend can rewrite one Azure FMSPC's TCB Info to clamp a
+        // component's required SVN down, so a platform behind every published
+        // TCB level matches one. No Seismic relying party asks for that: it
+        // makes a verdict depend on a caller's flag rather than on the
+        // evidence and the collateral, which is exactly what archived
+        // founding evidence must not do.
+        false,
     );
 
     let measurements = verifier
@@ -243,8 +249,6 @@ pub struct VerifyOptions {
     pub pccs_url: Option<String>,
     /// Ask the backend to log/dump DCAP quote material for debugging.
     pub dump_dcap_quotes: bool,
-    /// Allow the backend's Azure outdated-TCB override path.
-    pub override_azure_outdated_tcb: bool,
 }
 
 /// Generic verified Seismic attestation output.


### PR DESCRIPTION
The attested-tls backend can rewrite one Azure FMSPC's TCB Info so a component's required SVN clamps down to the platform's, letting a platform behind every published TCB level match one. We forwarded that as `VerifyOptions::override_azure_outdated_tcb` and as an `--override-azure-outdated-tcb` flag on verify-quote and the two examples.

No Seismic relying party should take it. It makes a verdict depend on a caller's flag rather than on the evidence and the collateral, so the same quote verifies for one operator and fails for another. Founding evidence that is archived for later re-verification must not carry that ambiguity.

Remove the field and the flags; the backend is now always constructed with the override off. A platform that Intel rates OutOfDate fails verification, as it should, and any allowance for it belongs in the measurement policy, not on argv.

BREAKING: `VerifyOptions` loses `override_azure_outdated_tcb`; `verify-quote`, `capture_measurements` and `azure_vtpm_roundtrip` no longer accept `--override-azure-outdated-tcb`.