### PR TITLE
feat(enclave): expose verify-quote and tdx-init's InitConfig as libraries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6450,12 +6450,21 @@ dependencies = [
  "seismic-network-manifest",
  "serde",
  "serde_json",
+ "tdx-init-config",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "toml 0.8.23",
  "tracing",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "tdx-init-config"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "toml 0.8.23",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
     "bin/attestation-service",   # -> seismic-attestation-service
     "bin/custodian-service",     # -> seismic-custodian-service
     "bin/summit-key-holder",     # -> summit-key-holder
-    "bin/verify-quote",          # -> verify-quote
+    "bin/verify-quote",          # -> verify-quote (+ lib: the verification)
     "bin/seismic-manifest",      # -> seismic-manifest (+ lib: the manifest renderer)
 
     "crates/attestation",
@@ -21,6 +21,7 @@ members = [
     "crates/measurement-admission",  # -> seismic-measurement-admission (CLI)
     "crates/measurement-registry-client",
     "crates/network-manifest",
+    "crates/tdx-init-config",
 ]
 
 [workspace.package]
@@ -43,6 +44,7 @@ seismic-custodian-service = { path = "bin/custodian-service" }
 seismic-measurement-admission = { path = "crates/measurement-admission" }
 seismic-measurement-registry-client = { path = "crates/measurement-registry-client" }
 seismic-network-manifest = { path = "crates/network-manifest" }
