### PR TITLE
feat(seismic-manifest): render and schema-check the network manifest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5742,6 +5742,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "seismic-manifest"
+version = "0.1.0"
+dependencies = [
+ "clap",
+ "hex",
+ "seismic-network-manifest",
+ "serde_json",
+]
+
+[[package]]
 name = "seismic-measurement-admission"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,15 +1,17 @@
 [workspace]
 resolver = "2"
-# The four deployed binaries live under bin/, next to `verify-quote`, which
-# runs off-node in deploy's hands; every crates/ member is a library (some also
-# build a tooling CLI behind their `cli` feature). The dir name is the crate;
-# the arrow is the binary target it builds.
+# The four deployed binaries live under bin/, next to `verify-quote` and
+# `seismic-manifest`, which run off-node in deploy's hands; every crates/
+# member is a library (some also build a tooling CLI behind their `cli`
+# feature). The dir name is the crate; the arrow is the binary target it
+# builds.
 members = [
     "bin/tdx-init",              # -> tdx-init
     "bin/attestation-service",   # -> seismic-attestation-service
     "bin/custodian-service",     # -> seismic-custodian-service
     "bin/summit-key-holder",     # -> summit-key-holder
     "bin/verify-quote",          # -> verify-quote
+    "bin/seismic-manifest",      # -> seismic-manifest (+ lib: the manifest renderer)
 
     "crates/attestation",
     "crates/attestation-rpc",

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ configuration at boot.
 
 ## Layout
 
-`bin/` holds the four deployed binaries plus `verify-quote`, which runs
-off-node in deploy's hands; every crate under `crates/` is a library they
-share.
+`bin/` holds the four deployed binaries plus `verify-quote` and
+`seismic-manifest`, which run off-node in deploy's hands; every crate under
+`crates/` is a library they share.
 
 ### Binaries (`bin/`)
 
@@ -18,6 +18,7 @@ share.
 | `attestation-service` | `seismic-attestation-service` | Network-facing JSON-RPC service (`:7878`): serves attestation evidence and purpose keys. Holds no key material — reaches the custodian over a Unix socket. |
 | `custodian-service` | `seismic-custodian-service` | Standalone service for the RAM-only root-key custodian: no network listener, minimal Unix-socket API, owns the per-boot LUKS keyfile handoff. |
 | `summit-key-holder` | `summit-key-holder` | Pre-manifest holder of a node's summit consensus keys: generates them in RAM at boot, serves `{pubkeys, quote}` over HTTP (`:7879`) for deploy's founding harvest, persists them into summit's keystore once LUKS opens. |
+| `seismic-manifest` | `seismic-manifest` | Not deployed to nodes: the network-manifest tool for deploy tooling — `render` turns a manifest document into the canonical `network-manifest.json` bytes (the manifest's sole emitter), `parse` puts an existing one through the same strict v1 parser every node reads it with. Also a library, so Rust deploy tooling links the renderer directly. |
 | `verify-quote` | `verify-quote` | Not deployed to nodes: operator relying-party CLI that DCAP-verifies node quotes against a measurement policy (JSON on stdout, exit 0 ⇔ verified). One verification path, two evidence sources: `harvest` checks a founding node's summit-keys quote from that node's archived harvest record, `deploy` challenges a freshly provisioned node's `getDeployVerificationEvidence` RPC itself. Shelled out to by deploy's tooling. |
 
 ### Libraries (`crates/`)

--- a/bin/seismic-manifest/Cargo.toml
+++ b/bin/seismic-manifest/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "seismic-manifest"
+version.workspace = true
+edition.workspace = true
+repository.workspace = true
+homepage.workspace = true
+authors.workspace = true
+license.workspace = true
+readme.workspace = true
+description = "Deploy-side network-manifest tool: canonical rendering and strict schema parsing over seismic-network-manifest"
+
+[dependencies]
+seismic-network-manifest.workspace = true
+
+clap.workspace = true
+hex.workspace = true
+serde_json.workspace = true

--- a/bin/seismic-manifest/src/lib.rs
+++ b/bin/seismic-manifest/src/lib.rs
@@ -1,0 +1,190 @@
+//! The canonical rendering of a [`NetworkManifestV1`] — the bytes whose
+//! SHA-256 is the network's identity.
+//!
+//! This crate is the manifest's only emitter, and it lives apart from the
+//! schema crate on purpose: `seismic-network-manifest` is parse-only, so a
+//! node build (tdx-init, the attestation service) has no code path that
+//! re-serializes the file — any re-rendering would risk changing the bytes
+//! and therefore the `network_id`. Deploy tooling links this crate (or runs
+//! the `seismic-manifest` binary) to render; nodes only ever parse.
+//!
+//! Rendering is deterministic so the same values always name the same
+//! network: 2-space indent, keys in sorted order at every level, `": "` after
+//! each key, integers unquoted, hex lowercase and `0x`-prefixed, raw UTF-8,
+//! one trailing newline. The schema crate's `fixtures/network-manifest-v1.json`
+//! pins the exact bytes; the round-trip test below holds `parse → render` to
+//! them.
+
+pub use seismic_network_manifest::{
+    ContractsManifest, EthManifest, ManifestError, MeasurementsManifest, NetworkId,
+    NetworkManifestV1, SummitManifest,
+};
+use serde_json::json;
+
+/// Render the canonical `network-manifest.json` bytes for these values.
+///
+/// Render once, then let the bytes travel verbatim: `network_id` is a hash of
+/// the file, so any re-rendering downstream would risk naming a different
+/// network.
+pub fn render(manifest: &NetworkManifestV1) -> Vec<u8> {
+    // Destructured field by field: any future addition or change to
+    // NetworkManifestV1 fails to compile here, so whoever makes it updates
+    // the rendering below.
+    let NetworkManifestV1 {
+        manifest_version,
+        name,
+        eth,
+        summit,
+        measurements,
+    } = manifest;
+    let EthManifest {
+        chain_id,
+        genesis_hash,
+    } = eth;
+    let SummitManifest {
+        genesis_config_digest,
+        namespace,
+    } = summit;
+    let MeasurementsManifest {
+        bootstrap_policy_hash,
+        contracts,
+    } = measurements;
+    let ContractsManifest {
+        registry,
+        authority,
+    } = contracts;
+
+    // Sorted keys are the canonical form: the one a holder of the file can
+    // reproduce with no schema in hand, since `jq -S .` over these bytes
+    // returns them unchanged. The literal below is kept sorted to read the
+    // way the artifact does, but `sort_keys` is what guarantees it.
+    let mut value = json!({
+        "eth": {
+            "chain_id": chain_id,
+            "genesis_hash": hex_0x(genesis_hash),
+        },
+        "manifest_version": manifest_version,
+        "measurements": {
+            "bootstrap_policy_hash": hex_0x(bootstrap_policy_hash),
+            "contracts": {
+                "authority": hex_0x(authority),
+                "registry": hex_0x(registry),
+            },
+        },
+        "name": name,
+        "summit": {
+            "genesis_config_digest": hex_0x(genesis_config_digest),
+            "namespace": namespace,
+        },
+    });
+    sort_keys(&mut value);
+    let mut bytes = serde_json::to_vec_pretty(&value)
+        .expect("a manifest built from parsed values always serializes");
+    bytes.push(b'\n');
+    bytes
+}
+
+/// Put every object's keys in sorted order.
+///
+/// Which order `serde_json` would otherwise emit depends on a feature no
+/// single crate controls: `preserve_order` swaps `Map` from a `BTreeMap` to an
+/// `IndexMap`, and cargo unifies it across whatever is being built — on for a
+/// `--workspace` build here (dcap-qvl pulls it in), off for a standalone
+/// `cargo install` of this crate. Sorting explicitly makes the two builds emit
+/// the same bytes, so the network_id never depends on how the tool was built.
+fn sort_keys(value: &mut serde_json::Value) {
+    if let serde_json::Value::Object(map) = value {
+        let mut entries: Vec<_> = std::mem::take(map).into_iter().collect();
+        entries.sort_by(|(a, _), (b, _)| a.cmp(b));
+        for (_, nested) in entries.iter_mut() {
+            sort_keys(nested);
+        }
+        *map = entries.into_iter().collect();
+    }
+}
+
+fn hex_0x(bytes: &[u8]) -> String {
+    format!("0x{}", hex::encode(bytes))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const FIXTURE: &[u8] =
+        include_bytes!("../../../crates/network-manifest/fixtures/network-manifest-v1.json");
+    const FIXTURE_NETWORK_ID: &str =
+        "0x8ef142e3f2bf15f8b201c4d8cda7848a9e846222c62b5615d4d36c7fccd98a24";
+
+    #[test]
+    fn render_reproduces_fixture_bytes() {
+        let manifest = NetworkManifestV1::from_json_bytes(FIXTURE).unwrap();
+        let rendered = render(&manifest);
+        assert_eq!(std::str::from_utf8(&rendered), std::str::from_utf8(FIXTURE));
+        assert_eq!(
+            NetworkId::from_manifest_bytes(&rendered).to_string(),
+            FIXTURE_NETWORK_ID
+        );
+    }
+
+    #[test]
+    fn render_is_canonical_regardless_of_input_formatting() {
+        // Same values, hostile formatting: reversed key order, no whitespace,
+        // uppercase hex. The renderer owns the bytes, not the input.
+        let value: serde_json::Value = serde_json::from_slice(FIXTURE).unwrap();
+        let compact = serde_json::to_string(&value)
+            .unwrap()
+            .replace("0xbbbb", "0xBBBB");
+        let reversed = {
+            let obj = value.as_object().unwrap();
+            let mut keys: Vec<_> = obj.keys().collect();
+            keys.reverse();
+            let mut s = String::from("{");
+            for (i, k) in keys.iter().enumerate() {
+                if i > 0 {
+                    s.push(',');
+                }
+                s.push_str(&format!(
+                    "{}:{}",
+                    serde_json::to_string(k).unwrap(),
+                    obj[*k]
+                ));
+            }
+            s.push('}');
+            s
+        };
+        for input in [compact, reversed] {
+            let manifest = NetworkManifestV1::from_json_bytes(input.as_bytes()).unwrap();
+            assert_eq!(render(&manifest), FIXTURE);
+        }
+    }
+
+    #[test]
+    fn sort_keys_orders_every_level() {
+        let mut value = json!({"b": 1, "a": {"d": 2, "c": {"f": 4, "e": 5}}});
+        sort_keys(&mut value);
+        assert_eq!(
+            serde_json::to_string(&value).unwrap(),
+            r#"{"a":{"c":{"e":5,"f":4},"d":2},"b":1}"#
+        );
+    }
+
+    #[test]
+    fn render_escapes_strings_as_json_requires() {
+        // Non-ASCII passes through as UTF-8 (never \u-escaped); quotes and
+        // control characters are escaped. The rendered bytes must still parse
+        // back to the same values.
+        let mut manifest = NetworkManifestV1::from_json_bytes(FIXTURE).unwrap();
+        manifest.name = "réseau \"un\"\ttab".to_string();
+        let rendered = render(&manifest);
+        assert!(
+            std::str::from_utf8(&rendered)
+                .unwrap()
+                .contains(r#""name": "réseau \"un\"\ttab""#)
+        );
+        assert_eq!(
+            NetworkManifestV1::from_json_bytes(&rendered).unwrap(),
+            manifest
+        );
+    }
+}

--- a/bin/seismic-manifest/src/main.rs
+++ b/bin/seismic-manifest/src/main.rs
@@ -1,0 +1,87 @@
+//! `seismic-manifest` — the network-manifest tool for non-Rust deploy tooling.
+//!
+//! Two subcommands over one strict parser:
+//!
+//! - `render <doc>`: a manifest document in any JSON formatting → the
+//!   canonical `network-manifest.json` bytes on stdout. The document is
+//!   strictly parsed first, so invalid values never render.
+//! - `parse <file>`: put existing manifest bytes through that same parser and
+//!   answer with the exit code.
+//!
+//! `-` reads stdin. `render` is the only subcommand that writes to stdout, and
+//! only on success: every failure is a message on stderr, a nonzero exit, and
+//! nothing on stdout. Rust consumers link this crate's library instead; the
+//! binary exists only for the subprocess boundary.
+
+use clap::{Parser, Subcommand};
+use seismic_manifest::{NetworkManifestV1, render};
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
+use std::process::ExitCode;
+
+#[derive(Parser)]
+#[command(name = "seismic-manifest", version, about)]
+struct Cli {
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Subcommand)]
+enum Command {
+    /// Render a manifest document (any JSON formatting) as the canonical
+    /// network-manifest.json bytes on stdout, after a strict schema parse.
+    Render {
+        /// Path to the manifest document (`-` for stdin).
+        document: PathBuf,
+    },
+    /// Put a network-manifest.json through the strict v1 parser, the one
+    /// every node reads the file with. Exit 0 if it parses; no stdout.
+    Parse {
+        /// Path to the manifest file (`-` for stdin).
+        manifest: PathBuf,
+    },
+}
+
+fn main() -> ExitCode {
+    match run(Cli::parse()) {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(err) => {
+            eprintln!("error: {err}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+fn run(cli: Cli) -> Result<(), String> {
+    match cli.command {
+        Command::Render { document } => {
+            let bytes = read_input(&document)?;
+            let manifest = NetworkManifestV1::from_json_bytes(&bytes).map_err(|e| e.to_string())?;
+            write_stdout(&render(&manifest))
+        }
+        Command::Parse { manifest } => {
+            let bytes = read_input(&manifest)?;
+            NetworkManifestV1::from_json_bytes(&bytes).map_err(|e| e.to_string())?;
+            Ok(())
+        }
+    }
+}
+
+fn read_input(path: &Path) -> Result<Vec<u8>, String> {
+    if path == Path::new("-") {
+        let mut buf = Vec::new();
+        std::io::stdin()
+            .read_to_end(&mut buf)
+            .map_err(|e| format!("reading stdin: {e}"))?;
+        return Ok(buf);
+    }
+    std::fs::read(path).map_err(|e| format!("reading {}: {e}", path.display()))
+}
+
+fn write_stdout(bytes: &[u8]) -> Result<(), String> {
+    let mut stdout = std::io::stdout().lock();
+    stdout
+        .write_all(bytes)
+        .and_then(|()| stdout.flush())
+        .map_err(|e| format!("writing stdout: {e}"))
+}

--- a/bin/seismic-manifest/tests/cli.rs
+++ b/bin/seismic-manifest/tests/cli.rs
@@ -1,0 +1,94 @@
+//! The `seismic-manifest` subprocess contract, as non-Rust callers rely on
+//! it: `render` puts the canonical bytes on stdout and nothing else does;
+//! every failure is stderr + nonzero exit with an empty stdout.
+
+use std::io::Write;
+use std::process::{Command, Output, Stdio};
+
+const FIXTURE: &[u8] =
+    include_bytes!("../../../crates/network-manifest/fixtures/network-manifest-v1.json");
+fn run(args: &[&str], stdin: &[u8]) -> Output {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_seismic-manifest"))
+        .args(args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    child.stdin.take().unwrap().write_all(stdin).unwrap();
+    child.wait_with_output().unwrap()
+}
+
+#[test]
+fn render_emits_canonical_bytes_from_any_formatting() {
+    let value: serde_json::Value = serde_json::from_slice(FIXTURE).unwrap();
+    let compact = serde_json::to_vec(&value).unwrap();
+    let out = run(&["render", "-"], &compact);
+    assert!(
+        out.status.success(),
+        "{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert_eq!(out.stdout, FIXTURE);
+}
+
+#[test]
+fn render_reads_a_file_path() {
+    let dir = std::env::temp_dir().join(format!("seismic-manifest-cli-{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = dir.join("doc.json");
+    std::fs::write(&path, FIXTURE).unwrap();
+    let out = run(&["render", path.to_str().unwrap()], b"");
+    std::fs::remove_dir_all(&dir).unwrap();
+    assert!(out.status.success());
+    assert_eq!(out.stdout, FIXTURE);
+}
+
+#[test]
+fn parse_accepts_a_valid_manifest_silently() {
+    let out = run(&["parse", "-"], FIXTURE);
+    assert!(
+        out.status.success(),
+        "{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(out.stdout.is_empty(), "parse must not write to stdout");
+}
+
+#[test]
+fn failures_leave_stdout_empty() {
+    let mut unknown_field: serde_json::Value = serde_json::from_slice(FIXTURE).unwrap();
+    unknown_field["tx_io_pk"] = "0x02ab".into();
+    let mut v2 = unknown_field.clone();
+    v2["manifest_version"] = 2.into();
+
+    let cases: [(&[&str], Vec<u8>, &str); 4] = [
+        (
+            &["render", "-"],
+            serde_json::to_vec(&unknown_field).unwrap(),
+            "tx_io_pk",
+        ),
+        (
+            &["parse", "-"],
+            serde_json::to_vec(&unknown_field).unwrap(),
+            "tx_io_pk",
+        ),
+        (
+            &["parse", "-"],
+            serde_json::to_vec(&v2).unwrap(),
+            "unsupported manifest_version 2",
+        ),
+        (&["parse", "-"], b"{not json".to_vec(), "schema v1"),
+    ];
+    for (args, stdin, expected) in cases {
+        let out = run(args, &stdin);
+        assert!(!out.status.success(), "{args:?} should fail");
+        assert!(out.stdout.is_empty(), "{args:?} wrote to stdout");
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        assert!(stderr.contains(expected), "{args:?}: {stderr}");
+    }
+
+    let out = run(&["parse", "/nonexistent/network-manifest.json"], b"");
+    assert!(!out.status.success());
+    assert!(out.stdout.is_empty());
+}

--- a/crates/network-manifest/README.md
+++ b/crates/network-manifest/README.md
@@ -10,5 +10,7 @@ manifest consumer parses it with the same code:
 - `seismic-attestation` re-exports these types for node-side callers
   (the attestation service, transcript bindings);
 - `tdx-init` validates the manifest embed at boot-config POST time;
-- the deploy tool emits the manifest and pins the same golden vector as
-  `fixtures/network-manifest-v1.json`.
+- `seismic-manifest` (`bin/seismic-manifest`) renders the manifest for deploy
+  tooling — the only emitter, kept out of this crate so node builds stay
+  parse-only — and its round-trip test holds `parse → render` to the exact
+  bytes of `fixtures/network-manifest-v1.json`.

--- a/crates/network-manifest/src/lib.rs
+++ b/crates/network-manifest/src/lib.rs
@@ -12,8 +12,9 @@
 //! through every hop (deploy artifact → node.toml embed → tdx-init → network-manifest.json).
 //! Consumers hash the bytes they read themselves rather than trusting a precomputed id.
 //!
-//! This crate deliberately implements `Deserialize` only. The deploy tool is
-//! the manifest's sole emitter; nothing on the node side may
+//! This crate deliberately implements `Deserialize` only. The manifest's sole
+//! emitter is the `seismic-manifest` crate (`bin/seismic-manifest`), which
+//! deploy tooling links or runs; nothing on the node side may
 //! parse-and-re-serialize the file, because any re-rendering risks changing the
 //! bytes and therefore the `network_id`. The emitter renders deterministically
 //! (2-space indent, key-sorted, single trailing newline); the parser accepts
@@ -260,11 +261,11 @@ fn decode_fixed_hex<'de, D: Deserializer<'de>, const N: usize>(
 mod tests {
     use super::*;
 
-    /// Rendered the way the deploy tool emits manifests: 2-space indent,
-    /// key-sorted, single trailing newline — i.e.
-    /// `json.dumps(manifest, indent=2, sort_keys=True) + "\n"`. Key order is
-    /// irrelevant to the parser but is part of the hashed bytes; regenerate
-    /// the pinned `network_id` below whenever the fixture changes.
+    /// Rendered by the canonical emitter (`bin/seismic-manifest`, whose
+    /// round-trip test holds `parse → render` to these exact bytes): 2-space
+    /// indent, key-sorted, single trailing newline. Key order is irrelevant
+    /// to the parser but is part of the hashed bytes; regenerate the pinned
+    /// `network_id` below whenever the fixture changes.
     const FIXTURE: &[u8] = include_bytes!("../fixtures/network-manifest-v1.json");
 
     #[test]


### PR DESCRIPTION
Closes SEI-211.

The deploy CLI re-implemented the manifest's canonical rendering and its `network_id` in Python, kept byte-for-byte in step with the Rust parser by a shared fixture and golden vectors on both sides. Two implementations of one security identifier is a standing split-brain risk, and the lockstep was held by hand.

`seismic-manifest` is the one implementation: a library with a thin CLI over the `seismic-network-manifest` schema crate. `render` takes a manifest document in any JSON formatting and writes the canonical `network-manifest.json` bytes; `parse` puts an existing manifest through the same strict v1 parser every node reads it with and answers with its exit code, writing nothing. Non-Rust callers shell out to the binary; Rust deploy tooling links the library.

The emitter lives apart from the schema crate on purpose. That crate implements `Deserialize` only, so no node build has a code path that re-serializes the file, and any re-rendering risks changing the bytes and therefore the `network_id`. A feature gate would not hold that line, since cargo unifies features across a `--workspace` build.

Two things the renderer does deliberately:

- It sorts keys itself rather than leaning on `serde_json::Map`. Which order that map yields is set by `preserve_order`, a non-additive feature any crate in the graph can turn on — `dcap-qvl` does, so a `--workspace` build gets insertion order while a standalone `cargo install` gets sorted. Sorting explicitly keeps the bytes, and the `network_id`, independent of how the tool was built.
- It destructures `NetworkManifestV1` field by field, so a later schema change fails to compile until the rendering is updated with it.

`network_id` is not part of the tool's output. It is `sha256` of the file bytes with no canonicalization step, so unlike the rendering and the schema it has nothing that could drift between implementations.