### PR TITLE
feat(verify-quote)!: archive the DCAP collateral a harvest verified against

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1150,7 +1150,7 @@ dependencies = [
 [[package]]
 name = "attestation"
 version = "0.0.1"
-source = "git+https://github.com/SeismicSystems/attested-tls?rev=2ce0feee147ef5ba071a9919a3fce80ef9643fd6#2ce0feee147ef5ba071a9919a3fce80ef9643fd6"
+source = "git+https://github.com/SeismicSystems/attested-tls?rev=604f3befc7af568a153a7c9728ef5bf800abafe6#604f3befc7af568a153a7c9728ef5bf800abafe6"
 dependencies = [
  "anyhow",
  "attest-measure",
@@ -4511,7 +4511,7 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 [[package]]
 name = "pccs"
 version = "0.0.1"
-source = "git+https://github.com/SeismicSystems/attested-tls?rev=2ce0feee147ef5ba071a9919a3fce80ef9643fd6#2ce0feee147ef5ba071a9919a3fce80ef9643fd6"
+source = "git+https://github.com/SeismicSystems/attested-tls?rev=604f3befc7af568a153a7c9728ef5bf800abafe6#604f3befc7af568a153a7c9728ef5bf800abafe6"
 dependencies = [
  "anyhow",
  "dcap-qvl",
@@ -5808,6 +5808,7 @@ name = "seismic-verify-quote"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "base64 0.22.1",
  "clap",
  "hex",
  "jsonrpsee",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,8 +49,10 @@ alloy-primitives = { version = "1.0", default-features = false, features = ["std
 alloy-sol-types = "1.0"
 aes-gcm = "0.10"
 anyhow = "1.0"
-# Pointing to https://github.com/SeismicSystems/attested-tls/pull/2
-attestation = { git = "https://github.com/SeismicSystems/attested-tls", rev = "2ce0feee147ef5ba071a9919a3fce80ef9643fd6" }
+# Seismic's attested-tls fork. The `seismic` branch carries our attestation
+# changes on top of flashbots/attested-tls main. Goal is to upstream everything and
+# eventually revert back to flashbots' attested-tls however.
+attestation = { git = "https://github.com/SeismicSystems/attested-tls", rev = "604f3befc7af568a153a7c9728ef5bf800abafe6" }
 az-cvm-vtpm = { version = "0.7.4", default-features = false }
 az-tdx-vtpm = "0.7.4"
 axum = "0.8.6"

--- a/bin/attestation-service/examples/capture_measurements.rs
+++ b/bin/attestation-service/examples/capture_measurements.rs
@@ -156,7 +156,8 @@ async fn main() -> anyhow::Result<()> {
             ..Default::default()
         },
     )
-    .await?;
+    .await?
+    .attestation;
     println!("Verification succeeded.");
 
     let pcrs = sorted_azure_pcrs(&verified)

--- a/bin/attestation-service/tests/admission.rs
+++ b/bin/attestation-service/tests/admission.rs
@@ -372,7 +372,8 @@ async fn observed_pcrs() -> HashMap<u32, [u8; 32]> {
         VerifyOptions::default(),
     )
     .await
-    .expect("verifying our own quote");
+    .expect("verifying our own quote")
+    .attestation;
     match verified {
         VerifiedSeismicAttestation::AzureTdx(azure) => azure
             .guest_measurements

--- a/bin/verify-quote/Cargo.toml
+++ b/bin/verify-quote/Cargo.toml
@@ -18,6 +18,7 @@ seismic-attestation.workspace = true
 seismic-attestation-rpc.workspace = true
 
 anyhow.workspace = true
+base64.workspace = true
 clap.workspace = true
 hex.workspace = true
 jsonrpsee.workspace = true

--- a/bin/verify-quote/src/collateral.rs
+++ b/bin/verify-quote/src/collateral.rs
@@ -1,0 +1,374 @@
+//! The archived form of the collateral snapshot a verification consumed.
+//!
+//! A founding quote is only re-verifiable for as long as the collateral it
+//! was checked against is available: Intel's TCB Info, QE Identity and both
+//! CRLs carry `nextUpdate` on a roughly 30-day cadence. So a founding
+//! archive keeps the bundle beside the quote, and this module is the only
+//! code that reads or writes the form it keeps it in.
+//!
+//! It keeps the instant beside the bundle. Every freshness check was
+//! evaluated at that one instant, so a replay given the bundle alone
+//! reproduces the verdict only by luck, and one given an instant earlier
+//! than the real one will honour a certificate that was revoked after it.
+//! [`CollateralSnapshot`] carries the two together, and so does the
+//! document.
+//!
+//! It also keeps the record's `harvest_nonce`. The two files of one box sit
+//! in two directories and are paired only by name, so the snapshot names
+//! the record it belongs to: the nonce is minted per box and bound into the
+//! quote, so no two records share one, and a replay refuses a snapshot
+//! filed beside the wrong record instead of evaluating the quote at the
+//! wrong instant against the wrong bundle.
+//!
+//! The document mirrors that: `ArchivedSnapshotV1` is the versioned
+//! envelope — the instant, the nonce, and the bundle under `collateral` —
+//! and `ArchivedCollateralV1` is [`QuoteCollateralV3`] field for field, in
+//! the archive's own serialization:
+//!
+//! - the PEM chains and the raw Intel-signed JSON bodies pass through as-is,
+//!   so `tcb_info` in the archive is recognisably the document Intel signed;
+//! - the binary components are base64 — the two CRLs are DER, the two
+//!   signatures raw ECDSA `r||s` — because `serde_json` renders their bytes
+//!   as thousand-element integer arrays;
+//! - `pck_certificate_chain` is absent when the fetch left it unset, which
+//!   is the normal case.
+//!
+//! `version` sits on the envelope and decouples the committed archive from
+//! `dcap-qvl`'s own struct, which may change shape across backend upgrades.
+//! Parsing is strict: unknown keys are rejected, so two readers can never
+//! disagree on field semantics, and the version is probed first so a future
+//! envelope is reported by number rather than by its first unknown field.
+//! New or changed fields require `version = 2` and an `ArchivedSnapshotV2`
+//! type; a v1 document has to keep reading as v1 forever.
+
+use anyhow::Context as _;
+use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64};
+use seismic_attestation::{CollateralSnapshot, QuoteCollateralV3};
+use serde::{Deserialize, Serialize};
+
+/// One box's archived collateral: the snapshot its verification consumed,
+/// and the `harvest_nonce` of the record it was verified with.
+#[derive(Debug, PartialEq, Eq)]
+pub struct ArchivedSnapshot {
+    pub harvest_nonce: [u8; 32],
+    pub snapshot: CollateralSnapshot,
+}
+
+/// One collateral snapshot, in the form the founding archive keeps.
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+struct ArchivedSnapshotV1 {
+    /// The schema number written into every document, so the file says
+    /// which shape it has. This is the value on disk; [`Self::VERSION`] is
+    /// the one this type reads and writes. Serde has no way to emit a
+    /// constant without a field to hold it, so `render` fills it from the
+    /// const and `parse` checks it against the const before anything else.
+    version: u32,
+    /// Seconds since the Unix epoch: the instant the verification held this
+    /// bundle to, and the instant a replay has to evaluate at.
+    verified_at: u64,
+    /// The record's `harvest_nonce`, hex, exactly as the record spells it.
+    harvest_nonce: String,
+    collateral: ArchivedCollateralV1,
+}
+
+impl ArchivedSnapshotV1 {
+    /// The `version` value this schema corresponds to.
+    const VERSION: u32 = 1;
+}
+
+/// The DCAP collateral bundle, in the archive's own serialization.
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+struct ArchivedCollateralV1 {
+    pck_crl_issuer_chain: String,
+    root_ca_crl: String,
+    pck_crl: String,
+    tcb_info_issuer_chain: String,
+    tcb_info: String,
+    tcb_info_signature: String,
+    qe_identity_issuer_chain: String,
+    qe_identity: String,
+    qe_identity_signature: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pck_certificate_chain: Option<String>,
+}
+
+impl From<&ArchivedSnapshot> for ArchivedSnapshotV1 {
+    fn from(archived: &ArchivedSnapshot) -> Self {
+        Self {
+            version: Self::VERSION,
+            verified_at: archived.snapshot.at,
+            harvest_nonce: hex::encode(archived.harvest_nonce),
+            collateral: ArchivedCollateralV1::from(&archived.snapshot.collateral),
+        }
+    }
+}
+
+impl TryFrom<ArchivedSnapshotV1> for ArchivedSnapshot {
+    type Error = anyhow::Error;
+
+    fn try_from(archived: ArchivedSnapshotV1) -> anyhow::Result<Self> {
+        let mut harvest_nonce = [0u8; 32];
+        hex::decode_to_slice(&archived.harvest_nonce, &mut harvest_nonce)
+            .context("archived collateral harvest_nonce is not 32 bytes of hex")?;
+        Ok(Self {
+            harvest_nonce,
+            snapshot: CollateralSnapshot {
+                at: archived.verified_at,
+                collateral: archived.collateral.try_into()?,
+            },
+        })
+    }
+}
+
+impl From<&QuoteCollateralV3> for ArchivedCollateralV1 {
+    fn from(collateral: &QuoteCollateralV3) -> Self {
+        Self {
+            pck_crl_issuer_chain: collateral.pck_crl_issuer_chain.clone(),
+            root_ca_crl: BASE64.encode(&collateral.root_ca_crl),
+            pck_crl: BASE64.encode(&collateral.pck_crl),
+            tcb_info_issuer_chain: collateral.tcb_info_issuer_chain.clone(),
+            tcb_info: collateral.tcb_info.clone(),
+            tcb_info_signature: BASE64.encode(&collateral.tcb_info_signature),
+            qe_identity_issuer_chain: collateral.qe_identity_issuer_chain.clone(),
+            qe_identity: collateral.qe_identity.clone(),
+            qe_identity_signature: BASE64.encode(&collateral.qe_identity_signature),
+            pck_certificate_chain: collateral.pck_certificate_chain.clone(),
+        }
+    }
+}
+
+impl TryFrom<ArchivedCollateralV1> for QuoteCollateralV3 {
+    type Error = anyhow::Error;
+
+    fn try_from(archived: ArchivedCollateralV1) -> anyhow::Result<Self> {
+        Ok(Self {
+            pck_crl_issuer_chain: archived.pck_crl_issuer_chain,
+            root_ca_crl: decode_base64("root_ca_crl", &archived.root_ca_crl)?,
+            pck_crl: decode_base64("pck_crl", &archived.pck_crl)?,
+            tcb_info_issuer_chain: archived.tcb_info_issuer_chain,
+            tcb_info: archived.tcb_info,
+            tcb_info_signature: decode_base64("tcb_info_signature", &archived.tcb_info_signature)?,
+            qe_identity_issuer_chain: archived.qe_identity_issuer_chain,
+            qe_identity: archived.qe_identity,
+            qe_identity_signature: decode_base64(
+                "qe_identity_signature",
+                &archived.qe_identity_signature,
+            )?,
+            pck_certificate_chain: archived.pck_certificate_chain,
+        })
+    }
+}
+
+/// Render the collateral snapshot a verification consumed as the archived
+/// document.
+///
+/// Pretty-printed with a trailing newline, matching every other file a
+/// founding archive holds: this is provenance a person reads, not a wire
+/// format.
+pub fn render(archived: &ArchivedSnapshot) -> anyhow::Result<String> {
+    let archived = ArchivedSnapshotV1::from(archived);
+    Ok(serde_json::to_string_pretty(&archived).context("rendering the DCAP collateral")? + "\n")
+}
+
+/// Read one archived document back into the snapshot it holds.
+pub fn parse(document: &str) -> anyhow::Result<ArchivedSnapshot> {
+    // Probe the version before the strict parse: a future envelope carries
+    // fields this schema does not know, and "version 2" is the actionable
+    // error, not "unknown field". Failing on an unknown version rather than
+    // guessing matters here — this bundle decides whether a founding quote
+    // verifies.
+    #[derive(Deserialize)]
+    struct VersionProbe {
+        version: u32,
+    }
+    let probe: VersionProbe =
+        serde_json::from_str(document).context("parsing the archived DCAP collateral")?;
+    anyhow::ensure!(
+        probe.version == ArchivedSnapshotV1::VERSION,
+        "archived collateral is version {}, and this build reads version {}",
+        probe.version,
+        ArchivedSnapshotV1::VERSION,
+    );
+    let archived: ArchivedSnapshotV1 =
+        serde_json::from_str(document).context("parsing the archived DCAP collateral")?;
+    archived.try_into()
+}
+
+/// Decode one base64 field, naming the field in the failure.
+fn decode_base64(field: &str, value: &str) -> anyhow::Result<Vec<u8>> {
+    BASE64
+        .decode(value)
+        .with_context(|| format!("archived collateral {field} is not valid base64"))
+}
+
+/// The instant the fabricated snapshot was held to. Distinct from every
+/// other number in the fixture, so a field that goes missing shows up.
+#[cfg(test)]
+pub const FABRICATED_AT: u64 = 1_780_922_561;
+
+/// The nonce of the record the fabricated snapshot belongs to.
+#[cfg(test)]
+pub const FABRICATED_NONCE: [u8; 32] = [0x5a; 32];
+
+/// A snapshot with a distinct value per field, so a conversion that crosses
+/// two fields is caught rather than cancelling out.
+#[cfg(test)]
+pub fn fabricated_snapshot() -> ArchivedSnapshot {
+    ArchivedSnapshot {
+        harvest_nonce: FABRICATED_NONCE,
+        snapshot: fabricated_collateral(),
+    }
+}
+
+#[cfg(test)]
+pub fn fabricated_collateral() -> CollateralSnapshot {
+    CollateralSnapshot {
+        at: FABRICATED_AT,
+        collateral: QuoteCollateralV3 {
+            pck_crl_issuer_chain:
+                "-----BEGIN CERTIFICATE-----\npck-crl-issuer\n-----END CERTIFICATE-----\n"
+                    .to_string(),
+            root_ca_crl: vec![0x30, 0x82, 0x01, 0x00],
+            pck_crl: vec![0x30, 0x82, 0x02, 0x01],
+            tcb_info_issuer_chain:
+                "-----BEGIN CERTIFICATE-----\ntcb-info-issuer\n-----END CERTIFICATE-----\n"
+                    .to_string(),
+            tcb_info: r#"{"tcbInfo":{"fmspc":"90C06F000000"},"signature":"ab"}"#.to_string(),
+            tcb_info_signature: vec![0xde, 0xad, 0xbe, 0xef],
+            qe_identity_issuer_chain:
+                "-----BEGIN CERTIFICATE-----\nqe-identity-issuer\n-----END CERTIFICATE-----\n"
+                    .to_string(),
+            qe_identity: r#"{"enclaveIdentity":{"id":"TD_QE"}}"#.to_string(),
+            qe_identity_signature: vec![0xfe, 0xed, 0xfa, 0xce],
+            pck_certificate_chain: None,
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn round_trip(snapshot: &ArchivedSnapshot) -> ArchivedSnapshot {
+        parse(&render(snapshot).unwrap()).unwrap()
+    }
+
+    /// The archive has to hand the verifier back exactly what it was given,
+    /// or an archived quote verifies against something other than the
+    /// collateral its founding used.
+    #[test]
+    fn envelope_round_trips_a_snapshot_unchanged() {
+        let snapshot = fabricated_snapshot();
+        assert_eq!(round_trip(&snapshot), snapshot);
+
+        let mut with_pck_chain = fabricated_snapshot();
+        with_pck_chain.snapshot.collateral.pck_certificate_chain =
+            Some("-----BEGIN CERTIFICATE-----\npck\n-----END CERTIFICATE-----\n".to_string());
+        assert_eq!(round_trip(&with_pck_chain), with_pck_chain);
+    }
+
+    /// The instant is the half a bundle cannot supply. Losing it silently
+    /// would leave a document that looks complete and replays at the wrong
+    /// time, so it is asserted on its own rather than through the round trip.
+    #[test]
+    fn document_carries_the_instant() {
+        let document = render(&fabricated_snapshot()).unwrap();
+        let value: serde_json::Value = serde_json::from_str(&document).unwrap();
+        assert_eq!(value["verified_at"], FABRICATED_AT);
+        assert_eq!(
+            round_trip(&fabricated_snapshot()).snapshot.at,
+            FABRICATED_AT
+        );
+    }
+
+    /// The nonce is what pairs a snapshot with its record, in the record's
+    /// own spelling so a reader can match the two files by eye.
+    #[test]
+    fn document_names_its_record_by_nonce() {
+        let document = render(&fabricated_snapshot()).unwrap();
+        let value: serde_json::Value = serde_json::from_str(&document).unwrap();
+        assert_eq!(value["harvest_nonce"], hex::encode(FABRICATED_NONCE));
+
+        let error = parse_mutated(|value| value["harvest_nonce"] = serde_json::json!("5a5a"))
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("harvest_nonce"), "{error}");
+    }
+
+    /// The DER components are base64, and the Intel-signed bodies and PEM
+    /// chains are the archive's own text — inspectable without tooling. The
+    /// bundle sits under `collateral`, so a reader sees where Intel's
+    /// material starts and the envelope ends.
+    #[test]
+    fn document_is_readable_and_versioned() {
+        let snapshot = fabricated_snapshot();
+        let expected = &snapshot.snapshot.collateral;
+        let document = render(&snapshot).unwrap();
+        let value: serde_json::Value = serde_json::from_str(&document).unwrap();
+
+        assert_eq!(value["version"], 1);
+        let collateral = &value["collateral"];
+        assert_eq!(collateral["tcb_info"], expected.tcb_info);
+        assert_eq!(collateral["qe_identity"], expected.qe_identity);
+        assert_eq!(
+            collateral["tcb_info_issuer_chain"],
+            expected.tcb_info_issuer_chain
+        );
+        assert_eq!(
+            collateral["root_ca_crl"],
+            BASE64.encode(&expected.root_ca_crl)
+        );
+        // Absent rather than null when the fetch left it unset, which is the
+        // normal case.
+        assert!(collateral.get("pck_certificate_chain").is_none());
+        assert!(document.ends_with("\n"));
+    }
+
+    /// Parse a rendered document after mutating it, the way a hand-edited or
+    /// future-version archive reaches a reader.
+    fn parse_mutated(
+        mutate: impl FnOnce(&mut serde_json::Value),
+    ) -> anyhow::Result<ArchivedSnapshot> {
+        let mut value: serde_json::Value =
+            serde_json::from_str(&render(&fabricated_snapshot()).unwrap()).unwrap();
+        mutate(&mut value);
+        parse(&serde_json::to_string(&value).unwrap())
+    }
+
+    /// A v2 envelope carries fields this schema does not know, so the version
+    /// has to be reported before the strict parse trips over one of them. A
+    /// future document must not be silently reinterpreted: this bundle decides
+    /// whether a founding quote verifies.
+    #[test]
+    fn foreign_version_is_reported_before_unknown_fields() {
+        let error = parse_mutated(|value| {
+            value["version"] = serde_json::json!(2);
+            value["some_v2_field"] = serde_json::json!("new");
+        })
+        .unwrap_err()
+        .to_string();
+        assert!(error.contains("version 2"), "{error}");
+    }
+
+    /// An unknown key at the declared version is a reader and a writer that
+    /// disagree on the format, not a field to skip.
+    #[test]
+    fn unknown_fields_are_rejected() {
+        assert!(parse_mutated(|value| value["surprise"] = serde_json::json!(1)).is_err());
+        assert!(
+            parse_mutated(|value| value["collateral"]["surprise"] = serde_json::json!(1)).is_err()
+        );
+    }
+
+    #[test]
+    fn malformed_base64_fails_by_field_name() {
+        let error = parse_mutated(|value| {
+            value["collateral"]["pck_crl"] = serde_json::json!("not base64!!")
+        })
+        .unwrap_err()
+        .to_string();
+        assert!(error.contains("pck_crl"), "{error}");
+    }
+}

--- a/bin/verify-quote/src/main.rs
+++ b/bin/verify-quote/src/main.rs
@@ -21,7 +21,13 @@
 //! ```text
 //! verify-quote harvest \
 //!   --record inputs/harvest/box-1.json \
-//!   --policy build/measurements.json
+//!   --policy build/measurements.json \
+//!   --dump-collateral /tmp/box-1-collateral.json
+//!
+//! verify-quote harvest \
+//!   --record inputs/harvest/box-1.json \
+//!   --policy build/measurements.json \
+//!   --collateral inputs/harvest/dcap-collateral/box-1.json
 //!
 //! verify-quote deploy \
 //!   --endpoint http://<node-ip>:7878 \
@@ -34,17 +40,35 @@
 //! binding mismatch, measurement mismatch, DCAP failure, non-Azure evidence —
 //! is an error on stderr with a nonzero exit and nothing on stdout.
 //!
+//! `--dump-collateral` writes the Intel collateral a harvest verified
+//! against to its own file, once the quote has verified. The destination is
+//! the caller's scratch space: a founding archive admits a cohort's
+//! collateral all at once, so the file is theirs to move into place once
+//! every box has passed.
+//!
+//! `--collateral` is the other end of that archive, and the mode an auditor
+//! runs: the record is verified against the snapshot beside it, at the
+//! instant that snapshot was held to, reaching no collateral service at all.
+//! The snapshot names the record it belongs to by `harvest_nonce`, so a
+//! snapshot filed beside the wrong record is refused rather than replayed.
+//! Intel's TCB Info, QE Identity and both CRLs carry `nextUpdate` on a
+//! roughly 30-day cadence, so this is the only mode under which a founding
+//! quote still verifies a month after the founding.
+//!
 //! Verification-only: this never touches a local TPM. Azure TDX verification
 //! is pure computation over the evidence bytes (the `azure-verifier` feature
 //! of the `attestation` backend), so it builds and runs anywhere, including
 //! macOS; `deploy` additionally makes one JSON-RPC request to the target node.
 
+mod collateral;
+
 use anyhow::Context as _;
 use clap::{Args, Parser, Subcommand};
 use jsonrpsee::http_client::HttpClientBuilder;
 use seismic_attestation::{
-    AttestationExchangeMessage, AttestationType, NetworkId, NetworkManifestV1,
-    SeismicMeasurementPolicy, VerifiedAzureAttestation, VerifiedSeismicAttestation, VerifyOptions,
+    AttestationExchangeMessage, AttestationType, CollateralSnapshot, NetworkId, NetworkManifestV1,
+    SeismicMeasurementPolicy, VerifiedAzureAttestation, VerifiedEvidence,
+    VerifiedSeismicAttestation, VerifyMode, VerifyOptions,
     bindings::{
         binding64_from_digest32, deploy_verification_binding, founding_summit_keys_binding,
     },
@@ -137,6 +161,20 @@ struct HarvestCli {
     #[arg(long, value_name = "PATH")]
     record: PathBuf,
 
+    /// Write the DCAP collateral this verification consumed to PATH, once
+    /// the quote has verified. Somewhere disposable: the caller archives it.
+    #[arg(long, value_name = "PATH")]
+    dump_collateral: Option<PathBuf>,
+
+    /// Verify against the archived collateral snapshot at PATH, at the
+    /// instant it was held to, instead of fetching and using the wall clock.
+    #[arg(
+        long,
+        value_name = "PATH",
+        conflicts_with_all = ["dump_collateral", "pccs_url"]
+    )]
+    collateral: Option<PathBuf>,
+
     #[command(flatten)]
     common: CommonArgs,
 }
@@ -219,9 +257,18 @@ async fn run_harvest(cli: HarvestCli) -> anyhow::Result<String> {
     let binding = harvest_binding(&nonce, &node_pk, &consensus_pk);
 
     let policy = load_policy(&cli.common.policy).await?;
-    let verified = verify_azure(record.evidence, binding, policy, &cli.common)
+    let mode = match &cli.collateral {
+        Some(path) => archived_mode(path, &nonce).await?,
+        None => VerifyMode::Live,
+    };
+    let (verified, collateral) = verify_azure(record.evidence, binding, policy, mode, &cli.common)
         .await
         .context("verifying harvest evidence")?;
+    // After the verdict, never before: a burned harvest must not leave a
+    // half-archive behind for a later reader to trust.
+    if let Some(path) = &cli.dump_collateral {
+        dump_collateral(path, &nonce, &collateral).await?;
+    }
     Ok(report(&verified, []))
 }
 
@@ -264,9 +311,17 @@ async fn run_deploy(cli: DeployCli) -> anyhow::Result<String> {
         })?;
 
     let binding = deploy_binding(&network_id, &deployment_nonce);
-    let verified = verify_azure(response.evidence, binding, policy, &cli.common)
-        .await
-        .context("verifying deploy-verification evidence")?;
+    // The collateral goes unarchived here: a live challenge is fresh
+    // evidence, judged against fresh collateral at the wall clock.
+    let (verified, _collateral) = verify_azure(
+        response.evidence,
+        binding,
+        policy,
+        VerifyMode::Live,
+        &cli.common,
+    )
+    .await
+    .context("verifying deploy-verification evidence")?;
     // The extras document what was checked: which network identity the binding
     // committed to, and the nonce that made this run's quote fresh.
     Ok(report(
@@ -301,7 +356,8 @@ async fn load_policy(path: &Path) -> anyhow::Result<SeismicMeasurementPolicy> {
         .with_context(|| format!("loading measurement policy {}", path.display()))
 }
 
-/// Verify Azure TDX evidence against `binding` and `policy`.
+/// Verify Azure TDX evidence against `binding` and `policy`, returning the
+/// verified output and the DCAP collateral the verification consumed.
 ///
 /// Wrong-platform evidence is rejected on the claimed type, before
 /// verification: DCAP verification costs collateral round-trips, and this
@@ -310,8 +366,9 @@ async fn verify_azure(
     evidence: AttestationExchangeMessage,
     binding: [u8; 64],
     policy: SeismicMeasurementPolicy,
+    mode: VerifyMode,
     common: &CommonArgs,
-) -> anyhow::Result<VerifiedAzureAttestation> {
+) -> anyhow::Result<(VerifiedAzureAttestation, CollateralSnapshot)> {
     anyhow::ensure!(
         evidence.attestation_type() == AttestationType::AzureTdx,
         "expected {} evidence, got {}",
@@ -319,20 +376,90 @@ async fn verify_azure(
         evidence.attestation_type().as_str(),
     );
 
-    let verified = verify_evidence_with_policy(
+    let VerifiedEvidence {
+        attestation,
+        collateral,
+    } = verify_evidence_with_policy(
         evidence,
         binding,
         policy,
         VerifyOptions {
+            mode,
             pccs_url: common.pccs_url.clone(),
             dump_dcap_quotes: false,
         },
     )
     .await?;
-    let VerifiedSeismicAttestation::AzureTdx(verified) = verified else {
-        anyhow::bail!("verified output is not azure-tdx despite azure-tdx evidence: {verified:?}");
+    let VerifiedSeismicAttestation::AzureTdx(verified) = attestation else {
+        anyhow::bail!(
+            "verified output is not azure-tdx despite azure-tdx evidence: {attestation:?}"
+        );
     };
-    Ok(verified)
+    Ok((verified, collateral))
+}
+
+/// Resolve `--collateral` into the mode it names, for the record whose
+/// `harvest_nonce` is `nonce`.
+///
+/// The archived snapshot is the whole input: the bundle Intel served, and the
+/// instant the founding verification held it to be current. So this reaches
+/// no collateral service, and `--pccs-url` has nothing left to reach.
+///
+/// The snapshot has to be the one this record's verification produced. The
+/// instant decides which validity and revocation windows are open, so a
+/// snapshot filed beside another box's record would evaluate the quote at
+/// the wrong instant against the wrong bundle. Neither file is signed, so
+/// this is not a trust boundary; it catches the mispairing an archive comes
+/// to by accident, exactly, since no two records share a nonce.
+async fn archived_mode(path: &Path, nonce: &[u8; 32]) -> anyhow::Result<VerifyMode> {
+    let document = tokio::fs::read_to_string(path)
+        .await
+        .with_context(|| format!("reading --collateral {}", path.display()))?;
+    let archived = collateral::parse(&document).with_context(|| {
+        format!(
+            "--collateral {} is not an archived snapshot",
+            path.display()
+        )
+    })?;
+    anyhow::ensure!(
+        &archived.harvest_nonce == nonce,
+        "--collateral {} belongs to the record with harvest_nonce {}, not to this one ({}): \
+         they are not from one harvest",
+        path.display(),
+        hex::encode(archived.harvest_nonce),
+        hex::encode(nonce),
+    );
+    Ok(VerifyMode::Archived(archived.snapshot))
+}
+
+/// Archive the DCAP collateral the verification of the record with
+/// `harvest_nonce` `nonce` consumed.
+///
+/// The caller owns the layout and passes the destination; this writes the
+/// exact bundle the verdict depended on, so what is archived is what was
+/// verified.
+async fn dump_collateral(
+    path: &Path,
+    nonce: &[u8; 32],
+    collateral: &CollateralSnapshot,
+) -> anyhow::Result<()> {
+    let archived = collateral::ArchivedSnapshot {
+        harvest_nonce: *nonce,
+        snapshot: collateral.clone(),
+    };
+    let document = collateral::render(&archived)?;
+    // Read the document back before it leaves this process. The caller
+    // archives these bytes verbatim and nothing parses them again until a
+    // re-verification that may be a year away, so a snapshot that does not
+    // round-trip has to fail the harvest that produced it.
+    let reread = collateral::parse(&document).context("re-reading the rendered DCAP collateral")?;
+    anyhow::ensure!(
+        reread == archived,
+        "the rendered DCAP collateral does not read back as the collateral this verification used"
+    );
+    tokio::fs::write(path, document)
+        .await
+        .with_context(|| format!("writing --dump-collateral {}", path.display()))
 }
 
 /// Decode one fixed-length hex field of the record, naming the field in every
@@ -482,6 +609,218 @@ mod tests {
     #[test]
     fn cli_definition_is_valid() {
         Cli::command().debug_assert();
+    }
+
+    /// Capturing the collateral is optional, and its destination is the
+    /// caller's: deploy owns the founding archive's layout, so the path
+    /// arrives on argv. `deploy` has no such flag — a live challenge is
+    /// judged against live collateral and archives nothing.
+    #[test]
+    fn dump_collateral_is_optional_and_harvest_only() {
+        let dir = tempfile::tempdir().unwrap();
+        let record = write_file(&dir, "node-1.json", &record_json("{}"));
+        let policy = write_file(&dir, "policy.json", VALID_POLICY);
+
+        let Command::Harvest(harvest) = harvest_cli(&record, &policy).command else {
+            panic!("expected the harvest subcommand");
+        };
+        assert_eq!(harvest.dump_collateral, None);
+
+        let destination = dir.path().join("dcap-collateral/node-1.json");
+        let cli = Cli::try_parse_from([
+            "verify-quote".as_ref(),
+            "harvest".as_ref(),
+            "--record".as_ref(),
+            record.as_os_str(),
+            "--policy".as_ref(),
+            policy.as_os_str(),
+            "--dump-collateral".as_ref(),
+            destination.as_os_str(),
+        ])
+        .expect("well-formed argv");
+        let Command::Harvest(harvest) = cli.command else {
+            panic!("expected the harvest subcommand");
+        };
+        assert_eq!(
+            harvest.dump_collateral.as_deref(),
+            Some(destination.as_path())
+        );
+
+        assert!(
+            Cli::try_parse_from([
+                "verify-quote".as_ref(),
+                "deploy".as_ref(),
+                "--endpoint".as_ref(),
+                "http://127.0.0.1:1".as_ref(),
+                "--manifest".as_ref(),
+                policy.as_os_str(),
+                "--policy".as_ref(),
+                policy.as_os_str(),
+                "--dump-collateral".as_ref(),
+                destination.as_os_str(),
+            ])
+            .is_err()
+        );
+    }
+
+    /// A harvest CLI in offline mode over the given collateral document.
+    fn offline_cli(dir: &tempfile::TempDir, record: &str, document: &str) -> Cli {
+        let record = write_file(dir, "node-1.json", record);
+        let policy = write_file(dir, "policy.json", VALID_POLICY);
+        let snapshot = write_file(dir, "node-1-collateral.json", document);
+        Cli::try_parse_from([
+            "verify-quote".as_ref(),
+            "harvest".as_ref(),
+            "--record".as_ref(),
+            record.as_os_str(),
+            "--policy".as_ref(),
+            policy.as_os_str(),
+            "--collateral".as_ref(),
+            snapshot.as_os_str(),
+        ])
+        .expect("well-formed argv")
+    }
+
+    const NO_ATTESTATION: &str = r#"{ "attestation_type": "none", "attestation": [] }"#;
+
+    /// `--collateral` is the whole collateral input: capture verifies live
+    /// and writes, replay reads and verifies offline, and an offline run
+    /// reaches no collateral service. So it excludes both the flag that
+    /// captures and the flag that points at a PCCS — each would name
+    /// something the run does not do.
+    #[test]
+    fn offline_mode_excludes_capture_and_the_pccs() {
+        let dir = tempfile::tempdir().unwrap();
+        let record = write_file(&dir, "node-1.json", &record_json("{}"));
+        let policy = write_file(&dir, "policy.json", VALID_POLICY);
+        let snapshot = dir.path().join("node-1-collateral.json");
+
+        for extra in [
+            vec!["--dump-collateral", snapshot.to_str().unwrap()],
+            vec!["--pccs-url", "http://127.0.0.1:8081"],
+        ] {
+            let mut argv = vec![
+                "verify-quote",
+                "harvest",
+                "--record",
+                record.to_str().unwrap(),
+                "--policy",
+                policy.to_str().unwrap(),
+                "--collateral",
+                snapshot.to_str().unwrap(),
+            ];
+            argv.extend(extra.iter().copied());
+            assert!(Cli::try_parse_from(&argv).is_err(), "{argv:?}");
+        }
+    }
+
+    /// The instant decides which validity and revocation windows are open, so
+    /// a snapshot has to be the one this record's verification produced. The
+    /// snapshot names its record by nonce, and no two records share one, so
+    /// a snapshot filed beside another box's record is refused exactly.
+    #[tokio::test]
+    async fn replay_pairs_a_snapshot_with_its_record_by_nonce() {
+        let dir = tempfile::tempdir().unwrap();
+        let document = collateral::render(&collateral::fabricated_snapshot()).unwrap();
+        let path = write_file(&dir, "node-1-collateral.json", &document);
+
+        let mode = archived_mode(&path, &collateral::FABRICATED_NONCE)
+            .await
+            .unwrap();
+        assert_eq!(
+            mode,
+            VerifyMode::Archived(collateral::fabricated_collateral())
+        );
+
+        let other_record = [0xa5u8; 32];
+        let error = archived_mode(&path, &other_record)
+            .await
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("not from one harvest"), "{error}");
+        assert!(error.contains(&hex::encode(other_record)), "{error}");
+    }
+
+    /// The dump names the record it was verified with, so the snapshot a
+    /// harvest archives is the one its own replay accepts.
+    #[tokio::test]
+    async fn dump_names_the_record_it_verified() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("node-1-collateral.json");
+        let nonce = [0x3cu8; 32];
+
+        dump_collateral(&path, &nonce, &collateral::fabricated_collateral())
+            .await
+            .unwrap();
+        let archived = collateral::parse(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        assert_eq!(archived.harvest_nonce, nonce);
+        assert_eq!(archived.snapshot, collateral::fabricated_collateral());
+    }
+
+    /// Offline mode fails by flag name on every way the snapshot can be
+    /// unusable, since a reader who mistypes the path must not be told the
+    /// founding failed to verify.
+    #[tokio::test]
+    async fn offline_mode_fails_by_flag_name_on_an_unusable_snapshot() {
+        let dir = tempfile::tempdir().unwrap();
+        let record = record_json(NO_ATTESTATION);
+
+        for document in ["not json at all", r#"{ "version": 2 }"#] {
+            let error = run(offline_cli(&dir, &record, document))
+                .await
+                .unwrap_err()
+                .to_string();
+            assert!(error.contains("--collateral"), "{error}");
+        }
+
+        let policy = write_file(&dir, "policy.json", VALID_POLICY);
+        let record_path = write_file(&dir, "record.json", &record);
+        let missing = dir.path().join("absent.json");
+        let error = run(Cli::try_parse_from([
+            "verify-quote".as_ref(),
+            "harvest".as_ref(),
+            "--record".as_ref(),
+            record_path.as_os_str(),
+            "--policy".as_ref(),
+            policy.as_os_str(),
+            "--collateral".as_ref(),
+            missing.as_os_str(),
+        ])
+        .expect("well-formed argv"))
+        .await
+        .unwrap_err()
+        .to_string();
+        assert!(error.contains("--collateral"), "{error}");
+    }
+
+    /// The dump follows the verdict: a run that does not verify leaves no
+    /// collateral behind, so a burned harvest cannot leave a half-archive a
+    /// later reader mistakes for provenance.
+    #[tokio::test]
+    async fn a_failed_verification_writes_no_collateral() {
+        let dir = tempfile::tempdir().unwrap();
+        let record = write_file(
+            &dir,
+            "node-1.json",
+            &record_json(r#"{ "attestation_type": "none", "attestation": [] }"#),
+        );
+        let policy = write_file(&dir, "policy.json", VALID_POLICY);
+        let destination = dir.path().join("node-1-collateral.json");
+
+        let cli = Cli::try_parse_from([
+            "verify-quote".as_ref(),
+            "harvest".as_ref(),
+            "--record".as_ref(),
+            record.as_os_str(),
+            "--policy".as_ref(),
+            policy.as_os_str(),
+            "--dump-collateral".as_ref(),
+            destination.as_os_str(),
+        ])
+        .expect("well-formed argv");
+
+        assert!(run(cli).await.is_err());
+        assert!(!destination.exists());
     }
 
     /// The bindings are wire-format commitments shared with the quoting node,

--- a/crates/attestation/examples/azure_vtpm_roundtrip.rs
+++ b/crates/attestation/examples/azure_vtpm_roundtrip.rs
@@ -257,7 +257,7 @@ async fn verify_exchange_message(
     )
     .await?;
     println!("Verification succeeded.");
-    Ok(verified)
+    Ok(verified.attestation)
 }
 
 #[cfg(target_os = "linux")]

--- a/crates/attestation/src/lib.rs
+++ b/crates/attestation/src/lib.rs
@@ -46,9 +46,12 @@ pub use attestation::{
 };
 /// Backend evidence envelope and attestation-type enum used on the wire.
 pub use attestation::{AttestationExchangeMessage, AttestationType};
+/// Collateral types the public API leaks, through [`VerifyOptions::mode`] and
+/// [`VerifiedEvidence::collateral`].
+pub use attestation::{CollateralSnapshot, QuoteCollateralV3, VerifyMode};
 
 use attestation::{
-    AttestationGenerator, AttestationVerifier,
+    AttestationGenerator, AttestationResult as BackendAttestationResult, AttestationVerifier,
     measurements::{MeasurementFormatError, MeasurementPolicy as BackendMeasurementPolicy},
 };
 use std::{collections::HashMap, path::PathBuf};
@@ -96,7 +99,7 @@ pub async fn verify_evidence_with_policy(
     expected_binding: [u8; 64],
     policy: SeismicMeasurementPolicy,
     options: VerifyOptions,
-) -> Result<VerifiedSeismicAttestation, AttestationError> {
+) -> Result<VerifiedEvidence, AttestationError> {
     verify_with_backend_policy(
         evidence,
         expected_binding,
@@ -137,7 +140,8 @@ pub async fn verify_evidence_with_predicate(
         crypto_only,
         VerifyOptions::default(),
     )
-    .await?;
+    .await?
+    .attestation;
 
     admission
         .admit(&verified)
@@ -151,7 +155,7 @@ async fn verify_with_backend_policy(
     expected_binding: [u8; 64],
     backend_policy: BackendMeasurementPolicy,
     options: VerifyOptions,
-) -> Result<VerifiedSeismicAttestation, AttestationError> {
+) -> Result<VerifiedEvidence, AttestationError> {
     let attestation_type = evidence.attestation_type();
     let verifier = AttestationVerifier::new(
         backend_policy,
@@ -166,8 +170,12 @@ async fn verify_with_backend_policy(
         false,
     );
 
-    let measurements = verifier
-        .verify_attestation(evidence, expected_binding)
+    let BackendAttestationResult {
+        measurements,
+        collateral,
+        ..
+    } = verifier
+        .verify_attestation(evidence, expected_binding, options.mode)
         .await?
         // The verifier accepts evidence that declares no attestation when its
         // policy names no attested platform, and reports that as `None`. Every
@@ -175,7 +183,14 @@ async fn verify_with_backend_policy(
         // refused here, before any admission predicate sees it.
         .ok_or(AttestationError::Unattested)?;
 
-    VerifiedSeismicAttestation::from_backend(attestation_type, expected_binding, measurements)
+    Ok(VerifiedEvidence {
+        attestation: VerifiedSeismicAttestation::from_backend(
+            attestation_type,
+            expected_binding,
+            measurements,
+        )?,
+        collateral,
+    })
 }
 
 // === Public policy and output types ===
@@ -243,12 +258,53 @@ impl SeismicMeasurementPolicy {
 }
 
 /// Operational options passed through to the attestation backend verifier.
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
+///
+/// The default is a live challenge: fetch collateral, and hold every
+/// freshness check to the wall clock. That is the conservative reading of
+/// evidence — a caller wanting an archived bundle honoured has to say so.
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct VerifyOptions {
+    /// Where the verification gets its DCAP collateral, and the instant it
+    /// evaluates freshness at.
+    ///
+    /// [VerifyMode::Live] is what a live challenge wants. Archived evidence
+    /// is checked against its own bundle, as of when it was collected.
+    pub mode: VerifyMode,
     /// Optional PCCS URL for DCAP collateral. If omitted, the backend default is used.
+    ///
+    /// Only consulted under [VerifyMode::Live]. An archived verification
+    /// carries the bundle it verifies against, so it reaches no collateral
+    /// service at all.
     pub pccs_url: Option<String>,
     /// Ask the backend to log/dump DCAP quote material for debugging.
     pub dump_dcap_quotes: bool,
+}
+
+// Hand-written because the backend's `VerifyMode` has no default of its own:
+// which bundle a verification honours is a decision it makes every caller
+// state.
+impl Default for VerifyOptions {
+    fn default() -> Self {
+        Self {
+            mode: VerifyMode::Live,
+            pccs_url: None,
+            dump_dcap_quotes: false,
+        }
+    }
+}
+
+/// A verification's typed outcome, plus the collateral snapshot it consumed.
+///
+/// A caller archiving founding provenance keeps the snapshot beside the
+/// evidence. Fetching its own copy instead does not substitute: a collateral
+/// cache may refresh between two fetches, and a bundle without its instant
+/// does not re-verify.
+#[derive(Clone, Debug)]
+pub struct VerifiedEvidence {
+    /// The verdict: what the evidence proved about the guest that produced it.
+    pub attestation: VerifiedSeismicAttestation,
+    /// The bundle this verification used, and the instant it was held to.
+    pub collateral: CollateralSnapshot,
 }
 
 /// Generic verified Seismic attestation output.


### PR DESCRIPTION
A founding harvest record verifies only for as long as the collateral its verification consumed is still what Intel serves. TCB Info, QE Identity and both CRLs carry nextUpdate on a roughly 30-day cadence, so a month after the founding the archived quote stops verifying against live collateral, and founding TEE-ness becomes something the operator vouches for rather than something a reader can check.

The verifier is the only component that knows which bundle it used, so it is the one that hands it over. `seismic-attestation` follows the attested-tls fork onto SeismicSystems/attested-tls#3 and #4: `verify_evidence_with_policy` returns `VerifiedEvidence`, the verdict plus the `CollateralSnapshot` (bundle and the instant every freshness check was held to), and `VerifyOptions::mode` chooses between a live fetch at the wall clock and an archived snapshot at its own instant.

`verify-quote harvest` grows the two ends of the archive:

- `--dump-collateral PATH` writes the snapshot the verification consumed, once the quote has verified and never before, so a burned harvest leaves nothing a later reader mistakes for provenance. The document is a versioned JSON envelope in the archive's own serialization: the instant, the record's `harvest_nonce`, and the bundle with Intel's signed bodies and PEM chains as-is and the DER components base64. Parsing is strict and probes the version first. The rendered bytes are parsed back before they leave the process.
- `--collateral PATH` verifies the record against that snapshot, at that instant, reaching no collateral service; it excludes `--dump-collateral` and `--pccs-url`. The snapshot names its record by nonce, so one filed beside another box's record is refused rather than replayed at the wrong instant against the wrong bundle.

`deploy` is unchanged in behaviour: a live challenge is judged against live collateral and archives nothing.

BREAKING: `verify_evidence_with_policy` returns `VerifiedEvidence`; `VerifyOptions` gains `mode` and no longer derives `Default` mechanically.