+tdx-init-config = { path = "crates/tdx-init-config" }
 
 # Other deps
 alloy = "1.0"

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ configuration at boot.
 | `custodian-service` | `seismic-custodian-service` | Standalone service for the RAM-only root-key custodian: no network listener, minimal Unix-socket API, owns the per-boot LUKS keyfile handoff. |
 | `summit-key-holder` | `summit-key-holder` | Pre-manifest holder of a node's summit consensus keys: generates them in RAM at boot, serves `{pubkeys, quote}` over HTTP (`:7879`) for deploy's founding harvest, persists them into summit's keystore once LUKS opens. |
 | `seismic-manifest` | `seismic-manifest` | Not deployed to nodes: the network-manifest tool for deploy tooling — `render` turns a manifest document into the canonical `network-manifest.json` bytes (the manifest's sole emitter), `parse` puts an existing one through the same strict v1 parser every node reads it with. Also a library, so Rust deploy tooling links the renderer directly. |
-| `verify-quote` | `verify-quote` | Not deployed to nodes: operator relying-party CLI that DCAP-verifies node quotes against a measurement policy (JSON on stdout, exit 0 ⇔ verified). One verification path, two evidence sources: `harvest` checks a founding node's summit-keys quote from that node's archived harvest record, `deploy` challenges a freshly provisioned node's `getDeployVerificationEvidence` RPC itself. Shelled out to by deploy's tooling. |
+| `verify-quote` | `verify-quote` | Not deployed to nodes: operator relying-party CLI that DCAP-verifies node quotes against a measurement policy (JSON on stdout, exit 0 ⇔ verified). One verification path, two evidence sources: `harvest` checks a founding node's summit-keys quote from that node's archived harvest record, `deploy` challenges a freshly provisioned node's `getDeployVerificationEvidence` RPC itself. Also a library, so Rust deploy tooling links the verification directly; the binary is for shelling out. |
 
 ### Libraries (`crates/`)
 
@@ -34,6 +34,7 @@ configuration at boot.
 | `measurement-admission` | Admission-ID derivation and measurement-policy compiler for the on-chain `MeasurementRegistry` (plus the policy-compiler CLI behind the `cli` feature). |
 | `network-manifest` | Network-manifest schema (`NetworkManifestV1`) and `network_id` derivation. |
 | `measurement-registry-client` | Read-only Alloy client for the on-chain `MeasurementRegistry`. |
+| `tdx-init-config` | Schema of the bootstrap config `tdx-init` accepts over HTTP: both ends of that POST link it, so deploy tooling builds the struct the node deserializes. |
 
 ## Boot chain
 

--- a/bin/tdx-init/Cargo.toml
+++ b/bin/tdx-init/Cargo.toml
@@ -11,6 +11,7 @@ description = "Boot-time node initialization: receives node config over HTTP and
 
 [dependencies]
 seismic-network-manifest.workspace = true
+tdx-init-config.workspace = true
 
 axum.workspace = true
 base64.workspace = true

--- a/bin/tdx-init/README.md
+++ b/bin/tdx-init/README.md
@@ -28,8 +28,9 @@ Behavior:
 ## InitConfig schema
 
 The HTTP receiver accepts TOML with `Content-Type: application/toml`.
-Unknown top-level sections or fields are rejected — see
-[`src/config.rs`](src/config.rs).
+Unknown top-level sections or fields are rejected. The schema is its own
+crate, [`tdx-init-config`](../../crates/tdx-init-config), so deploy tooling
+constructs the exact struct this binary deserializes.
 
 ```toml
 [network]                            # coordinator-produced; a function of the network, not of this node

--- a/bin/tdx-init/src/main.rs
+++ b/bin/tdx-init/src/main.rs
@@ -4,7 +4,6 @@ use std::path::Path;
 use tokio::fs;
 use tracing::info;
 
-mod config;
 mod error;
 mod manifest;
 mod peers;

--- a/bin/tdx-init/src/peers.rs
+++ b/bin/tdx-init/src/peers.rs
@@ -25,9 +25,9 @@
 //! which would otherwise boot an attestation service with no way to obtain
 //! `root_key`.
 
-use crate::config::NodeConfig;
 use crate::error::{Result, TdxInitError};
 use std::net::{IpAddr, SocketAddr};
+use tdx_init_config::NodeConfig;
 use tracing::{info, warn};
 
 /// Number of hex chars in an enode node id: the 64-byte secp256k1 public key
@@ -201,7 +201,7 @@ fn is_self(host: &str, external_ip: IpAddr) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::DomainConfig;
+    use tdx_init_config::DomainConfig;
 
     fn node(external_ip: &str, genesis_node: bool) -> NodeConfig {
         NodeConfig {

--- a/bin/tdx-init/src/server.rs
+++ b/bin/tdx-init/src/server.rs
@@ -1,4 +1,3 @@
-use crate::config::InitConfig;
 use crate::error::{Result, TdxInitError};
 use axum::{
     Router,
@@ -9,6 +8,7 @@ use axum::{
     routing::post,
 };
 use std::sync::Arc;
+use tdx_init_config::InitConfig;
 use tokio::net::TcpListener;
 use tokio::sync::oneshot;
 use tracing::info;

--- a/bin/tdx-init/src/writer.rs
+++ b/bin/tdx-init/src/writer.rs
@@ -1,8 +1,8 @@
-use crate::config::InitConfig;
 use crate::error::Result;
 use std::net::SocketAddr;
 use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
+use tdx_init_config::InitConfig;
 use tokio::fs;
 use tracing::info;
 
@@ -189,8 +189,8 @@ async fn write_with_mode(path: &Path, content: impl AsRef<[u8]>, mode: u32) -> R
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::{DomainConfig, NetworkConfig, NodeConfig};
     use base64::Engine as _;
+    use tdx_init_config::{DomainConfig, NetworkConfig, NodeConfig};
     use tempfile::TempDir;
 
     /// A syntactically valid enode at `host_port` (128-hex pubkey).

--- a/bin/verify-quote/Cargo.toml
+++ b/bin/verify-quote/Cargo.toml
@@ -7,7 +7,11 @@ homepage.workspace = true
 authors.workspace = true
 license.workspace = true
 readme.workspace = true
-description = "Operator relying-party CLI that verifies Seismic node quotes against intended image measurements"
+description = "Relying-party verification of Seismic node quotes against intended image measurements, and the CLI over it"
+
+[lib]
+name = "seismic_verify_quote"
+path = "src/lib.rs"
 
 [[bin]]
 name = "verify-quote"

--- a/bin/verify-quote/src/collateral.rs
+++ b/bin/verify-quote/src/collateral.rs
@@ -48,7 +48,7 @@ use serde::{Deserialize, Serialize};
 
 /// One box's archived collateral: the snapshot its verification consumed,
 /// and the `harvest_nonce` of the record it was verified with.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ArchivedSnapshot {
     pub harvest_nonce: [u8; 32],
     pub snapshot: CollateralSnapshot,

--- a/bin/verify-quote/src/lib.rs
+++ b/bin/verify-quote/src/lib.rs
@@ -1,0 +1,799 @@
+//! Relying-party verification of Seismic node quotes.
+//!
+//! Two checks, sharing one DCAP verification path (`seismic-attestation` over
+//! the complete evidence envelope, enforcing the measurement policy). They
+//! differ only in which binding they recompute and where the evidence comes
+//! from:
+//!
+//! - [`verify_harvest`] checks one founding node's summit-keys harvest quote,
+//!   taking that node's whole harvest record (see [`HarvestRecord`]): the
+//!   record's evidence must carry
+//!   `founding_summit_keys_binding(harvest_nonce, node_public_key,
+//!   consensus_public_key)` over the record's own claims. The record is per
+//!   node, so one call covers one node's harvest.
+//! - [`verify_deploy`] checks a freshly provisioned node before the operator
+//!   relies on it (publishing its address, handing it out as a bootnode): it
+//!   mints a fresh `deployment_nonce`, requests evidence from the node's
+//!   attestation service (`getDeployVerificationEvidence`), and recomputes
+//!   `deploy_verification_binding(network_id, nonce)` from the caller's own
+//!   copy of the network manifest.
+//!
+//! A harvest is judged against the collateral its caller chooses, and both
+//! choices matter (see [`HarvestCollateral`]): a live verification fetches
+//! Intel's bundle and judges at the wall clock, and hands back the bundle it
+//! consumed so an archive can keep it ([`VerifiedHarvest::archived_collateral`]);
+//! a replay is given an archived bundle and the instant it was held to, and
+//! reaches no collateral service at all. Intel's TCB Info, QE Identity and both
+//! CRLs carry `nextUpdate` on a roughly 30-day cadence, so the replay is the
+//! only mode under which a founding quote still verifies a month after the
+//! founding.
+//!
+//! A measurement policy is required throughout: there is no accept-any entry
+//! point, because the measurement check is the point.
+//!
+//! Verification-only: nothing here touches a local TPM. Azure TDX verification
+//! is pure computation over the evidence bytes (the `azure-verifier` feature of
+//! the `attestation` backend), so it builds and runs anywhere, including macOS;
+//! [`verify_deploy`] additionally makes one JSON-RPC request to the target node.
+
+pub mod collateral;
+
+use anyhow::Context as _;
+use jsonrpsee::http_client::HttpClientBuilder;
+use seismic_attestation::{
+    AttestationType, VerifiedAzureAttestation, VerifiedEvidence, VerifiedSeismicAttestation,
+    VerifyMode, VerifyOptions,
+    bindings::{
+        binding64_from_digest32, deploy_verification_binding, founding_summit_keys_binding,
+    },
+    verify_evidence_with_policy,
+};
+use seismic_attestation_rpc::AttestationRpcClient as _;
+use serde::Deserialize;
+use std::{collections::BTreeMap, time::Duration};
+
+pub use collateral::ArchivedSnapshot;
+pub use seismic_attestation::{
+    AttestationExchangeMessage, CollateralSnapshot, NetworkId, NetworkManifestV1,
+    SeismicMeasurementPolicy,
+};
+
+/// How long a node gets to answer a deploy-verification challenge. Quote
+/// generation opens the node's TPM exclusively and is serialized in-process,
+/// so a busy node answers in seconds, not milliseconds.
+const QUOTE_REQUEST_TIMEOUT: Duration = Duration::from_secs(120);
+
+/// One founding node's harvest record: the four facts a harvest quote is
+/// verified against, in one JSON document.
+///
+/// This is the founding harvest archive's schema, and what makes the archive
+/// re-verifiable: deploy writes one such document per node when it collects
+/// the keys, and anyone re-checking the founding set later hands the same file
+/// straight back to [`verify_harvest`]. What the archive keeps alongside these
+/// fields (when the harvest ran, the report of the verification that passed) is
+/// ignored here, so an archived file verifies as-is.
+///
+/// The three claims are untrusted input: the quote's `report_data` is what
+/// decides whether the node's keys really are these, so a wrong claim surfaces
+/// as a binding mismatch.
+#[derive(Debug, Deserialize)]
+pub struct HarvestRecord {
+    /// The nonce the quote was requested with (32 bytes hex).
+    pub harvest_nonce: String,
+
+    /// The ed25519 node pubkey the key holder served (32 bytes hex).
+    pub node_public_key: String,
+
+    /// The BLS12-381 MinPk consensus pubkey the key holder served
+    /// (48 bytes hex).
+    pub consensus_public_key: String,
+
+    /// The evidence the key holder served, verbatim.
+    pub evidence: AttestationExchangeMessage,
+}
+
+/// Where the DCAP collateral a harvest is judged against comes from.
+///
+/// Capture and replay are the two ends of a founding archive, and they exclude
+/// each other by construction: a replay reaches no collateral service, so there
+/// is nothing left for a PCCS to serve.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum HarvestCollateral {
+    /// Fetch Intel's bundle and judge the quote at the wall clock, optionally
+    /// from `pccs_url` instead of the backend's default provider.
+    Live { pccs_url: Option<String> },
+
+    /// Replay against an archived snapshot, at the instant it was held to,
+    /// reaching no collateral service. Boxed: a bundle of Intel's material is
+    /// far larger than the other choice, which is a URL at most.
+    Archived(Box<ArchivedSnapshot>),
+}
+
+impl Default for HarvestCollateral {
+    fn default() -> Self {
+        Self::Live { pccs_url: None }
+    }
+}
+
+/// What a passing verification proves, whatever its purpose: the `report_data`
+/// the quote carried — recomputed by the verifier and matched — and every
+/// register the quote attests.
+///
+/// Every quoted register is carried, not just the ones the policy pins,
+/// because the caller keeps this as provenance.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct QuoteReport {
+    /// The 64-byte `report_data` bound into the quote.
+    pub binding: [u8; 64],
+
+    /// Every register the quote covers, in register order.
+    pub pcrs: BTreeMap<u32, [u8; 32]>,
+}
+
+impl QuoteReport {
+    fn from_verified(verified: &VerifiedAzureAttestation) -> Self {
+        Self {
+            binding: verified.binding,
+            // Register order, so archived reports diff cleanly across nodes,
+            // boots and builds: the backend hands back a `HashMap`, whose
+            // iteration order is not stable.
+            pcrs: verified
+                .guest_measurements
+                .pcrs
+                .iter()
+                .map(|(index, value)| (*index, *value))
+                .collect(),
+        }
+    }
+
+    /// This report as a JSON object.
+    pub fn to_json(&self) -> serde_json::Value {
+        let pcrs: serde_json::Map<String, serde_json::Value> = self
+            .pcrs
+            .iter()
+            .map(|(index, value)| (format!("pcr{index}"), hex::encode(value).into()))
+            .collect();
+        serde_json::json!({
+            "verified": true,
+            "attestation_type": AttestationType::AzureTdx.as_str(),
+            "binding": hex::encode(self.binding),
+            "pcrs": pcrs,
+        })
+    }
+}
+
+/// A verified harvest quote, and the collateral the verdict depended on.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VerifiedHarvest {
+    /// What the quote proved.
+    pub report: QuoteReport,
+
+    /// The record's `harvest_nonce`: what names the record this verification
+    /// belongs to.
+    pub harvest_nonce: [u8; 32],
+
+    /// The DCAP collateral this verification consumed — Intel's bundle and the
+    /// instant it was held to.
+    pub collateral: CollateralSnapshot,
+}
+
+impl VerifiedHarvest {
+    /// This verification's report as a JSON object.
+    pub fn to_json(&self) -> serde_json::Value {
+        self.report.to_json()
+    }
+
+    /// The archived-collateral document for this verification: the exact bundle
+    /// the verdict depended on, naming the record it was verified with.
+    ///
+    /// The caller owns the layout and writes these bytes verbatim. They are
+    /// read back here before they leave this process: nothing parses them again
+    /// until a re-verification that may be a year away, so a snapshot that does
+    /// not round-trip has to fail the harvest that produced it.
+    pub fn archived_collateral(&self) -> anyhow::Result<String> {
+        let archived = ArchivedSnapshot {
+            harvest_nonce: self.harvest_nonce,
+            snapshot: self.collateral.clone(),
+        };
+        let document = collateral::render(&archived)?;
+        let reread =
+            collateral::parse(&document).context("re-reading the rendered DCAP collateral")?;
+        anyhow::ensure!(
+            reread == archived,
+            "the rendered DCAP collateral does not read back as the collateral this \
+             verification used"
+        );
+        Ok(document)
+    }
+}
+
+/// A verified deploy-verification challenge, and the facts of what was checked.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VerifiedDeploy {
+    /// What the quote proved.
+    pub report: QuoteReport,
+
+    /// The network identity the binding committed to.
+    pub network_id: NetworkId,
+
+    /// The nonce that made this run's quote fresh.
+    pub deployment_nonce: [u8; 32],
+}
+
+impl VerifiedDeploy {
+    /// This verification's report as a JSON object, carrying the
+    /// purpose-specific facts of what was checked alongside what the quote
+    /// proved.
+    pub fn to_json(&self) -> serde_json::Value {
+        let mut object = self.report.to_json();
+        let map = object.as_object_mut().expect("a report is a JSON object");
+        map.insert("network_id".to_string(), self.network_id.to_string().into());
+        map.insert(
+            "deployment_nonce".to_string(),
+            hex::encode(self.deployment_nonce).into(),
+        );
+        object
+    }
+}
+
+/// Verify one founding node's summit-keys harvest quote against `policy`.
+///
+/// The record's claims decide the binding: the quote must carry
+/// `founding_summit_keys_binding` over this record's nonce and both pubkeys, so
+/// a record claiming keys the node never quoted fails as a binding mismatch.
+///
+/// A [`HarvestCollateral::Archived`] snapshot has to be the one this record's
+/// verification produced, and is refused otherwise. The instant decides which
+/// validity and revocation windows are open, so a snapshot filed beside another
+/// box's record would evaluate the quote at the wrong instant against the wrong
+/// bundle. Neither file is signed, so this is not a trust boundary; it catches
+/// the mispairing an archive comes to by accident, exactly, since no two records
+/// share a nonce.
+pub async fn verify_harvest(
+    record: HarvestRecord,
+    policy: SeismicMeasurementPolicy,
+    collateral: HarvestCollateral,
+) -> anyhow::Result<VerifiedHarvest> {
+    // Resolve everything that can fail on a malformed record before any
+    // verification: DCAP costs collateral round-trips, so a bad field should
+    // not be discovered on the far side of them.
+    let nonce = decode_hex_field::<32>("harvest_nonce", &record.harvest_nonce)?;
+    let node_pk = decode_hex_field::<32>("node_public_key", &record.node_public_key)?;
+    let consensus_pk =
+        decode_hex_field::<48>("consensus_public_key", &record.consensus_public_key)?;
+    let binding = harvest_binding(&nonce, &node_pk, &consensus_pk);
+
+    let (mode, pccs_url) = match collateral {
+        HarvestCollateral::Live { pccs_url } => (VerifyMode::Live, pccs_url),
+        HarvestCollateral::Archived(archived) => {
+            anyhow::ensure!(
+                archived.harvest_nonce == nonce,
+                "the archived collateral belongs to the record with harvest_nonce {}, not to \
+                 this one ({}): they are not from one harvest",
+                hex::encode(archived.harvest_nonce),
+                hex::encode(nonce),
+            );
+            (VerifyMode::Archived(archived.snapshot), None)
+        }
+    };
+
+    let (verified, collateral) = verify_azure(record.evidence, binding, policy, mode, pccs_url)
+        .await
+        .context("verifying harvest evidence")?;
+    Ok(VerifiedHarvest {
+        report: QuoteReport::from_verified(&verified),
+        harvest_nonce: nonce,
+        collateral,
+    })
+}
+
+/// Challenge the node serving `endpoint` and verify its answer against
+/// `policy`, for the network `manifest_bytes` names.
+///
+/// A pass proves a measured node holding this manifest answered this exact
+/// request. The check protects only the operator's own decisions: membership in
+/// the network is granted by the network's own gates (the attested root-key
+/// handshake and its admission policy), never by this check.
+///
+/// `manifest_bytes` are the exact `network-manifest.json` bytes the node is
+/// expected to have booted with — the network identity the binding commits to
+/// is their hash. They are strictly parsed first, which is what separates "you
+/// passed the wrong file" from "this node answered for another network":
+/// without the parse, any file hashes to some id and the run fails as a binding
+/// mismatch — the alarm that makes an operator burn a box.
+pub async fn verify_deploy(
+    endpoint: &str,
+    manifest_bytes: &[u8],
+    policy: SeismicMeasurementPolicy,
+    pccs_url: Option<String>,
+) -> anyhow::Result<VerifiedDeploy> {
+    NetworkManifestV1::from_json_bytes(manifest_bytes)
+        .context("the manifest is not a v1 network manifest")?;
+    let network_id = NetworkId::from_manifest_bytes(manifest_bytes);
+
+    let client = HttpClientBuilder::default()
+        .request_timeout(QUOTE_REQUEST_TIMEOUT)
+        .build(endpoint)
+        .with_context(|| format!("endpoint {endpoint} is not a usable URL"))?;
+
+    // Minted here and never handed to anyone but the node under test, so the
+    // returned quote can only answer this exact request.
+    let deployment_nonce: [u8; 32] = rand::random();
+    let response = client
+        .get_deploy_verification_evidence(deployment_nonce)
+        .await
+        .with_context(|| format!("requesting deploy-verification evidence from {endpoint}"))?;
+
+    let binding = deploy_binding(&network_id, &deployment_nonce);
+    // The collateral goes unarchived here: a live challenge is fresh evidence,
+    // judged against fresh collateral at the wall clock.
+    let (verified, _collateral) = verify_azure(
+        response.evidence,
+        binding,
+        policy,
+        VerifyMode::Live,
+        pccs_url,
+    )
+    .await
+    .context("verifying deploy-verification evidence")?;
+    Ok(VerifiedDeploy {
+        report: QuoteReport::from_verified(&verified),
+        network_id,
+        deployment_nonce,
+    })
+}
+
+/// The 64-byte `report_data` a harvested quote must carry.
+///
+/// Pure and deliberately trivial: this one line is the single definition of the
+/// check, linked by everything that verifies a harvest.
+pub fn harvest_binding(nonce: &[u8; 32], node_pk: &[u8; 32], consensus_pk: &[u8; 48]) -> [u8; 64] {
+    binding64_from_digest32(founding_summit_keys_binding(nonce, node_pk, consensus_pk))
+}
+
+/// The 64-byte `report_data` a deploy-verification quote must carry
+/// (same single-definition rationale as [`harvest_binding`]).
+pub fn deploy_binding(network_id: &NetworkId, deployment_nonce: &[u8; 32]) -> [u8; 64] {
+    binding64_from_digest32(deploy_verification_binding(network_id, deployment_nonce))
+}
+
+/// Verify Azure TDX evidence against `binding` and `policy`, returning the
+/// verified output and the DCAP collateral the verification consumed.
+///
+/// Wrong-platform evidence is rejected on the claimed type, before
+/// verification: DCAP verification costs collateral round-trips, and this
+/// policy format cannot pin a non-Azure platform's measurements anyway.
+async fn verify_azure(
+    evidence: AttestationExchangeMessage,
+    binding: [u8; 64],
+    policy: SeismicMeasurementPolicy,
+    mode: VerifyMode,
+    pccs_url: Option<String>,
+) -> anyhow::Result<(VerifiedAzureAttestation, CollateralSnapshot)> {
+    anyhow::ensure!(
+        evidence.attestation_type() == AttestationType::AzureTdx,
+        "expected {} evidence, got {}",
+        AttestationType::AzureTdx.as_str(),
+        evidence.attestation_type().as_str(),
+    );
+
+    let VerifiedEvidence {
+        attestation,
+        collateral,
+    } = verify_evidence_with_policy(
+        evidence,
+        binding,
+        policy,
+        VerifyOptions {
+            mode,
+            pccs_url,
+            dump_dcap_quotes: false,
+        },
+    )
+    .await?;
+    let VerifiedSeismicAttestation::AzureTdx(verified) = attestation else {
+        anyhow::bail!(
+            "verified output is not azure-tdx despite azure-tdx evidence: {attestation:?}"
+        );
+    };
+    Ok((verified, collateral))
+}
+
+/// Decode one fixed-length hex field of the record, naming the field in every
+/// failure.
+///
+/// A field of the wrong length or spelling is a malformed record, not a failed
+/// quote, and the two look alike once the binding is computed — so each is
+/// rejected up front, by name.
+fn decode_hex_field<const N: usize>(field: &str, value: &str) -> anyhow::Result<[u8; N]> {
+    let bare = value.strip_prefix("0x").unwrap_or(value);
+    let bytes = hex::decode(bare).with_context(|| format!("record {field} is not valid hex"))?;
+    bytes.try_into().map_err(|bytes: Vec<u8>| {
+        anyhow::anyhow!(
+            "record {field} must be {N} bytes ({} hex chars), got {}",
+            N * 2,
+            bytes.len()
+        )
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use seismic_attestation::AzureGuestMeasurements;
+    use std::collections::HashMap;
+
+    /// One real founding, kept verbatim: a harvest record, the collateral
+    /// snapshot its verification consumed, and the promoted policy it was
+    /// verified against. Captured on Azure TDX hardware from cohort
+    /// `tmp-devnet-1` on image `seismic-dev_2026-08-27.5c012e.vhd`,
+    /// harvested 2026-08-27T20:20:55Z and torn down the same day. The
+    /// pubkeys are a destroyed throwaway network's, so the committed archive
+    /// discloses nothing.
+    const FOUNDING_RECORD: &str = include_str!("../fixtures/founding-record-v1.json");
+    const FOUNDING_COLLATERAL: &str = include_str!("../fixtures/founding-collateral-v1.json");
+    const FOUNDING_POLICY: &str = include_str!("../fixtures/founding-policy-v1.json");
+
+    /// The instant frozen into that snapshot, and the reason the fixture
+    /// cannot rot: a replay evaluates every freshness window here, not at
+    /// the wall clock.
+    const FOUNDING_VERIFIED_AT: u64 = 1787862055;
+
+    /// How many registers the Azure TDX v1 admission schema
+    /// (`seismic.azure-tdx.pcr4-pcr9-pcr11.v1`) pins: guest identity is that
+    /// tuple and nothing else, so a promoted policy carries exactly three.
+    const AZURE_TDX_V1_REGISTERS: usize = 3;
+
+    /// How many registers an Azure vTPM quote attests: PCRs 0-23, all
+    /// covered by the signed `pcrDigest` whether or not a policy pins them.
+    const AZURE_VTPM_REGISTERS: usize = 24;
+
+    const NONCE_HEX: &str = "7777777777777777777777777777777777777777777777777777777777777777";
+    const NODE_PK_HEX: &str = "8888888888888888888888888888888888888888888888888888888888888888";
+    const CONSENSUS_PK_HEX: &str = "999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999";
+
+    /// A policy that parses. Its measurements never get checked in the
+    /// fabricated cases: those fail before verification, which is the point —
+    /// no test here reaches live DCAP.
+    const VALID_POLICY: &str = r#"[
+      {
+        "attestation_type": "azure-tdx",
+        "measurement_id": "verify-quote-test.vhd",
+        "measurements": {
+          "pcr4": { "expected_any": ["d57063c0669599b885c43a0683436a3463ad49513ddb3996e6fc96040508fd8e"] }
+        }
+      }
+    ]"#;
+
+    fn policy(document: &str) -> SeismicMeasurementPolicy {
+        SeismicMeasurementPolicy::from_json_bytes(document.as_bytes()).expect("policy document")
+    }
+
+    fn record(document: &str) -> HarvestRecord {
+        serde_json::from_str(document).expect("harvest record")
+    }
+
+    /// A harvest record carrying `evidence` verbatim, with the frozen claims
+    /// the binding vectors use.
+    fn record_json(evidence: &str) -> String {
+        format!(
+            r#"{{
+              "harvest_nonce": "{NONCE_HEX}",
+              "node_public_key": "{NODE_PK_HEX}",
+              "consensus_public_key": "{CONSENSUS_PK_HEX}",
+              "evidence": {evidence}
+            }}"#
+        )
+    }
+
+    /// The registers a policy document pins, and the single value each
+    /// demands, read straight out of the JSON.
+    fn policy_registers(document: &str) -> BTreeMap<String, String> {
+        let records: serde_json::Value = serde_json::from_str(document).expect("policy document");
+        records[0]["measurements"]
+            .as_object()
+            .expect("a measurements map")
+            .iter()
+            .map(|(register, entry)| {
+                let values = entry["expected_any"].as_array().expect("expected_any");
+                assert_eq!(values.len(), 1, "{register} pins more than one value");
+                (
+                    register.clone(),
+                    values[0].as_str().expect("hex").to_string(),
+                )
+            })
+            .collect()
+    }
+
+    /// The property the founding archive exists for, over real hardware
+    /// evidence: a founding quote re-verifies against its own archived
+    /// collateral, reaching no collateral service and depending in no way on
+    /// when the test runs.
+    ///
+    /// Every other offline test here runs on fabricated collateral, which
+    /// exercises the plumbing but never a bundle Intel actually served. This
+    /// one holds the whole path to real material — the DCAP chain, the TCB
+    /// Info and QE Identity windows, both CRLs, and the Azure AK certificate
+    /// chain — at the instant the snapshot pins. A live verification of this
+    /// same record stops passing once the bundle's `nextUpdate` lapses
+    /// (2026-09-26); this one keeps passing, which is the whole point.
+    #[tokio::test]
+    async fn a_real_founding_reverifies_offline_against_its_archived_collateral() {
+        // Asserted before verifying: a fixture re-captured without its
+        // instant should fail here, not as a puzzling expiry years from now.
+        let archived = collateral::parse(FOUNDING_COLLATERAL).expect("archived snapshot");
+        assert_eq!(archived.snapshot.at, FOUNDING_VERIFIED_AT);
+
+        let verified = verify_harvest(
+            record(FOUNDING_RECORD),
+            policy(FOUNDING_POLICY),
+            HarvestCollateral::Archived(Box::new(archived)),
+        )
+        .await
+        .expect("the archived founding verifies offline");
+
+        let report = verified.to_json();
+        assert_eq!(report["verified"], true);
+        assert_eq!(report["attestation_type"], "azure-tdx");
+
+        // The policy has to be one that really pins this guest: a policy
+        // whose measurements map were empty accepts any quote, and this test
+        // would pass while checking nothing. So every register it pins must
+        // come back with the value it demanded.
+        let pinned = policy_registers(FOUNDING_POLICY);
+        assert_eq!(pinned.len(), AZURE_TDX_V1_REGISTERS, "{pinned:?}");
+        let pcrs = report["pcrs"].as_object().unwrap();
+        for (register, expected) in &pinned {
+            assert_eq!(pcrs[register], *expected, "{register}");
+        }
+        // And the rest ride along as provenance, pinned by the same signed
+        // pcrDigest but constrained by no policy.
+        assert_eq!(pcrs.len(), AZURE_VTPM_REGISTERS);
+    }
+
+    /// The other half of the same property: the pinned instant is what makes
+    /// that founding verify, not the bundle alone. Move the instant past the
+    /// bundle's `nextUpdate` and the very same record and snapshot stop
+    /// verifying — which is what a live verification will do to this record
+    /// from 2026-09-26 on, and what the archive exists to avoid.
+    #[tokio::test]
+    async fn the_archived_instant_is_what_makes_the_founding_verify() {
+        // 2027-01-15, months past every window in the archived bundle. Only
+        // the instant changes; the collateral is the same bytes that verify
+        // in the test above.
+        let mut document: serde_json::Value = serde_json::from_str(FOUNDING_COLLATERAL).unwrap();
+        document["verified_at"] = serde_json::json!(1_800_000_000u64);
+        let archived = collateral::parse(&document.to_string()).expect("archived snapshot");
+
+        let error = verify_harvest(
+            record(FOUNDING_RECORD),
+            policy(FOUNDING_POLICY),
+            HarvestCollateral::Archived(Box::new(archived)),
+        )
+        .await
+        .expect_err("an expired bundle must not verify");
+        assert!(
+            format!("{error:#}").contains("DCAP"),
+            "expected a DCAP freshness failure, got: {error:#}"
+        );
+    }
+
+    /// The instant decides which validity and revocation windows are open, so
+    /// a snapshot has to be the one this record's verification produced. The
+    /// snapshot names its record by nonce, and no two records share one, so
+    /// a snapshot filed beside another box's record is refused exactly —
+    /// before any verification, since the pairing is what decides whether the
+    /// bundle applies at all.
+    #[tokio::test]
+    async fn replay_pairs_a_snapshot_with_its_record_by_nonce() {
+        let error = verify_harvest(
+            record(&record_json(NO_ATTESTATION)),
+            policy(VALID_POLICY),
+            HarvestCollateral::Archived(Box::new(collateral::fabricated_snapshot())),
+        )
+        .await
+        .unwrap_err()
+        .to_string();
+        assert!(error.contains("not from one harvest"), "{error}");
+        assert!(error.contains(NONCE_HEX), "{error}");
+        assert!(
+            error.contains(&hex::encode(collateral::FABRICATED_NONCE)),
+            "{error}"
+        );
+    }
+
+    const NO_ATTESTATION: &str = r#"{ "attestation_type": "none", "attestation": [] }"#;
+
+    /// One job, one binding: a quote from a platform whose measurements this
+    /// policy format cannot pin is rejected without any collateral fetching.
+    #[tokio::test]
+    async fn non_azure_evidence_is_rejected() {
+        let error = verify_harvest(
+            record(&record_json(NO_ATTESTATION)),
+            policy(VALID_POLICY),
+            HarvestCollateral::default(),
+        )
+        .await
+        .unwrap_err();
+        assert!(
+            format!("{error:#}").contains("expected azure-tdx evidence"),
+            "{error:#}"
+        );
+    }
+
+    /// The archived document a verification hands back names the record it was
+    /// verified with, so the snapshot a harvest archives is the one its own
+    /// replay accepts.
+    #[test]
+    fn the_archived_document_names_the_record_it_verified() {
+        let nonce = [0x3cu8; 32];
+        let verified = VerifiedHarvest {
+            report: QuoteReport {
+                binding: [0u8; 64],
+                pcrs: BTreeMap::new(),
+            },
+            harvest_nonce: nonce,
+            collateral: collateral::fabricated_collateral(),
+        };
+
+        let archived = collateral::parse(&verified.archived_collateral().unwrap()).unwrap();
+        assert_eq!(archived.harvest_nonce, nonce);
+        assert_eq!(archived.snapshot, collateral::fabricated_collateral());
+    }
+
+    /// The bindings are wire-format commitments shared with the quoting node,
+    /// so these vectors are frozen: each is its `bindings.rs` frozen digest,
+    /// zero-padded to 64 bytes.
+    #[test]
+    fn bindings_match_frozen_vectors() {
+        let harvest = harvest_binding(&[0x77; 32], &[0x88; 32], &[0x99; 48]);
+        assert_eq!(
+            hex::encode(&harvest[..32]),
+            "8973b984dc10f809ebfaacdcad64b8cc5a647cf24e4bc27b3833cc234a9290e5"
+        );
+        assert_eq!(&harvest[32..], &[0u8; 32]);
+
+        let deploy = deploy_binding(&NetworkId::from_bytes([0x11; 32]), &[0x66; 32]);
+        assert_eq!(
+            hex::encode(&deploy[..32]),
+            "16a53bcb2d1421951a830a1308bca525b8ecfbf96fc89ad6152cdbfce4777eb9"
+        );
+        assert_eq!(&deploy[32..], &[0u8; 32]);
+    }
+
+    /// The record's hex fields feed the binding, and a wrong one produces a
+    /// mismatch that looks exactly like a bad quote — so they are rejected up
+    /// front, by name.
+    #[test]
+    fn hex_fields_fail_by_field_name() {
+        let not_hex = decode_hex_field::<32>("harvest_nonce", "zz77")
+            .unwrap_err()
+            .to_string();
+        assert!(not_hex.contains("harvest_nonce"), "{not_hex}");
+
+        let wrong_length = decode_hex_field::<48>("consensus_public_key", NODE_PK_HEX)
+            .unwrap_err()
+            .to_string();
+        assert!(
+            wrong_length.contains("consensus_public_key"),
+            "{wrong_length}"
+        );
+        assert!(wrong_length.contains("48 bytes"), "{wrong_length}");
+
+        assert_eq!(
+            decode_hex_field::<32>("node_public_key", NODE_PK_HEX).unwrap(),
+            [0x88; 32]
+        );
+        // The archive writes bare hex; 0x-prefixed means the same key.
+        assert_eq!(
+            decode_hex_field::<32>("node_public_key", &format!("0x{NODE_PK_HEX}")).unwrap(),
+            [0x88; 32]
+        );
+    }
+
+    /// The archived record is the input format: a file carrying the harvest's
+    /// own provenance fields around the four verified ones parses as-is.
+    #[test]
+    fn record_ignores_the_archives_extra_fields() {
+        let archived = format!(
+            r#"{{
+              "harvest_nonce": "{NONCE_HEX}",
+              "node_public_key": "{NODE_PK_HEX}",
+              "consensus_public_key": "{CONSENSUS_PK_HEX}",
+              "evidence": {{ "attestation_type": "azure-tdx", "attestation": [1, 2, 3] }},
+              "harvested_at": "2026-08-04T00:00:00+00:00",
+              "verification": {{ "verified": true, "pcrs": {{}} }}
+            }}"#
+        );
+        let record = record(&archived);
+
+        assert_eq!(
+            decode_hex_field::<32>("harvest_nonce", &record.harvest_nonce).unwrap(),
+            [0x77; 32]
+        );
+        assert_eq!(
+            decode_hex_field::<48>("consensus_public_key", &record.consensus_public_key).unwrap(),
+            [0x99; 48]
+        );
+    }
+
+    #[test]
+    fn report_carries_every_quoted_register() {
+        let verified = VerifiedAzureAttestation {
+            binding: harvest_binding(&[0x77; 32], &[0x88; 32], &[0x99; 48]),
+            guest_measurements: AzureGuestMeasurements {
+                pcrs: HashMap::from([(11, [0xbb; 32]), (4, [0x44; 32]), (9, [0x99; 32])]),
+            },
+        };
+
+        let report = QuoteReport::from_verified(&verified).to_json();
+
+        assert_eq!(report["verified"], true);
+        assert_eq!(report["attestation_type"], "azure-tdx");
+        assert_eq!(
+            report["binding"],
+            format!(
+                "8973b984dc10f809ebfaacdcad64b8cc5a647cf24e4bc27b3833cc234a9290e5{}",
+                "00".repeat(32)
+            )
+        );
+        // Not just the policy's registers: the caller archives this as harvest
+        // provenance.
+        let pcrs = report["pcrs"].as_object().unwrap();
+        assert_eq!(pcrs.len(), 3);
+        assert_eq!(pcrs["pcr4"], "44".repeat(32));
+        assert_eq!(pcrs["pcr9"], "99".repeat(32));
+        assert_eq!(pcrs["pcr11"], "bb".repeat(32));
+    }
+
+    /// The deploy report documents what was checked: the network identity the
+    /// binding committed to and the nonce that made the quote fresh.
+    #[test]
+    fn report_extras_document_the_deploy_check() {
+        let network_id = NetworkId::from_bytes([0x11; 32]);
+        let deployment_nonce = [0x66u8; 32];
+        let verified = VerifiedDeploy {
+            report: QuoteReport {
+                binding: deploy_binding(&network_id, &deployment_nonce),
+                pcrs: BTreeMap::from([(4, [0x44; 32])]),
+            },
+            network_id,
+            deployment_nonce,
+        };
+
+        let report = verified.to_json();
+
+        assert_eq!(report["verified"], true);
+        assert_eq!(report["network_id"], format!("0x{}", "11".repeat(32)));
+        assert_eq!(report["deployment_nonce"], "66".repeat(32));
+    }
+
+    /// A file that isn't a manifest is named as such, rather than hashing to
+    /// some id and surfacing later as a binding mismatch — which reads as a
+    /// node that answered for another network. The parse comes before the
+    /// node is contacted, so the endpoint here is never reached.
+    #[tokio::test]
+    async fn deploy_rejects_a_manifest_that_is_not_one() {
+        let error = verify_deploy(
+            "http://127.0.0.1:1",
+            b"{}".as_slice(),
+            policy(VALID_POLICY),
+            None,
+        )
+        .await
+        .unwrap_err()
+        .to_string();
+        assert!(error.contains("not a v1 network manifest"), "{error}");
+    }
+
+    #[tokio::test]
+    async fn deploy_malformed_endpoint_is_rejected() {
+        let manifest =
+            include_str!("../../../crates/network-manifest/fixtures/network-manifest-v1.json");
+        let error = verify_deploy("not a url", manifest.as_bytes(), policy(VALID_POLICY), None)
+            .await
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("not a usable URL"), "{error}");
+    }
+}

--- a/bin/verify-quote/src/main.rs
+++ b/bin/verify-quote/src/main.rs
@@ -1,22 +1,12 @@
 //! `verify-quote` — operator-side relying party for Seismic node quotes.
 //!
-//! Two checks, one per subcommand, sharing one DCAP verification path
-//! (`seismic-attestation` over the complete evidence envelope, enforcing the
-//! measurement policy). The subcommands differ only in which binding they
-//! recompute and where the evidence comes from:
+//! Clap over the crate's library, which holds the verification itself: two
+//! checks, one per subcommand, sharing one DCAP verification path.
 //!
 //! - `harvest` checks one founding node's summit-keys harvest quote, taking
-//!   that node's whole harvest record (see [`HarvestRecord`]): the record's
-//!   evidence must carry
-//!   `founding_summit_keys_binding(harvest_nonce, node_public_key,
-//!   consensus_public_key)` over the record's own claims. The record is per
-//!   node, so one run covers one node's harvest.
-//! - `deploy` checks a freshly provisioned node before the operator relies
-//!   on it (publishing its address, handing it out as a bootnode): it mints a
-//!   fresh `deployment_nonce`, requests evidence from the node's attestation
-//!   service (`getDeployVerificationEvidence` at `--endpoint`), and
-//!   recomputes `deploy_verification_binding(network_id, nonce)` from its own
-//!   copy of the network manifest.
+//!   that node's whole harvest record from the founding archive.
+//! - `deploy` checks a freshly provisioned node before the operator relies on
+//!   it, by challenging its attestation service with a fresh nonce.
 //!
 //! ```text
 //! verify-quote harvest \
@@ -49,38 +39,19 @@
 //! `--collateral` is the other end of that archive, and the mode an auditor
 //! runs: the record is verified against the snapshot beside it, at the
 //! instant that snapshot was held to, reaching no collateral service at all.
-//! The snapshot names the record it belongs to by `harvest_nonce`, so a
-//! snapshot filed beside the wrong record is refused rather than replayed.
-//! Intel's TCB Info, QE Identity and both CRLs carry `nextUpdate` on a
-//! roughly 30-day cadence, so this is the only mode under which a founding
-//! quote still verifies a month after the founding.
 //!
-//! Verification-only: this never touches a local TPM. Azure TDX verification
-//! is pure computation over the evidence bytes (the `azure-verifier` feature
-//! of the `attestation` backend), so it builds and runs anywhere, including
-//! macOS; `deploy` additionally makes one JSON-RPC request to the target node.
-
-mod collateral;
+//! This binary exists for the subprocess boundary. Rust callers link the
+//! library instead.
 
 use anyhow::Context as _;
 use clap::{Args, Parser, Subcommand};
-use jsonrpsee::http_client::HttpClientBuilder;
-use seismic_attestation::{
-    AttestationExchangeMessage, AttestationType, CollateralSnapshot, NetworkId, NetworkManifestV1,
-    SeismicMeasurementPolicy, VerifiedAzureAttestation, VerifiedEvidence,
-    VerifiedSeismicAttestation, VerifyMode, VerifyOptions,
-    bindings::{
-        binding64_from_digest32, deploy_verification_binding, founding_summit_keys_binding,
-    },
-    verify_evidence_with_policy,
+use seismic_verify_quote::{
+    ArchivedSnapshot, HarvestCollateral, HarvestRecord, SeismicMeasurementPolicy, collateral,
+    verify_deploy, verify_harvest,
 };
-use seismic_attestation_rpc::AttestationRpcClient as _;
-use serde::Deserialize;
 use std::{
-    collections::BTreeMap,
     io::Read as _,
     path::{Path, PathBuf},
-    time::Duration,
 };
 
 #[derive(Debug, Parser)]
@@ -179,35 +150,6 @@ struct HarvestCli {
     common: CommonArgs,
 }
 
-/// One founding node's harvest record: the four facts a harvest quote is
-/// verified against, in one JSON document.
-///
-/// This is the founding harvest archive's schema, and what makes the archive
-/// re-verifiable: deploy writes one such document per node when it collects
-/// the keys, and anyone re-checking the founding set later hands the same file
-/// straight back to `harvest`. What the archive keeps alongside these fields
-/// (when the harvest ran, the report of the verification that passed) is
-/// ignored here, so an archived file verifies as-is.
-///
-/// The three claims are untrusted input: the quote's `report_data` is what
-/// decides whether the node's keys really are these, so a wrong claim surfaces
-/// as a binding mismatch.
-#[derive(Debug, Deserialize)]
-struct HarvestRecord {
-    /// The nonce the quote was requested with (32 bytes hex).
-    harvest_nonce: String,
-
-    /// The ed25519 node pubkey the key holder served (32 bytes hex).
-    node_public_key: String,
-
-    /// The BLS12-381 MinPk consensus pubkey the key holder served
-    /// (48 bytes hex).
-    consensus_public_key: String,
-
-    /// The evidence the key holder served, verbatim.
-    evidence: AttestationExchangeMessage,
-}
-
 #[derive(Debug, Args)]
 struct DeployCli {
     /// The node's attestation-service JSON-RPC endpoint,
@@ -244,108 +186,43 @@ async fn run(cli: Cli) -> anyhow::Result<String> {
 }
 
 async fn run_harvest(cli: HarvestCli) -> anyhow::Result<String> {
-    // Resolve everything that can fail on bad input before any verification:
-    // DCAP costs collateral round-trips, so a malformed record should not be
+    // Resolve everything the filesystem can fail on before any verification:
+    // DCAP costs collateral round-trips, so a mistyped path should not be
     // discovered on the far side of them.
     let record_bytes = read_record(&cli.record).await?;
     let record: HarvestRecord =
         serde_json::from_slice(&record_bytes).context("--record is not a harvest record")?;
-    let nonce = decode_hex_field::<32>("harvest_nonce", &record.harvest_nonce)?;
-    let node_pk = decode_hex_field::<32>("node_public_key", &record.node_public_key)?;
-    let consensus_pk =
-        decode_hex_field::<48>("consensus_public_key", &record.consensus_public_key)?;
-    let binding = harvest_binding(&nonce, &node_pk, &consensus_pk);
-
     let policy = load_policy(&cli.common.policy).await?;
-    let mode = match &cli.collateral {
-        Some(path) => archived_mode(path, &nonce).await?,
-        None => VerifyMode::Live,
+    let collateral = match &cli.collateral {
+        Some(path) => HarvestCollateral::Archived(Box::new(read_archived_collateral(path).await?)),
+        None => HarvestCollateral::Live {
+            pccs_url: cli.common.pccs_url,
+        },
     };
-    let (verified, collateral) = verify_azure(record.evidence, binding, policy, mode, &cli.common)
-        .await
-        .context("verifying harvest evidence")?;
+
+    let verified = verify_harvest(record, policy, collateral).await?;
     // After the verdict, never before: a burned harvest must not leave a
     // half-archive behind for a later reader to trust.
     if let Some(path) = &cli.dump_collateral {
-        dump_collateral(path, &nonce, &collateral).await?;
+        let document = verified.archived_collateral()?;
+        tokio::fs::write(path, document)
+            .await
+            .with_context(|| format!("writing --dump-collateral {}", path.display()))?;
     }
-    Ok(report(&verified, []))
+    Ok(verified.to_json().to_string())
 }
 
 async fn run_deploy(cli: DeployCli) -> anyhow::Result<String> {
-    // Resolve every local input before contacting the node: a mistyped path
+    // Read every local input before contacting the node: a mistyped path
     // should not be discovered on the far side of an RPC round-trip.
     let manifest_bytes = tokio::fs::read(&cli.manifest)
         .await
         .with_context(|| format!("reading --manifest {}", cli.manifest.display()))?;
-    // Parse strictly, then derive the id from the same raw bytes. The parse is
-    // what separates "you passed the wrong file" from "this node answered for
-    // another network": without it, any file hashes to some id and the run
-    // fails as a binding mismatch — the alarm that makes an operator burn a box.
-    NetworkManifestV1::from_json_bytes(&manifest_bytes).with_context(|| {
-        format!(
-            "--manifest {} is not a v1 network manifest",
-            cli.manifest.display()
-        )
-    })?;
-    let network_id = NetworkId::from_manifest_bytes(&manifest_bytes);
     let policy = load_policy(&cli.common.policy).await?;
-    let client = HttpClientBuilder::default()
-        // Quote generation opens the node's TPM exclusively and is serialized
-        // in-process, so a busy node answers in seconds, not milliseconds.
-        .request_timeout(Duration::from_secs(120))
-        .build(&cli.endpoint)
-        .with_context(|| format!("--endpoint {} is not a usable URL", cli.endpoint))?;
 
-    // Minted here and never handed to anyone but the node under test, so the
-    // returned quote can only answer this exact request.
-    let deployment_nonce: [u8; 32] = rand::random();
-    let response = client
-        .get_deploy_verification_evidence(deployment_nonce)
-        .await
-        .with_context(|| {
-            format!(
-                "requesting deploy-verification evidence from --endpoint {}",
-                cli.endpoint
-            )
-        })?;
-
-    let binding = deploy_binding(&network_id, &deployment_nonce);
-    // The collateral goes unarchived here: a live challenge is fresh
-    // evidence, judged against fresh collateral at the wall clock.
-    let (verified, _collateral) = verify_azure(
-        response.evidence,
-        binding,
-        policy,
-        VerifyMode::Live,
-        &cli.common,
-    )
-    .await
-    .context("verifying deploy-verification evidence")?;
-    // The extras document what was checked: which network identity the binding
-    // committed to, and the nonce that made this run's quote fresh.
-    Ok(report(
-        &verified,
-        [
-            ("network_id", network_id.to_string()),
-            ("deployment_nonce", hex::encode(deployment_nonce)),
-        ],
-    ))
-}
-
-/// The 64-byte `report_data` a harvested quote must carry.
-///
-/// Pure and deliberately trivial: the deploy tooling calls this binary
-/// instead of deriving the binding itself, so this one line is the single
-/// definition of the check on both sides.
-fn harvest_binding(nonce: &[u8; 32], node_pk: &[u8; 32], consensus_pk: &[u8; 48]) -> [u8; 64] {
-    binding64_from_digest32(founding_summit_keys_binding(nonce, node_pk, consensus_pk))
-}
-
-/// The 64-byte `report_data` a deploy-verification quote must carry
-/// (same single-definition rationale as [`harvest_binding`]).
-fn deploy_binding(network_id: &NetworkId, deployment_nonce: &[u8; 32]) -> [u8; 64] {
-    binding64_from_digest32(deploy_verification_binding(network_id, deployment_nonce))
+    let verified =
+        verify_deploy(&cli.endpoint, &manifest_bytes, policy, cli.common.pccs_url).await?;
+    Ok(verified.to_json().to_string())
 }
 
 /// Load the measurement policy, failing closed: this binary has no accept-any
@@ -356,126 +233,18 @@ async fn load_policy(path: &Path) -> anyhow::Result<SeismicMeasurementPolicy> {
         .with_context(|| format!("loading measurement policy {}", path.display()))
 }
 
-/// Verify Azure TDX evidence against `binding` and `policy`, returning the
-/// verified output and the DCAP collateral the verification consumed.
+/// Read the archived collateral snapshot `--collateral` names.
 ///
-/// Wrong-platform evidence is rejected on the claimed type, before
-/// verification: DCAP verification costs collateral round-trips, and this
-/// policy format cannot pin a non-Azure platform's measurements anyway.
-async fn verify_azure(
-    evidence: AttestationExchangeMessage,
-    binding: [u8; 64],
-    policy: SeismicMeasurementPolicy,
-    mode: VerifyMode,
-    common: &CommonArgs,
-) -> anyhow::Result<(VerifiedAzureAttestation, CollateralSnapshot)> {
-    anyhow::ensure!(
-        evidence.attestation_type() == AttestationType::AzureTdx,
-        "expected {} evidence, got {}",
-        AttestationType::AzureTdx.as_str(),
-        evidence.attestation_type().as_str(),
-    );
-
-    let VerifiedEvidence {
-        attestation,
-        collateral,
-    } = verify_evidence_with_policy(
-        evidence,
-        binding,
-        policy,
-        VerifyOptions {
-            mode,
-            pccs_url: common.pccs_url.clone(),
-            dump_dcap_quotes: false,
-        },
-    )
-    .await?;
-    let VerifiedSeismicAttestation::AzureTdx(verified) = attestation else {
-        anyhow::bail!(
-            "verified output is not azure-tdx despite azure-tdx evidence: {attestation:?}"
-        );
-    };
-    Ok((verified, collateral))
-}
-
-/// Resolve `--collateral` into the mode it names, for the record whose
-/// `harvest_nonce` is `nonce`.
-///
-/// The archived snapshot is the whole input: the bundle Intel served, and the
-/// instant the founding verification held it to be current. So this reaches
-/// no collateral service, and `--pccs-url` has nothing left to reach.
-///
-/// The snapshot has to be the one this record's verification produced. The
-/// instant decides which validity and revocation windows are open, so a
-/// snapshot filed beside another box's record would evaluate the quote at
-/// the wrong instant against the wrong bundle. Neither file is signed, so
-/// this is not a trust boundary; it catches the mispairing an archive comes
-/// to by accident, exactly, since no two records share a nonce.
-async fn archived_mode(path: &Path, nonce: &[u8; 32]) -> anyhow::Result<VerifyMode> {
+/// Both failures are the flag's, not the founding's: a reader who mistypes the
+/// path must not be told the quote failed to verify.
+async fn read_archived_collateral(path: &Path) -> anyhow::Result<ArchivedSnapshot> {
     let document = tokio::fs::read_to_string(path)
         .await
         .with_context(|| format!("reading --collateral {}", path.display()))?;
-    let archived = collateral::parse(&document).with_context(|| {
+    collateral::parse(&document).with_context(|| {
         format!(
             "--collateral {} is not an archived snapshot",
             path.display()
-        )
-    })?;
-    anyhow::ensure!(
-        &archived.harvest_nonce == nonce,
-        "--collateral {} belongs to the record with harvest_nonce {}, not to this one ({}): \
-         they are not from one harvest",
-        path.display(),
-        hex::encode(archived.harvest_nonce),
-        hex::encode(nonce),
-    );
-    Ok(VerifyMode::Archived(archived.snapshot))
-}
-
-/// Archive the DCAP collateral the verification of the record with
-/// `harvest_nonce` `nonce` consumed.
-///
-/// The caller owns the layout and passes the destination; this writes the
-/// exact bundle the verdict depended on, so what is archived is what was
-/// verified.
-async fn dump_collateral(
-    path: &Path,
-    nonce: &[u8; 32],
-    collateral: &CollateralSnapshot,
-) -> anyhow::Result<()> {
-    let archived = collateral::ArchivedSnapshot {
-        harvest_nonce: *nonce,
-        snapshot: collateral.clone(),
-    };
-    let document = collateral::render(&archived)?;
-    // Read the document back before it leaves this process. The caller
-    // archives these bytes verbatim and nothing parses them again until a
-    // re-verification that may be a year away, so a snapshot that does not
-    // round-trip has to fail the harvest that produced it.
-    let reread = collateral::parse(&document).context("re-reading the rendered DCAP collateral")?;
-    anyhow::ensure!(
-        reread == archived,
-        "the rendered DCAP collateral does not read back as the collateral this verification used"
-    );
-    tokio::fs::write(path, document)
-        .await
-        .with_context(|| format!("writing --dump-collateral {}", path.display()))
-}
-
-/// Decode one fixed-length hex field of the record, naming the field in every
-/// failure.
-///
-/// A field of the wrong length or spelling is a malformed record, not a failed
-/// quote, and the two look alike once the binding is computed — so each is
-/// rejected up front, by name.
-fn decode_hex_field<const N: usize>(field: &str, value: &str) -> anyhow::Result<[u8; N]> {
-    let bare = value.strip_prefix("0x").unwrap_or(value);
-    let bytes = hex::decode(bare).with_context(|| format!("record {field} is not valid hex"))?;
-    bytes.try_into().map_err(|bytes: Vec<u8>| {
-        anyhow::anyhow!(
-            "record {field} must be {N} bytes ({} hex chars), got {}",
-            N * 2,
-            bytes.len()
         )
     })
 }
@@ -495,49 +264,10 @@ async fn read_record(path: &Path) -> anyhow::Result<Vec<u8>> {
         .with_context(|| format!("reading --record {}", path.display()))
 }
 
-/// The success report: one JSON object, printed only once verification passed.
-///
-/// Registers come out of a `BTreeMap` so the object is assembled in register
-/// order and archived reports diff cleanly across nodes, boots, and builds (the
-/// backend hands back a `HashMap`, whose iteration order is not stable). Every
-/// quoted register is included, not just the policy's, because the caller keeps
-/// this output as provenance. `extras` carries the purpose-specific facts of
-/// what was checked.
-fn report(
-    verified: &VerifiedAzureAttestation,
-    extras: impl IntoIterator<Item = (&'static str, String)>,
-) -> String {
-    let pcrs: serde_json::Map<String, serde_json::Value> = verified
-        .guest_measurements
-        .pcrs
-        .iter()
-        .map(|(index, value)| (*index, *value))
-        .collect::<BTreeMap<u32, [u8; 32]>>()
-        .into_iter()
-        .map(|(index, value)| (format!("pcr{index}"), hex::encode(value).into()))
-        .collect();
-
-    let mut object = serde_json::json!({
-        "verified": true,
-        "attestation_type": AttestationType::AzureTdx.as_str(),
-        "binding": hex::encode(verified.binding),
-        "pcrs": pcrs,
-    });
-    for (key, value) in extras {
-        object
-            .as_object_mut()
-            .expect("report literal is an object")
-            .insert(key.to_string(), value.into());
-    }
-    object.to_string()
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use clap::CommandFactory as _;
-    use seismic_attestation::AzureGuestMeasurements;
-    use std::collections::HashMap;
 
     /// A policy that parses. Its measurements never get checked in these tests:
     /// every case here fails before verification, which is the point — no test
@@ -557,34 +287,11 @@ mod tests {
     const VALID_MANIFEST: &str =
         include_str!("../../../crates/network-manifest/fixtures/network-manifest-v1.json");
 
-    /// One real founding, kept verbatim: a harvest record, the collateral
-    /// snapshot its verification consumed, and the promoted policy it was
-    /// verified against. Captured on Azure TDX hardware from cohort
-    /// `tmp-devnet-1` on image `seismic-dev_2026-08-27.5c012e.vhd`,
-    /// harvested 2026-08-27T20:20:55Z and torn down the same day. The
-    /// pubkeys are a destroyed throwaway network's, so the committed archive
-    /// discloses nothing.
-    const FOUNDING_RECORD: &str = include_str!("../fixtures/founding-record-v1.json");
-    const FOUNDING_COLLATERAL: &str = include_str!("../fixtures/founding-collateral-v1.json");
-    const FOUNDING_POLICY: &str = include_str!("../fixtures/founding-policy-v1.json");
-
-    /// The instant frozen into that snapshot, and the reason the fixture
-    /// cannot rot: a replay evaluates every freshness window here, not at
-    /// the wall clock.
-    const FOUNDING_VERIFIED_AT: u64 = 1787862055;
-
-    /// How many registers the Azure TDX v1 admission schema
-    /// (`seismic.azure-tdx.pcr4-pcr9-pcr11.v1`) pins: guest identity is that
-    /// tuple and nothing else, so a promoted policy carries exactly three.
-    const AZURE_TDX_V1_REGISTERS: usize = 3;
-
-    /// How many registers an Azure vTPM quote attests: PCRs 0-23, all
-    /// covered by the signed `pcrDigest` whether or not a policy pins them.
-    const AZURE_VTPM_REGISTERS: usize = 24;
-
     const NONCE_HEX: &str = "7777777777777777777777777777777777777777777777777777777777777777";
     const NODE_PK_HEX: &str = "8888888888888888888888888888888888888888888888888888888888888888";
     const CONSENSUS_PK_HEX: &str = "999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999";
+
+    const NO_ATTESTATION: &str = r#"{ "attestation_type": "none", "attestation": [] }"#;
 
     fn write_file(dir: &tempfile::TempDir, name: &str, contents: &str) -> PathBuf {
         let path = dir.path().join(name);
@@ -592,23 +299,16 @@ mod tests {
         path
     }
 
-    /// The registers a policy document pins, and the single value each
-    /// demands, read straight out of the JSON.
-    fn policy_registers(document: &str) -> BTreeMap<String, String> {
-        let records: serde_json::Value = serde_json::from_str(document).expect("policy document");
-        records[0]["measurements"]
-            .as_object()
-            .expect("a measurements map")
-            .iter()
-            .map(|(register, entry)| {
-                let values = entry["expected_any"].as_array().expect("expected_any");
-                assert_eq!(values.len(), 1, "{register} pins more than one value");
-                (
-                    register.clone(),
-                    values[0].as_str().expect("hex").to_string(),
-                )
-            })
-            .collect()
+    /// A harvest record carrying `evidence` verbatim.
+    fn record_json(evidence: &str) -> String {
+        format!(
+            r#"{{
+              "harvest_nonce": "{NONCE_HEX}",
+              "node_public_key": "{NODE_PK_HEX}",
+              "consensus_public_key": "{CONSENSUS_PK_HEX}",
+              "evidence": {evidence}
+            }}"#
+        )
     }
 
     fn harvest_cli(record: &Path, policy: &Path) -> Cli {
@@ -621,19 +321,6 @@ mod tests {
             policy.as_os_str(),
         ])
         .expect("well-formed argv")
-    }
-
-    /// A harvest record carrying `evidence` verbatim, with the frozen claims
-    /// the binding vectors use.
-    fn record_json(evidence: &str) -> String {
-        format!(
-            r#"{{
-              "harvest_nonce": "{NONCE_HEX}",
-              "node_public_key": "{NODE_PK_HEX}",
-              "consensus_public_key": "{CONSENSUS_PK_HEX}",
-              "evidence": {evidence}
-            }}"#
-        )
     }
 
     fn deploy_cli(endpoint: &str, manifest: &Path, policy: &Path) -> Cli {
@@ -707,26 +394,6 @@ mod tests {
         );
     }
 
-    /// A harvest CLI in offline mode over the given collateral document.
-    fn offline_cli(dir: &tempfile::TempDir, record: &str, document: &str) -> Cli {
-        let record = write_file(dir, "node-1.json", record);
-        let policy = write_file(dir, "policy.json", VALID_POLICY);
-        let snapshot = write_file(dir, "node-1-collateral.json", document);
-        Cli::try_parse_from([
-            "verify-quote".as_ref(),
-            "harvest".as_ref(),
-            "--record".as_ref(),
-            record.as_os_str(),
-            "--policy".as_ref(),
-            policy.as_os_str(),
-            "--collateral".as_ref(),
-            snapshot.as_os_str(),
-        ])
-        .expect("well-formed argv")
-    }
-
-    const NO_ATTESTATION: &str = r#"{ "attestation_type": "none", "attestation": [] }"#;
-
     /// `--collateral` is the whole collateral input: capture verifies live
     /// and writes, replay reads and verifies offline, and an offline run
     /// reaches no collateral service. So it excludes both the flag that
@@ -758,58 +425,12 @@ mod tests {
         }
     }
 
-    /// The instant decides which validity and revocation windows are open, so
-    /// a snapshot has to be the one this record's verification produced. The
-    /// snapshot names its record by nonce, and no two records share one, so
-    /// a snapshot filed beside another box's record is refused exactly.
-    #[tokio::test]
-    async fn replay_pairs_a_snapshot_with_its_record_by_nonce() {
-        let dir = tempfile::tempdir().unwrap();
-        let document = collateral::render(&collateral::fabricated_snapshot()).unwrap();
-        let path = write_file(&dir, "node-1-collateral.json", &document);
-
-        let mode = archived_mode(&path, &collateral::FABRICATED_NONCE)
-            .await
-            .unwrap();
-        assert_eq!(
-            mode,
-            VerifyMode::Archived(collateral::fabricated_collateral())
-        );
-
-        let other_record = [0xa5u8; 32];
-        let error = archived_mode(&path, &other_record)
-            .await
-            .unwrap_err()
-            .to_string();
-        assert!(error.contains("not from one harvest"), "{error}");
-        assert!(error.contains(&hex::encode(other_record)), "{error}");
-    }
-
-    /// The property the founding archive exists for, over real hardware
-    /// evidence: a founding quote re-verifies against its own archived
-    /// collateral, reaching no collateral service and depending in no way on
-    /// when the test runs.
-    ///
-    /// Every other offline test here runs on fabricated collateral, which
-    /// exercises the plumbing but never a bundle Intel actually served. This
-    /// one holds the whole path to real material — the DCAP chain, the TCB
-    /// Info and QE Identity windows, both CRLs, and the Azure AK certificate
-    /// chain — at the instant the snapshot pins. A live verification of this
-    /// same record stops passing once the bundle's `nextUpdate` lapses
-    /// (2026-09-26); this one keeps passing, which is the whole point.
-    #[tokio::test]
-    async fn a_real_founding_reverifies_offline_against_its_archived_collateral() {
-        let dir = tempfile::tempdir().unwrap();
-        let record = write_file(&dir, "founding-record.json", FOUNDING_RECORD);
-        let policy = write_file(&dir, "founding-policy.json", FOUNDING_POLICY);
-        let snapshot = write_file(&dir, "founding-collateral.json", FOUNDING_COLLATERAL);
-
-        // Asserted before verifying: a fixture re-captured without its
-        // instant should fail here, not as a puzzling expiry years from now.
-        let archived = collateral::parse(FOUNDING_COLLATERAL).expect("archived snapshot");
-        assert_eq!(archived.snapshot.at, FOUNDING_VERIFIED_AT);
-
-        let rendered = run(Cli::try_parse_from([
+    /// A harvest CLI in offline mode over the given collateral document.
+    fn offline_cli(dir: &tempfile::TempDir, record: &str, document: &str) -> Cli {
+        let record = write_file(dir, "node-1.json", record);
+        let policy = write_file(dir, "policy.json", VALID_POLICY);
+        let snapshot = write_file(dir, "node-1-collateral.json", document);
+        Cli::try_parse_from([
             "verify-quote".as_ref(),
             "harvest".as_ref(),
             "--record".as_ref(),
@@ -819,80 +440,7 @@ mod tests {
             "--collateral".as_ref(),
             snapshot.as_os_str(),
         ])
-        .expect("well-formed argv"))
-        .await
-        .expect("the archived founding verifies offline");
-
-        let report: serde_json::Value = serde_json::from_str(&rendered).unwrap();
-        assert_eq!(report["verified"], true);
-        assert_eq!(report["attestation_type"], "azure-tdx");
-
-        // The policy has to be one that really pins this guest: a policy
-        // whose measurements map were empty accepts any quote, and this test
-        // would pass while checking nothing. So every register it pins must
-        // come back with the value it demanded.
-        let pinned = policy_registers(FOUNDING_POLICY);
-        assert_eq!(pinned.len(), AZURE_TDX_V1_REGISTERS, "{pinned:?}");
-        let pcrs = report["pcrs"].as_object().unwrap();
-        for (register, expected) in &pinned {
-            assert_eq!(pcrs[register], *expected, "{register}");
-        }
-        // And the rest ride along as provenance, pinned by the same signed
-        // pcrDigest but constrained by no policy.
-        assert_eq!(pcrs.len(), AZURE_VTPM_REGISTERS);
-    }
-
-    /// The other half of the same property: the pinned instant is what makes
-    /// that founding verify, not the bundle alone. Move the instant past the
-    /// bundle's `nextUpdate` and the very same record and snapshot stop
-    /// verifying — which is what a live verification will do to this record
-    /// from 2026-09-26 on, and what the archive exists to avoid.
-    #[tokio::test]
-    async fn the_archived_instant_is_what_makes_the_founding_verify() {
-        let dir = tempfile::tempdir().unwrap();
-        let record = write_file(&dir, "founding-record.json", FOUNDING_RECORD);
-        let policy = write_file(&dir, "founding-policy.json", FOUNDING_POLICY);
-
-        // 2027-01-15, months past every window in the archived bundle. Only
-        // the instant changes; the collateral is the same bytes that verify
-        // in the test above.
-        let mut document: serde_json::Value = serde_json::from_str(FOUNDING_COLLATERAL).unwrap();
-        document["verified_at"] = serde_json::json!(1_800_000_000u64);
-        let snapshot = write_file(&dir, "founding-collateral.json", &document.to_string());
-
-        let error = run(Cli::try_parse_from([
-            "verify-quote".as_ref(),
-            "harvest".as_ref(),
-            "--record".as_ref(),
-            record.as_os_str(),
-            "--policy".as_ref(),
-            policy.as_os_str(),
-            "--collateral".as_ref(),
-            snapshot.as_os_str(),
-        ])
-        .expect("well-formed argv"))
-        .await
-        .expect_err("an expired bundle must not verify");
-        assert!(
-            format!("{error:#}").contains("DCAP"),
-            "expected a DCAP freshness failure, got: {error:#}"
-        );
-    }
-
-    /// The dump names the record it was verified with, so the snapshot a
-    /// harvest archives is the one its own replay accepts.
-    #[tokio::test]
-    async fn dump_names_the_record_it_verified() {
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("node-1-collateral.json");
-        let nonce = [0x3cu8; 32];
-
-        dump_collateral(&path, &nonce, &collateral::fabricated_collateral())
-            .await
-            .unwrap();
-        let archived = collateral::parse(&std::fs::read_to_string(&path).unwrap()).unwrap();
-        assert_eq!(archived.harvest_nonce, nonce);
-        assert_eq!(archived.snapshot, collateral::fabricated_collateral());
+        .expect("well-formed argv")
     }
 
     /// Offline mode fails by flag name on every way the snapshot can be
@@ -937,11 +485,7 @@ mod tests {
     #[tokio::test]
     async fn a_failed_verification_writes_no_collateral() {
         let dir = tempfile::tempdir().unwrap();
-        let record = write_file(
-            &dir,
-            "node-1.json",
-            &record_json(r#"{ "attestation_type": "none", "attestation": [] }"#),
-        );
+        let record = write_file(&dir, "node-1.json", &record_json(NO_ATTESTATION));
         let policy = write_file(&dir, "policy.json", VALID_POLICY);
         let destination = dir.path().join("node-1-collateral.json");
 
@@ -959,82 +503,6 @@ mod tests {
 
         assert!(run(cli).await.is_err());
         assert!(!destination.exists());
-    }
-
-    /// The bindings are wire-format commitments shared with the quoting node,
-    /// so these vectors are frozen: each is its `bindings.rs` frozen digest,
-    /// zero-padded to 64 bytes.
-    #[test]
-    fn bindings_match_frozen_vectors() {
-        let harvest = harvest_binding(&[0x77; 32], &[0x88; 32], &[0x99; 48]);
-        assert_eq!(
-            hex::encode(&harvest[..32]),
-            "8973b984dc10f809ebfaacdcad64b8cc5a647cf24e4bc27b3833cc234a9290e5"
-        );
-        assert_eq!(&harvest[32..], &[0u8; 32]);
-
-        let deploy = deploy_binding(&NetworkId::from_bytes([0x11; 32]), &[0x66; 32]);
-        assert_eq!(
-            hex::encode(&deploy[..32]),
-            "16a53bcb2d1421951a830a1308bca525b8ecfbf96fc89ad6152cdbfce4777eb9"
-        );
-        assert_eq!(&deploy[32..], &[0u8; 32]);
-    }
-
-    /// The record's hex fields feed the binding, and a wrong one produces a
-    /// mismatch that looks exactly like a bad quote — so they are rejected up
-    /// front, by name.
-    #[test]
-    fn hex_fields_fail_by_field_name() {
-        let not_hex = decode_hex_field::<32>("harvest_nonce", "zz77")
-            .unwrap_err()
-            .to_string();
-        assert!(not_hex.contains("harvest_nonce"), "{not_hex}");
-
-        let wrong_length = decode_hex_field::<48>("consensus_public_key", NODE_PK_HEX)
-            .unwrap_err()
-            .to_string();
-        assert!(
-            wrong_length.contains("consensus_public_key"),
-            "{wrong_length}"
-        );
-        assert!(wrong_length.contains("48 bytes"), "{wrong_length}");
-
-        assert_eq!(
-            decode_hex_field::<32>("node_public_key", NODE_PK_HEX).unwrap(),
-            [0x88; 32]
-        );
-        // The archive writes bare hex; 0x-prefixed means the same key.
-        assert_eq!(
-            decode_hex_field::<32>("node_public_key", &format!("0x{NODE_PK_HEX}")).unwrap(),
-            [0x88; 32]
-        );
-    }
-
-    /// The archived record is the input format: a file carrying the harvest's
-    /// own provenance fields around the four verified ones parses as-is.
-    #[test]
-    fn record_ignores_the_archives_extra_fields() {
-        let archived = format!(
-            r#"{{
-              "harvest_nonce": "{NONCE_HEX}",
-              "node_public_key": "{NODE_PK_HEX}",
-              "consensus_public_key": "{CONSENSUS_PK_HEX}",
-              "evidence": {{ "attestation_type": "azure-tdx", "attestation": [1, 2, 3] }},
-              "harvested_at": "2026-08-04T00:00:00+00:00",
-              "verification": {{ "verified": true, "pcrs": {{}} }}
-            }}"#
-        );
-        let record: HarvestRecord = serde_json::from_str(&archived).expect("archived record");
-
-        assert_eq!(
-            decode_hex_field::<32>("harvest_nonce", &record.harvest_nonce).unwrap(),
-            [0x77; 32]
-        );
-        assert_eq!(
-            decode_hex_field::<48>("consensus_public_key", &record.consensus_public_key).unwrap(),
-            [0x99; 48]
-        );
     }
 
     #[tokio::test]
@@ -1096,21 +564,6 @@ mod tests {
         assert!(error.contains("measurement policy"), "{error}");
     }
 
-    /// One job, one binding: a quote from a platform whose measurements this
-    /// policy format cannot pin is rejected without any collateral fetching.
-    #[tokio::test]
-    async fn non_azure_evidence_is_rejected() {
-        let dir = tempfile::tempdir().unwrap();
-        let record = write_file(
-            &dir,
-            "node-1.json",
-            &record_json(r#"{ "attestation_type": "none", "attestation": [] }"#),
-        );
-        let policy = write_file(&dir, "policy.json", VALID_POLICY);
-
-        assert!(run(harvest_cli(&record, &policy)).await.is_err());
-    }
-
     #[tokio::test]
     async fn deploy_missing_manifest_fails_by_flag_name() {
         let dir = tempfile::tempdir().unwrap();
@@ -1127,22 +580,6 @@ mod tests {
         assert!(error.contains("reading --manifest"), "{error}");
     }
 
-    /// A file that isn't a manifest is named as such, rather than hashing to
-    /// some id and surfacing later as a binding mismatch — which reads as a
-    /// node that answered for another network.
-    #[tokio::test]
-    async fn deploy_rejects_a_manifest_that_is_not_one() {
-        let dir = tempfile::tempdir().unwrap();
-        let manifest = write_file(&dir, "reth-genesis.json", "{}");
-        let policy = write_file(&dir, "policy.json", VALID_POLICY);
-
-        let error = run(deploy_cli("http://127.0.0.1:1", &manifest, &policy))
-            .await
-            .unwrap_err()
-            .to_string();
-        assert!(error.contains("not a v1 network manifest"), "{error}");
-    }
-
     /// Local inputs resolve before the node is contacted: a bad policy fails
     /// even though the endpoint points nowhere, proving no RPC was attempted.
     #[tokio::test]
@@ -1156,74 +593,5 @@ mod tests {
             .unwrap_err()
             .to_string();
         assert!(error.contains("measurement policy"), "{error}");
-    }
-
-    #[tokio::test]
-    async fn deploy_malformed_endpoint_fails_by_flag_name() {
-        let dir = tempfile::tempdir().unwrap();
-        let manifest = write_file(&dir, "network-manifest.json", VALID_MANIFEST);
-        let policy = write_file(&dir, "policy.json", VALID_POLICY);
-
-        let error = run(deploy_cli("not a url", &manifest, &policy))
-            .await
-            .unwrap_err()
-            .to_string();
-        assert!(error.contains("--endpoint"), "{error}");
-    }
-
-    #[test]
-    fn report_carries_every_quoted_register() {
-        let verified = VerifiedAzureAttestation {
-            binding: harvest_binding(&[0x77; 32], &[0x88; 32], &[0x99; 48]),
-            guest_measurements: AzureGuestMeasurements {
-                pcrs: HashMap::from([(11, [0xbb; 32]), (4, [0x44; 32]), (9, [0x99; 32])]),
-            },
-        };
-
-        let report: serde_json::Value = serde_json::from_str(&report(&verified, [])).unwrap();
-
-        assert_eq!(report["verified"], true);
-        assert_eq!(report["attestation_type"], "azure-tdx");
-        assert_eq!(
-            report["binding"],
-            format!(
-                "8973b984dc10f809ebfaacdcad64b8cc5a647cf24e4bc27b3833cc234a9290e5{}",
-                "00".repeat(32)
-            )
-        );
-        // Not just the policy's registers: the caller archives this as harvest
-        // provenance.
-        let pcrs = report["pcrs"].as_object().unwrap();
-        assert_eq!(pcrs.len(), 3);
-        assert_eq!(pcrs["pcr4"], "44".repeat(32));
-        assert_eq!(pcrs["pcr9"], "99".repeat(32));
-        assert_eq!(pcrs["pcr11"], "bb".repeat(32));
-    }
-
-    /// The deploy report documents what was checked: the network identity the
-    /// binding committed to and the nonce that made the quote fresh.
-    #[test]
-    fn report_extras_document_the_deploy_check() {
-        let network_id = NetworkId::from_bytes([0x11; 32]);
-        let nonce = [0x66u8; 32];
-        let verified = VerifiedAzureAttestation {
-            binding: deploy_binding(&network_id, &nonce),
-            guest_measurements: AzureGuestMeasurements {
-                pcrs: HashMap::from([(4, [0x44; 32])]),
-            },
-        };
-
-        let rendered = report(
-            &verified,
-            [
-                ("network_id", network_id.to_string()),
-                ("deployment_nonce", hex::encode(nonce)),
-            ],
-        );
-        let report: serde_json::Value = serde_json::from_str(&rendered).unwrap();
-
-        assert_eq!(report["verified"], true);
-        assert_eq!(report["network_id"], format!("0x{}", "11".repeat(32)));
-        assert_eq!(report["deployment_nonce"], "66".repeat(32));
     }
 }

--- a/crates/tdx-init-config/Cargo.toml
+++ b/crates/tdx-init-config/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "tdx-init-config"
+version.workspace = true
+edition.workspace = true
+repository.workspace = true
+homepage.workspace = true
+authors.workspace = true
+license.workspace = true
+readme.workspace = true
+description = "Schema of the bootstrap config tdx-init accepts over HTTP at deploy time"
+
+[dependencies]
+serde.workspace = true
+
+[dev-dependencies]
+toml.workspace = true

--- a/crates/tdx-init-config/src/lib.rs
+++ b/crates/tdx-init-config/src/lib.rs
@@ -1,8 +1,25 @@
+//! The bootstrap config a Seismic node accepts at deploy time: the schema of
+//! the TOML document POSTed to `tdx-init` on `:8080`, and the only definition
+//! of that wire format.
+//!
+//! It is a crate of its own so both ends of the POST hold the same types: the
+//! on-node `tdx-init` binary deserializes [`InitConfig`] and fans it out into
+//! per-service config files, and deploy tooling constructs the same struct
+//! rather than hand-assembling TOML. Nothing here does any work — no I/O, no
+//! validation beyond serde's — so linking it costs a downstream crate nothing
+//! but `serde`. Every semantic check (the manifest schema, the genesis
+//! commitments, the peer derivation) lives in `tdx-init` itself, where the
+//! POST is handled.
+//!
+//! `deny_unknown_fields` throughout: a field this build does not know is a
+//! deploy tool and a node that disagree on the format, which must be a clean
+//! `400` rather than a node silently running with defaults.
+
 use serde::{Deserialize, Serialize};
 
 /// Operator-supplied initialization config, received over HTTP at deploy
 /// time and fanned out by tdx-init into per-component config files under
-/// [`crate::CONF_DIR`].
+/// `/run/seismic/conf`.
 ///
 /// Two sections, split by provenance: `[network]` is coordinator-produced —
 /// a function of the network at POST time, never tailored to the recipient —
@@ -13,7 +30,8 @@ use serde::{Deserialize, Serialize};
 /// match across the cohort — differing bytes there mean a different network.
 /// Anything derivable from these is derived rather than delivered twice —
 /// e.g. the root-key fetch peers come from `[network].bootnodes`
-/// (`src/peers.rs`), so there is no second list that could skew from it.
+/// (`bin/tdx-init/src/peers.rs`), so there is no second list that could skew
+/// from it.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct InitConfig {
@@ -29,8 +47,8 @@ pub struct InitConfig {
 }
 
 /// DNS name + contact email for the Let's Encrypt cert that fronts this
-/// node's public RPC. Written by the writer module to `domain.env` under
-/// [`crate::CONF_DIR`] as `DOMAIN_NAME=...` / `DOMAIN_EMAIL=...`, which
+/// node's public RPC. Written by tdx-init to `domain.env` under
+/// `/run/seismic/conf` as `DOMAIN_NAME=...` / `DOMAIN_EMAIL=...`, which
 /// `setup-nginx-ssl` (seismic-images) sources before invoking certbot
 /// for cert issuance and renewal.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -45,9 +63,9 @@ pub struct DomainConfig {
 /// `network_id = SHA-256(exact network-manifest.json bytes)`, so the manifest
 /// travels base64-encoded (opaque bytes) rather than as an inline string:
 /// tdx-init validates it at POST time and writes the decoded bytes verbatim
-/// to `network-manifest.json` under [`crate::CONF_DIR`], never
-/// parse-and-re-serialize. Validation lives in `src/manifest.rs` (schema in
-/// the `seismic-network-manifest` crate).
+/// to `network-manifest.json` under `/run/seismic/conf`, never
+/// parse-and-re-serialize. Validation lives in `bin/tdx-init/src/manifest.rs`
+/// (schema in the `seismic-network-manifest` crate).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct NetworkConfig {
@@ -75,8 +93,8 @@ pub struct NetworkConfig {
     /// whose `eth.genesis_hash` pins its genesis block; required because a
     /// node booted without it has no chain spec and reth crash-loops.
     /// Validated at POST time against the manifest's `eth.chain_id`
-    /// (`src/reth_genesis.rs`) and written verbatim to `reth-genesis.json`
-    /// under [`crate::CONF_DIR`].
+    /// (`bin/tdx-init/src/reth_genesis.rs`) and written verbatim to
+    /// `reth-genesis.json` under `/run/seismic/conf`.
     pub reth_genesis_base64: String,
 
     /// base64 encoding of the summit genesis TOML — the consensus-layer
@@ -88,8 +106,8 @@ pub struct NetworkConfig {
     /// booted without it has no consensus genesis and its summit blocks
     /// forever — late joiners need it just as much as the founders do.
     /// Validated structurally at POST time against the manifest's
-    /// `summit.namespace` (`src/summit_genesis.rs`) and written verbatim to
-    /// `summit-genesis.toml` under [`crate::CONF_DIR`].
+    /// `summit.namespace` (`bin/tdx-init/src/summit_genesis.rs`) and written
+    /// verbatim to `summit-genesis.toml` under `/run/seismic/conf`.
     pub summit_genesis_base64: String,
 
     /// Network-wide devp2p bootnodes, as `enode://<128 hex pubkey>@host:port`
@@ -97,8 +115,9 @@ pub struct NetworkConfig {
     /// node's own entry dropped, they feed both of reth's devp2p flags
     /// (`reth-p2p.env`'s `RETH_BOOTNODES_FLAG` and `RETH_TRUSTED_PEERS_FLAG`)
     /// and, as `http://<host>:7878`, the attestation service's root-key fetch
-    /// list (`attestation.env`); the rendering lives in `src/peers.rs`, which
-    /// also documents why reth gets the list twice. The field is required,
+    /// list (`attestation.env`); the rendering lives in
+    /// `bin/tdx-init/src/peers.rs`, which also documents why reth gets the list
+    /// twice. The field is required,
     /// but an empty list is valid on the genesis node only — it has no peers
     /// to dial and mints `root_key` itself; a non-genesis POST with no usable
     /// bootnode is rejected with `400`.
@@ -116,7 +135,7 @@ pub struct NodeConfig {
     /// advertises the correct external address to peers. Also used to drop
     /// this node's own enode when deriving root-key fetch peers from
     /// `[network].bootnodes`. Validated as an `IpAddr` at POST time
-    /// (`src/peers.rs`).
+    /// (`bin/tdx-init/src/peers.rs`).
     pub external_ip: String,
 
     /// Root-key custody flag: true iff this node is the network's genesis
@@ -192,7 +211,8 @@ email = "ops@example.com"
     #[test]
     fn accepts_empty_bootnodes() {
         // The genesis node has no peers to dial: the key is required but an
-        // empty list parses fine (the genesis-only rule lives in src/peers.rs).
+        // empty list parses fine (the genesis-only rule lives in
+        // bin/tdx-init/src/peers.rs).
         let toml_input = r#"
 [network]
 manifest_base64 = "eyJtYW5pZmVzdF92ZXJzaW9uIjogMX0K"


### PR DESCRIPTION
The Rust deploy CLI links the enclave crates it needs rather than shelling out to their binaries. Two of the pieces it wants are bin-only: the quote verification, and the schema of the boot config a node accepts. Both are factored out here, and neither binary changes behaviour.

`bin/verify-quote` becomes a library with a thin CLI over it, the shape `seismic-manifest` already has. `lib.rs` holds the verification — both bindings, the one DCAP path they share, and the archived snapshot's render and parse — and `main.rs` is clap, the filesystem and stdout. The argv contract and the stdout/stderr behaviour are unchanged, so the Python shell-out keeps working until it is replaced.

The library speaks in types where the CLI spoke in strings. `verify_harvest` takes the record, the policy and a `HarvestCollateral`, which makes the CLI's `conflicts_with_all` rule unrepresentable: a replay carries the archived snapshot it is judged against, so there is no PCCS left for it to reach. `verify_deploy` takes the endpoint, the manifest bytes and the policy, and mints the deployment nonce itself. Both answer with what was checked — the quoted registers, the binding, and each purpose's own facts — rather than a rendered string, and `to_json` renders the report the binary has always printed. The tests follow the same seam: the verification cases moved to the library, the argv and file-handling cases stayed with the binary.

`bin/tdx-init/src/config.rs` becomes `crates/tdx-init-config`, so both ends of that POST hold the same types instead of the deploy side hand-assembling TOML. It is serde and nothing else — no I/O, no validation beyond `deny_unknown_fields` — so the on-node binary's dependency set is unchanged and a downstream crate pays only for `serde`. Every semantic check (the manifest schema, the genesis commitments, the peer derivation) stays in `tdx-init`, where the POST is handled, and the doc comments that pointed at the binary's own items now name paths from the repo root.

Closes SEI-435.

A Linux consumer that only verifies still links the Azure attester stack through `seismic-attestation`, and with it tss-esapi and an x86-only dependency; SEI-455 gates that.